### PR TITLE
feat: Google OAuth login + Founder role

### DIFF
--- a/schema/003_google_oauth.sql
+++ b/schema/003_google_oauth.sql
@@ -1,0 +1,33 @@
+-- fanfiction.fyi — Google OAuth + Founder role
+-- Add 'founder' role to the users table CHECK constraint
+-- SQLite doesn't support ALTER TABLE ... ALTER CONSTRAINT, so we recreate.
+
+-- Step 1: Create new users table with expanded role
+CREATE TABLE IF NOT EXISTS users_new (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  email         TEXT NOT NULL UNIQUE,
+  password_hash TEXT,  -- nullable for OAuth-only users
+  role          TEXT NOT NULL DEFAULT 'user' CHECK (role IN ('founder', 'admin', 'mod', 'user')),
+  google_id     TEXT,  -- Google sub claim for OAuth matching
+  avatar_url    TEXT,  -- Google profile picture
+  display_name  TEXT,  -- Google display name
+  invite_code   TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Step 2: Copy existing data
+INSERT INTO users_new (id, email, password_hash, role, invite_code, created_at, updated_at)
+  SELECT id, email, password_hash, role, invite_code, created_at, updated_at FROM users;
+
+-- Step 3: Drop old table and rename
+DROP TABLE users;
+ALTER TABLE users_new RENAME TO users;
+
+-- Step 4: Recreate indexes (auto-dropped with old table)
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
+CREATE INDEX IF NOT EXISTS idx_users_google_id ON users (google_id);
+
+-- Step 5: Seed founder account (password_hash is NULL — OAuth-only)
+INSERT OR IGNORE INTO users (email, role, google_id, display_name, created_at, updated_at)
+  VALUES ('kaleb.bays@gmail.com', 'founder', NULL, 'Kaleb', datetime('now'), datetime('now'));

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
-import type { User, Pseud } from './types';
+import type { User, Pseud, UserRole } from './types';
+import { ROLE_LEVEL } from './types';
 import { queryFirst, run, queryAll } from './db';
 
 const SESSION_COOKIE = 'session';
@@ -91,6 +92,23 @@ export async function requireAuth(
   if (!auth) {
     const err = new Error('Unauthorized');
     (err as any).status = 401;
+    throw err;
+  }
+  return auth;
+}
+
+// Require a minimum role level (founder > admin > mod > user)
+export async function requireRole(
+  db: D1Database,
+  request: Request,
+  minimumRole: UserRole
+): Promise<{ user: User; pseuds: Pseud[] }> {
+  const auth = await requireAuth(db, request);
+  const userLevel = ROLE_LEVEL[auth.user.role as UserRole] ?? 0;
+  const requiredLevel = ROLE_LEVEL[minimumRole] ?? 0;
+  if (userLevel < requiredLevel) {
+    const err = new Error('Forbidden');
+    (err as any).status = 403;
     throw err;
   }
   return auth;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,15 +3,33 @@
  */
 
 export enum UserRole {
+  Founder = 'founder',
   Admin = 'admin',
   Mod = 'mod',
   User = 'user',
+}
+
+/** Role hierarchy: higher number = more privs */
+export const ROLE_LEVEL: Record<UserRole, number> = {
+  [UserRole.Founder]: 100,
+  [UserRole.Admin]: 80,
+  [UserRole.Mod]: 50,
+  [UserRole.User]: 10,
+};
+
+/** Check if a role has at least the required level */
+export function hasRoleLevel(role: UserRole, required: UserRole): boolean {
+  return (ROLE_LEVEL[role] ?? 0) >= (ROLE_LEVEL[required] ?? 0);
 }
 
 export interface User {
   id: number;
   email: string;
   role: UserRole;
+  password_hash?: string | null;
+  google_id?: string | null;
+  avatar_url?: string | null;
+  display_name?: string | null;
   invite_code?: string | null;
   created_at: string;
   updated_at: string;

--- a/src/pages/api/auth/google.ts
+++ b/src/pages/api/auth/google.ts
@@ -1,0 +1,31 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+
+/**
+ * GET /api/auth/google
+ * Initiates Google OAuth flow — redirects user to Google consent screen.
+ */
+export const GET: APIRoute = async ({ url, locals }) => {
+  const env = locals.runtime.env;
+  const clientId = env.GOOGLE_CLIENT_ID as string;
+
+  if (!clientId) {
+    return new Response(JSON.stringify({ error: 'Google OAuth not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const redirectUri = `${url.origin}/api/auth/google/callback`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'openid email profile',
+    access_type: 'offline',
+    prompt: 'consent',
+  });
+
+  return Response.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params}`, 302);
+};

--- a/src/pages/api/auth/google/callback.ts
+++ b/src/pages/api/auth/google/callback.ts
@@ -1,0 +1,126 @@
+export const prerender = false;
+
+import { queryFirst, run, queryAll } from '@/lib/db';
+import { createSession, setSessionCookie } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+
+/**
+ * GET /api/auth/google/callback
+ * Google OAuth callback — exchanges code for tokens, upserts user, creates session.
+ */
+export const GET: APIRoute = async ({ url, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const env = locals.runtime.env;
+  const clientId = env.GOOGLE_CLIENT_ID as string;
+  const clientSecret = env.GOOGLE_CLIENT_SECRET as string;
+
+  const code = url.searchParams.get('code');
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    return Response.redirect(`${url.origin}/login?error=oauth_denied`, 302);
+  }
+
+  if (!code) {
+    return Response.redirect(`${url.origin}/login?error=oauth_no_code`, 302);
+  }
+
+  // Exchange code for tokens
+  const redirectUri = `${url.origin}/api/auth/google/callback`;
+  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    console.error('Google token exchange failed:', await tokenRes.text());
+    return Response.redirect(`${url.origin}/login?error=oauth_token_failed`, 302);
+  }
+
+  const tokens = await tokenRes.json();
+
+  // Decode ID token payload (base64) — we trust Google's token endpoint
+  const idToken = tokens.id_token as string;
+  const [_header, payloadB64, _sig] = idToken.split('.');
+  const payload = JSON.parse(
+    // Workers don't have atob in all contexts — manual base64url decode
+    decodeURIComponent(
+      Array.from(atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/')))
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    )
+  );
+
+  const googleEmail = payload.email as string;
+  const googleSub = payload.sub as string;
+  const googleName = payload.name as string | undefined;
+  const googlePicture = payload.picture as string | undefined;
+
+  if (!googleEmail) {
+    return Response.redirect(`${url.origin}/login?error=oauth_no_email`, 302);
+  }
+
+  // Determine role — founder for specific email
+  const FOUNDER_EMAIL = 'kaleb.bays@gmail.com';
+  const role = googleEmail === FOUNDER_EMAIL ? 'founder' : 'user';
+
+  // Upsert user
+  const existingUser = await queryFirst<{ id: number; role: string }>(
+    db,
+    `SELECT id, role FROM users WHERE email = ?1`,
+    googleEmail
+  );
+
+  let userId: number;
+
+  if (existingUser) {
+    userId = existingUser.id;
+    // Update Google fields on existing user (but never downgrade role)
+    await run(
+      db,
+      `UPDATE users SET google_id = ?1, avatar_url = ?2, display_name = COALESCE(?3, display_name), updated_at = datetime('now')
+       WHERE id = ?4 AND (google_id IS NULL OR google_id != ?1)`,
+      googleSub, googlePicture ?? null, googleName ?? null, userId
+    );
+    // Elevate to founder if applicable (never downgrade)
+    if (role === 'founder' && existingUser.role !== 'founder') {
+      await run(db, `UPDATE users SET role = 'founder', updated_at = datetime('now') WHERE id = ?1`, userId);
+    }
+  } else {
+    // Create new OAuth user (no password, no invite code needed for Google signup)
+    const result = await run(
+      db,
+      `INSERT INTO users (email, role, google_id, avatar_url, display_name, created_at, updated_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'))`,
+      googleEmail, role, googleSub, googlePicture ?? null, googleName ?? null
+    );
+    userId = result.meta.last_row_id;
+
+    // Create default pseud from Google name or email local part
+    const pseudName = googleName || googleEmail.split('@')[0];
+    await run(
+      db,
+      `INSERT INTO pseuds (user_id, name, created_at) VALUES (?1, ?2, datetime('now'))`,
+      userId, pseudName
+    );
+  }
+
+  // Create session
+  const token = await createSession(db, userId);
+
+  // Redirect to home with session cookie
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: '/',
+      'Set-Cookie': setSessionCookie(token),
+    },
+  });
+};

--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -3,20 +3,17 @@ export const prerender = false;
 ---
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Sign in to fanfiction.fyi" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <title>Sign In — fanfiction.fyi</title>
-  </head>
   <body>
     <div class="auth-container">
       <a href="/" class="auth-logo">fanfiction.fyi</a>
       <h1 class="auth-title">Sign In</h1>
+
+      <a href="/api/auth/google" class="btn-google">
+        <svg width="18" height="18" viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.93 0 6.51 5.19 2.56 12.9l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.81 14.93 48 24 48z"/></svg>
+        Sign in with Google
+      </a>
+
+      <div class="auth-divider"><span>or</span></div>
 
       <form id="login-form" class="auth-form">
         <div class="form-field">
@@ -62,6 +59,42 @@ export const prerender = false;
     color: var(--md-sys-color-on-surface);
     text-align: center;
     margin: 0;
+  }
+
+  .btn-google {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .btn-google:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+
+  .auth-divider {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    color: var(--md-sys-color-on-surface-variant);
+    font: var(--md-sys-typescale-body-small);
+  }
+
+  .auth-divider::before,
+  .auth-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--md-sys-color-outline-variant);
   }
 
   .auth-form {
@@ -141,6 +174,19 @@ export const prerender = false;
 <script>
   const form = document.getElementById('login-form') as HTMLFormElement;
   const errorEl = document.getElementById('login-error')!;
+
+  // Check for OAuth error in URL params
+  const urlParams = new URLSearchParams(window.location.search);
+  const oauthError = urlParams.get('error');
+  if (oauthError) {
+    const messages: Record<string, string> = {
+      oauth_denied: 'Google sign-in was cancelled',
+      oauth_no_code: 'Google OAuth failed — no authorization code',
+      oauth_token_failed: 'Google authentication failed',
+      oauth_no_email: 'Google account has no email',
+    };
+    errorEl.textContent = messages[oauthError] || 'Google sign-in failed';
+  }
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Google OAuth + Founder Role

### What
- **Google OAuth login flow**: `/api/auth/google` → consent screen → `/api/auth/google/callback` → upsert user → session cookie
- **Founder role**: New `founder` role in the role hierarchy (founder > admin > mod > user), mapped to `kaleb.bays@gmail.com`
- **Role middleware**: `requireRole(db, request, UserRole.Admin)` helper for gating endpoints
- **Login page**: "Sign in with Google" button with divider above email/password form

### Files Changed
| File | What |
|---|---|
| `schema/003_google_oauth.sql` | Migration: adds `founder` to CHECK constraint, `google_id`/`avatar_url`/`display_name` columns, seeds founder user |
| `src/lib/types.ts` | `Founder` enum value, `ROLE_LEVEL` hierarchy map, `hasRoleLevel()` helper |
| `src/lib/auth.ts` | `requireRole()` middleware |
| `src/pages/api/auth/google.ts` | OAuth redirect to Google consent |
| `src/pages/api/auth/google/callback.ts` | Code exchange → ID token decode → upsert user → session |
| `src/pages/login/index.astro` | Google button + OAuth error handling |

### Post-Merge Steps
1. Apply `003_google_oauth.sql` migration to remote D1
2. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` as Pages project secrets
3. Add `https://fanfiction.fyi/api/auth/google/callback` to Google Cloud Console authorized redirect URIs