### PR TITLE
Fix admin pages: wrap in Base layout, fix mojibake arrows

### DIFF
--- a/src/pages/admin/content.astro
+++ b/src/pages/admin/content.astro
@@ -1,5 +1,6 @@
 ---
 export const prerender = false;
+import Base from '@/layouts/Base.astro';
 import { queryFirst, queryAll } from '@/lib/db';
 import { UserRole, ROLE_LEVEL } from '@/lib/types';
 
@@ -42,39 +43,41 @@ const works = await queryAll<{
 `);
 ---
 
-<h1 class="admin-heading">Content Moderation</h1>
+<Base title="Content Moderation — Admin">
+  <h1 class="admin-heading">Content Moderation</h1>
 
-<h2 class="section-heading">Recent Comments</h2>
-<div class="comments-list">
-  {comments.map(c => (
-    <div class="comment-card" data-comment-id={c.id}>
-      <div class="comment-meta">
-        <span class="comment-author">{c.pseud_name}</span>
-        <span class="comment-work">on <a href={`/works/${c.work_id}`}>{c.work_title}</a></span>
-        <span class="comment-date">{new Date(c.created_at).toLocaleString()}</span>
+  <h2 class="section-heading">Recent Comments</h2>
+  <div class="comments-list">
+    {comments.map(c => (
+      <div class="comment-card" data-comment-id={c.id}>
+        <div class="comment-meta">
+          <span class="comment-author">{c.pseud_name}</span>
+          <span class="comment-work">on <a href={`/works/${c.work_id}`}>{c.work_title}</a></span>
+          <span class="comment-date">{new Date(c.created_at).toLocaleString()}</span>
+        </div>
+        <div class="comment-body">{c.content.length > 300 ? c.content.slice(0, 300) + '…' : c.content}</div>
+        <button class="btn-delete-comment" data-comment-id={c.id}>Delete</button>
       </div>
-      <div class="comment-body">{c.content.length > 300 ? c.content.slice(0, 300) + '…' : c.content}</div>
-      <button class="btn-delete-comment" data-comment-id={c.id}>Delete</button>
-    </div>
-  ))}
-  {comments.length === 0 && <p class="empty-state">No comments found.</p>}
-</div>
+    ))}
+    {comments.length === 0 && <p class="empty-state">No comments found.</p>}
+  </div>
 
-<h2 class="section-heading">Recent Published Works</h2>
-<div class="works-list">
-  {works.map(w => (
-    <div class="work-card">
-      <div class="work-info">
-        <a href={`/works/${w.id}`} class="work-title">{w.title}</a>
-        <span class="work-meta">by {w.author_name} · {w.word_count} words · {new Date(w.published_at).toLocaleDateString()}</span>
+  <h2 class="section-heading">Recent Published Works</h2>
+  <div class="works-list">
+    {works.map(w => (
+      <div class="work-card">
+        <div class="work-info">
+          <a href={`/works/${w.id}`} class="work-title">{w.title}</a>
+          <span class="work-meta">by {w.author_name} &middot; {w.word_count} words &middot; {new Date(w.published_at).toLocaleDateString()}</span>
+        </div>
+        <a href={`/works/${w.id}/edit`} class="btn-edit">Edit</a>
       </div>
-      <a href={`/works/${w.id}/edit`} class="btn-edit">Edit</a>
-    </div>
-  ))}
-  {works.length === 0 && <p class="empty-state">No published works found.</p>}
-</div>
+    ))}
+    {works.length === 0 && <p class="empty-state">No published works found.</p>}
+  </div>
 
-<div id="toast" class="toast hidden"></div>
+  <div id="toast" class="toast hidden"></div>
+</Base>
 
 <script>
   document.querySelectorAll('.btn-delete-comment').forEach(btn => {

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,5 +1,6 @@
 ---
 export const prerender = false;
+import Base from '@/layouts/Base.astro';
 import { queryFirst, queryAll } from '@/lib/db';
 import { UserRole, ROLE_LEVEL } from '@/lib/types';
 
@@ -25,45 +26,47 @@ const commentCount = await queryFirst<{ cnt: number }>(db, `SELECT COUNT(*) as c
 const tagCount = await queryFirst<{ cnt: number }>(db, `SELECT COUNT(*) as cnt FROM tags`);
 ---
 
-<h1 class="admin-heading">Admin Dashboard</h1>
+<Base title="Admin Dashboard">
+  <h1 class="admin-heading">Admin Dashboard</h1>
 
-<div class="stats-grid">
-  <div class="stat-card">
-    <span class="stat-number">{userCount?.cnt ?? 0}</span>
-    <span class="stat-label">Users</span>
-    <a href="/admin/users" class="stat-link">Manage users →</a>
+  <div class="stats-grid">
+    <div class="stat-card">
+      <span class="stat-number">{userCount?.cnt ?? 0}</span>
+      <span class="stat-label">Users</span>
+      <a href="/admin/users" class="stat-link">Manage users &rarr;</a>
+    </div>
+    <div class="stat-card">
+      <span class="stat-number">{workCount?.cnt ?? 0}</span>
+      <span class="stat-label">Works</span>
+      <a href="/admin/content" class="stat-link">Moderate content &rarr;</a>
+    </div>
+    <div class="stat-card">
+      <span class="stat-number">{commentCount?.cnt ?? 0}</span>
+      <span class="stat-label">Comments</span>
+      <a href="/admin/content" class="stat-link">Moderate content &rarr;</a>
+    </div>
+    <div class="stat-card">
+      <span class="stat-number">{tagCount?.cnt ?? 0}</span>
+      <span class="stat-label">Tags</span>
+      <a href="/admin/tags" class="stat-link">Manage tags &rarr;</a>
+    </div>
   </div>
-  <div class="stat-card">
-    <span class="stat-number">{workCount?.cnt ?? 0}</span>
-    <span class="stat-label">Works</span>
-    <a href="/admin/content" class="stat-link">Moderate content →</a>
-  </div>
-  <div class="stat-card">
-    <span class="stat-number">{commentCount?.cnt ?? 0}</span>
-    <span class="stat-label">Comments</span>
-    <a href="/admin/content" class="stat-link">Moderate content →</a>
-  </div>
-  <div class="stat-card">
-    <span class="stat-number">{tagCount?.cnt ?? 0}</span>
-    <span class="stat-label">Tags</span>
-    <a href="/admin/tags" class="stat-link">Manage tags →</a>
-  </div>
-</div>
 
-<div class="admin-links">
-  <a href="/admin/users" class="admin-link-card">
-    <h2>User Management</h2>
-    <p>View all users, change roles, ban/activate accounts.</p>
-  </a>
-  <a href="/admin/content" class="admin-link-card">
-    <h2>Content Moderation</h2>
-    <p>Review recent comments and works. Delete inappropriate comments.</p>
-  </a>
-  <a href="/admin/tags" class="admin-link-card">
-    <h2>Tag Management</h2>
-    <p>View all tags, see usage counts, merge duplicate tags.</p>
-  </a>
-</div>
+  <div class="admin-links">
+    <a href="/admin/users" class="admin-link-card">
+      <h2>User Management</h2>
+      <p>View all users, change roles, ban/activate accounts.</p>
+    </a>
+    <a href="/admin/content" class="admin-link-card">
+      <h2>Content Moderation</h2>
+      <p>Review recent comments and works. Delete inappropriate comments.</p>
+    </a>
+    <a href="/admin/tags" class="admin-link-card">
+      <h2>Tag Management</h2>
+      <p>View all tags, see usage counts, merge duplicate tags.</p>
+    </a>
+  </div>
+</Base>
 
 <style>
   .admin-heading {

--- a/src/pages/admin/tags.astro
+++ b/src/pages/admin/tags.astro
@@ -1,5 +1,6 @@
 ---
 export const prerender = false;
+import Base from '@/layouts/Base.astro';
 import { queryFirst, queryAll } from '@/lib/db';
 import { UserRole, ROLE_LEVEL } from '@/lib/types';
 
@@ -29,59 +30,61 @@ const tags = await queryAll<{
 `);
 ---
 
-<h1 class="admin-heading">Tag Management</h1>
+<Base title="Tag Management — Admin">
+  <h1 class="admin-heading">Tag Management</h1>
 
-<h2 class="section-heading">All Tags</h2>
-<div class="table-wrap">
-  <table class="admin-table">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Name</th>
-        <th>Type</th>
-        <th>Works</th>
-      </tr>
-    </thead>
-    <tbody>
-      {tags.map(t => (
+  <h2 class="section-heading">All Tags</h2>
+  <div class="table-wrap">
+    <table class="admin-table">
+      <thead>
         <tr>
-          <td>{t.id}</td>
-          <td>{t.name}</td>
-          <td><span class={`tag-type tag-type-${t.type}`}>{t.type}</span></td>
-          <td>{t.work_count}</td>
+          <th>ID</th>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Works</th>
         </tr>
-      ))}
-    </tbody>
-  </table>
-</div>
-
-<h2 class="section-heading">Merge Tags</h2>
-<div class="merge-form">
-  <p class="merge-hint">Select a source tag and a target tag. All works tagged with the source will be re-tagged with the target. The source tag will be deleted. Duplicate taggings are skipped.</p>
-  <div class="merge-row">
-    <div class="merge-field">
-      <label for="source-tag">Source (will be deleted)</label>
-      <select id="source-tag">
-        <option value="">— Select source tag —</option>
+      </thead>
+      <tbody>
         {tags.map(t => (
-          <option value={t.id}>{t.name} ({t.type}, {t.work_count} works)</option>
+          <tr>
+            <td>{t.id}</td>
+            <td>{t.name}</td>
+            <td><span class={`tag-type tag-type-${t.type}`}>{t.type}</span></td>
+            <td>{t.work_count}</td>
+          </tr>
         ))}
-      </select>
-    </div>
-    <div class="merge-field">
-      <label for="target-tag">Target (will remain)</label>
-      <select id="target-tag">
-        <option value="">— Select target tag —</option>
-        {tags.map(t => (
-          <option value={t.id}>{t.name} ({t.type}, {t.work_count} works)</option>
-        ))}
-      </select>
-    </div>
-    <button id="btn-merge" class="btn-merge">Merge</button>
+      </tbody>
+    </table>
   </div>
-</div>
 
-<div id="toast" class="toast hidden"></div>
+  <h2 class="section-heading">Merge Tags</h2>
+  <div class="merge-form">
+    <p class="merge-hint">Select a source tag and a target tag. All works tagged with the source will be re-tagged with the target. The source tag will be deleted. Duplicate taggings are skipped.</p>
+    <div class="merge-row">
+      <div class="merge-field">
+        <label for="source-tag">Source (will be deleted)</label>
+        <select id="source-tag">
+          <option value="">— Select source tag —</option>
+          {tags.map(t => (
+            <option value={t.id}>{t.name} ({t.type}, {t.work_count} works)</option>
+          ))}
+        </select>
+      </div>
+      <div class="merge-field">
+        <label for="target-tag">Target (will remain)</label>
+        <select id="target-tag">
+          <option value="">— Select target tag —</option>
+          {tags.map(t => (
+            <option value={t.id}>{t.name} ({t.type}, {t.work_count} works)</option>
+          ))}
+        </select>
+      </div>
+      <button id="btn-merge" class="btn-merge">Merge</button>
+    </div>
+  </div>
+
+  <div id="toast" class="toast hidden"></div>
+</Base>
 
 <script>
   document.getElementById('btn-merge')!.addEventListener('click', async () => {

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -1,5 +1,6 @@
 ---
 export const prerender = false;
+import Base from '@/layouts/Base.astro';
 import { queryFirst, queryAll, run } from '@/lib/db';
 import { UserRole, ROLE_LEVEL } from '@/lib/types';
 
@@ -25,58 +26,60 @@ const users = await queryAll<{
 const allRoles: UserRole[] = [UserRole.Admin, UserRole.Mod, UserRole.User];
 ---
 
-<h1 class="admin-heading">User Management</h1>
+<Base title="User Management — Admin">
+  <h1 class="admin-heading">User Management</h1>
 
-<div class="table-wrap">
-  <table class="admin-table">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Email</th>
-        <th>Role</th>
-        <th>Google</th>
-        <th>Banned</th>
-        <th>Created</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {users.map(u => (
-        <tr class:row-banned={u.banned === 1}>
-          <td>{u.id}</td>
-          <td>{u.email}</td>
-          <td>
-            {u.role === 'founder' ? (
-              <span class="badge badge-founder">founder</span>
-            ) : (
-              <select class="role-select" data-user-id={u.id} data-current-role={u.role}>
-                {allRoles.map(r => (
-                  <option value={r} selected={u.role === r}>{r}</option>
-                ))}
-              </select>
-            )}
-          </td>
-          <td>{u.google_id ? '✓' : '—'}</td>
-          <td>{u.banned ? 'Yes' : 'No'}</td>
-          <td>{new Date(u.created_at).toLocaleDateString()}</td>
-          <td>
-            {u.role !== 'founder' && (
-              <button
-                class={u.banned ? 'btn-activate' : 'btn-ban'}
-                data-user-id={u.id}
-                data-banned={u.banned}
-              >
-                {u.banned ? 'Activate' : 'Ban'}
-              </button>
-            )}
-          </td>
+  <div class="table-wrap">
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Google</th>
+          <th>Banned</th>
+          <th>Created</th>
+          <th>Actions</th>
         </tr>
-      ))}
-    </tbody>
-  </table>
-</div>
+      </thead>
+      <tbody>
+        {users.map(u => (
+          <tr class:row-banned={u.banned === 1}>
+            <td>{u.id}</td>
+            <td>{u.email}</td>
+            <td>
+              {u.role === 'founder' ? (
+                <span class="badge badge-founder">founder</span>
+              ) : (
+                <select class="role-select" data-user-id={u.id} data-current-role={u.role}>
+                  {allRoles.map(r => (
+                    <option value={r} selected={u.role === r}>{r}</option>
+                  ))}
+                </select>
+              )}
+            </td>
+            <td>{u.google_id ? '✓' : '—'}</td>
+            <td>{u.banned ? 'Yes' : 'No'}</td>
+            <td>{new Date(u.created_at).toLocaleDateString()}</td>
+            <td>
+              {u.role !== 'founder' && (
+                <button
+                  class={u.banned ? 'btn-activate' : 'btn-ban'}
+                  data-user-id={u.id}
+                  data-banned={u.banned}
+                >
+                  {u.banned ? 'Activate' : 'Ban'}
+                </button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
 
-<div id="toast" class="toast hidden"></div>
+  <div id="toast" class="toast hidden"></div>
+</Base>
 
 <script>
   // Role change handler


### PR DESCRIPTION
## Problem

All four admin pages (`/admin`, `/admin/users`, `/admin/content`, `/admin/tags`) render as completely unstyled raw text on a white background with no header, footer, or theme — just default serif font and broken `â†'` characters everywhere.

## Root Cause

The admin pages were standalone Astro page fragments — they had no `<Base>` layout wrapper, so they were missing:
- The full `<html>/<head>/<body>` document structure
- The M3 Obsidian theme CSS (`theme.css` via `@import`)
- The Google Fonts (Inter, JetBrains Mono) stylesheet
- The app header with navigation
- The footer
- The `data-theme` attribute on `<body>`
- The `<meta charset="UTF-8">` declaration (causing the mojibake `â†'` instead of `→`)

## Changes

- **All 4 admin pages**: Wrapped content in `<Base title="...">` component, which provides the full document shell, theme, header, and footer
- **index.astro**: Replaced bare `→` with `&rarr;` HTML entity to prevent encoding issues
- **content.astro**: Replaced bare `·` with `&middot;` HTML entity
- Added descriptive `<title>` values to each page via the Base layout prop

Once merged, the CI/CD will deploy automatically.