### PR TITLE
fix: redirect to homepage after logout instead of raw JSON

### DIFF
--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -13,7 +13,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     if (token) await deleteSession(db, token);
   }
   return new Response(null, {
-    status: 302,
+    status: 303,
     headers: {
       'Location': '/',
       'Set-Cookie': clearSessionCookie(),

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -12,8 +12,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const token = cookie.match(/session=([a-f0-9]+)/)?.[1];
     if (token) await deleteSession(db, token);
   }
-  return new Response(JSON.stringify({ ok: true }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json', 'Set-Cookie': clearSessionCookie() },
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'Location': '/',
+      'Set-Cookie': clearSessionCookie(),
+    },
   });
 };


### PR DESCRIPTION
## Problem
Clicking "Sign Out" navigates the browser to `/api/auth/logout` and displays raw JSON: `{"ok":true}`. The session cookie gets cleared, but the user sees an ugly JSON page instead of being redirected back to the site.

## Root Cause
The `POST /api/auth/logout` handler returns a JSON response (`{ ok: true }`) instead of a redirect. Since the form submission navigates the browser to this endpoint, the browser renders the JSON body as-is.

## Fix
Return a `302 Found` redirect to `/` instead of a JSON response. The session cookie is still cleared via the `Set-Cookie` header. This gives the user a seamless logout experience — click Sign Out → land on the homepage, logged out.