### PR TITLE
Add alias/pseud CRUD — create, edit, delete pseuds from Settings

### DIFF
--- a/src/pages/api/pseuds/[id].ts
+++ b/src/pages/api/pseuds/[id].ts
@@ -1,0 +1,107 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+
+/** GET /api/pseuds/[id] — single pseud (owner only) */
+export const GET: APIRoute = async ({ request, locals, params }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(db, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const pseudId = parseInt(params.id ?? '', 10);
+  if (isNaN(pseudId)) return new Response(JSON.stringify({ error: 'Invalid pseud ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  const pseud = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1 AND user_id = ?2`, pseudId, auth.user.id);
+  if (!pseud) return new Response(JSON.stringify({ error: 'Pseud not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  return new Response(JSON.stringify(pseud), { headers: { 'Content-Type': 'application/json' } });
+};
+
+/** PUT /api/pseuds/[id] — update pseud name/description (owner only) */
+export const PUT: APIRoute = async ({ request, locals, params }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(db, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const pseudId = parseInt(params.id ?? '', 10);
+  if (isNaN(pseudId)) return new Response(JSON.stringify({ error: 'Invalid pseud ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  // Verify ownership
+  const existing = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1 AND user_id = ?2`, pseudId, auth.user.id);
+  if (!existing) return new Response(JSON.stringify({ error: 'Pseud not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const { name, description } = body || {};
+  const newName = (typeof name === 'string' ? name.trim() : existing.name);
+  const newDesc = (description !== undefined ? (typeof description === 'string' ? description : null) : existing.description);
+
+  // Name validation
+  if (!newName || newName.length === 0) {
+    return new Response(JSON.stringify({ error: 'Name is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (newName.length > 100) {
+    return new Response(JSON.stringify({ error: 'Name must be 100 characters or fewer' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Check for duplicate name (excluding current pseud)
+  if (newName !== existing.name) {
+    const dup = await queryAll<any>(db, `SELECT id FROM pseuds WHERE user_id = ?1 AND name = ?2 AND id != ?3`, auth.user.id, newName, pseudId);
+    if (dup.length > 0) {
+      return new Response(JSON.stringify({ error: 'You already have a pseud with that name' }), { status: 409, headers: { 'Content-Type': 'application/json' } });
+    }
+  }
+
+  await run(db, `UPDATE pseuds SET name = ?1, description = ?2 WHERE id = ?3 AND user_id = ?4`, newName, newDesc, pseudId, auth.user.id);
+
+  const updated = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1`, pseudId);
+  return new Response(JSON.stringify(updated), { headers: { 'Content-Type': 'application/json' } });
+};
+
+/** DELETE /api/pseuds/[id] — delete a pseud (owner only, with safety checks) */
+export const DELETE: APIRoute = async ({ request, locals, params }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(db, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const pseudId = parseInt(params.id ?? '', 10);
+  if (isNaN(pseudId)) return new Response(JSON.stringify({ error: 'Invalid pseud ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  // Verify ownership
+  const existing = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1 AND user_id = ?2`, pseudId, auth.user.id);
+  if (!existing) return new Response(JSON.stringify({ error: 'Pseud not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  // Safety check: can't delete if pseud has creatorships (linked to works)
+  const creatorships = await queryAll<any>(db, `SELECT id FROM creatorships WHERE pseud_id = ?1`, pseudId);
+  if (creatorships.length > 0) {
+    return new Response(
+      JSON.stringify({ error: `Cannot delete pseud "${existing.name}" — it is credited on ${creatorships.length} work(s). Transfer or remove those credits first.` }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Safety check: can't delete last pseud
+  const allPseuds = await queryAll<any>(db, `SELECT id FROM pseuds WHERE user_id = ?1`, auth.user.id);
+  if (allPseuds.length <= 1) {
+    return new Response(
+      JSON.stringify({ error: 'You must have at least one pseud. Create a new one before deleting this one.' }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // Delete related records first (comments, kudos, bookmarks, readings)
+  await run(db, `DELETE FROM comments WHERE pseud_id = ?1`, pseudId);
+  await run(db, `DELETE FROM kudos WHERE pseud_id = ?1`, pseudId);
+  await run(db, `DELETE FROM bookmarks WHERE pseud_id = ?1`, pseudId);
+  await run(db, `DELETE FROM readings WHERE pseud_id = ?1`, pseudId);
+
+  // Delete the pseud itself
+  await run(db, `DELETE FROM pseuds WHERE id = ?1 AND user_id = ?2`, pseudId, auth.user.id);
+
+  return new Response(JSON.stringify({ success: true, deleted: pseudId }), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/pseuds/index.ts
+++ b/src/pages/api/pseuds/index.ts
@@ -8,7 +8,14 @@ export const GET: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB as D1Database;
   const auth = await requireAuth(db, request);
   if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
-  const pseuds = await queryAll<any>(db, `SELECT * FROM pseuds WHERE user_id = ?1 ORDER BY id`, auth.user.id);
+  const pseuds = await queryAll<any>(db, `
+    SELECT p.*, COUNT(c.id) as work_count
+    FROM pseuds p
+    LEFT JOIN creatorships c ON c.pseud_id = p.id
+    WHERE p.user_id = ?1
+    GROUP BY p.id
+    ORDER BY p.id
+  `, auth.user.id);
   return new Response(JSON.stringify(pseuds), { headers: { 'Content-Type': 'application/json' } });
 };
 
@@ -27,13 +34,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
     return new Response(JSON.stringify({ error: 'Name is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
-  const existing = await queryAll<any>(db, `SELECT id FROM pseuds WHERE user_id = ?1 AND name = ?2`, auth.user.id, name);
+  // Validate name length
+  const trimmedName = typeof name === 'string' ? name.trim() : '';
+  if (!trimmedName || trimmedName.length > 100) {
+    return new Response(JSON.stringify({ error: 'Name must be 1–100 characters' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const existing = await queryAll<any>(db, `SELECT id FROM pseuds WHERE user_id = ?1 AND name = ?2`, auth.user.id, trimmedName);
   if (existing.length > 0) {
     return new Response(JSON.stringify({ error: 'You already have a pseud with that name' }), { status: 409, headers: { 'Content-Type': 'application/json' } });
   }
 
-  const result = await run(db, `INSERT INTO pseuds (user_id, name, description, created_at) VALUES (?1, ?2, ?3, datetime('now'))`, auth.user.id, name, description || null);
-  const pseud = await queryAll<any>(db, `SELECT * FROM pseuds WHERE id = ?1`, result.meta.last_row_id);
+  const desc = (description !== undefined && description !== null) ? String(description) : null;
+  const result = await run(db, `INSERT INTO pseuds (user_id, name, description, created_at) VALUES (?1, ?2, ?3, datetime('now'))`, auth.user.id, trimmedName, desc);
+  const pseud = await queryAll<any>(db, `SELECT *, 0 as work_count FROM pseuds WHERE id = ?1`, result.meta.last_row_id);
 
   return new Response(JSON.stringify(pseud[0]), { status: 201, headers: { 'Content-Type': 'application/json' } });
 };

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -112,7 +112,35 @@ const themesJSON = JSON.stringify(
     </section>
 
     <!-- ═══════════════════════════════════════════════════ -->
-    <!--  SECTION 2: Account                                -->
+    <!--  SECTION 2: Aliases (Pseuds)                       -->
+    <!-- ═══════════════════════════════════════════════════ -->
+    <section class="settings-card" id="aliases-section">
+      <h2 class="card-title">Aliases</h2>
+      <p class="card-subtitle">Pseuds are pen names you write under. You can have multiple — one for each fandom or persona.</p>
+
+      <div id="pseuds-list" class="pseuds-list">
+        <!-- Populated by JS -->
+      </div>
+
+      <div class="pseud-add-form" id="pseud-add-form">
+        <h3 class="subsection-title" style="margin-top:0; border-top:none; padding-top:0;">Add Alias</h3>
+        <div class="form-group">
+          <label for="new-pseud-name" class="form-label">Name</label>
+          <input type="text" id="new-pseud-name" class="form-input" placeholder="e.g. DarkElfWriter" maxlength="100" />
+        </div>
+        <div class="form-group">
+          <label for="new-pseud-desc" class="form-label">Description <span class="form-hint" style="display:inline">(optional)</span></label>
+          <input type="text" id="new-pseud-desc" class="form-input" placeholder="A short blurb about this pseud" maxlength="200" />
+        </div>
+        <div class="form-actions">
+          <button type="button" class="btn-filled" id="add-pseud-btn">Add Alias</button>
+          <span class="inline-feedback" id="add-pseud-feedback"></span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════ -->
+    <!--  SECTION 3: Account                                -->
     <!-- ═══════════════════════════════════════════════════ -->
     <section class="settings-card" id="account-section">
       <h2 class="card-title">Account</h2>
@@ -178,7 +206,7 @@ const themesJSON = JSON.stringify(
     </section>
 
     <!-- ═══════════════════════════════════════════════════ -->
-    <!--  SECTION 3: Theme                                  -->
+    <!--  SECTION 4: Theme                                  -->
     <!-- ═══════════════════════════════════════════════════ -->
     <section class="settings-card">
       <h2 class="card-title">Theme</h2>
@@ -206,6 +234,29 @@ const themesJSON = JSON.stringify(
 
 <!-- Toast notification container -->
 <div id="toast-container"></div>
+
+<!-- ═══════════════════════════════════════════════════════ -->
+<!--  Edit Pseud Modal (hidden by default)                  -->
+<!-- ═══════════════════════════════════════════════════════ -->
+<div class="modal-overlay" id="pseud-edit-modal" style="display:none" role="dialog" aria-modal="true" aria-label="Edit alias">
+  <div class="modal-card">
+    <h3 class="modal-title">Edit Alias</h3>
+    <input type="hidden" id="edit-pseud-id" />
+    <div class="form-group">
+      <label for="edit-pseud-name" class="form-label">Name</label>
+      <input type="text" id="edit-pseud-name" class="form-input" maxlength="100" />
+    </div>
+    <div class="form-group">
+      <label for="edit-pseud-desc" class="form-label">Description <span class="form-hint" style="display:inline">(optional)</span></label>
+      <input type="text" id="edit-pseud-desc" class="form-input" maxlength="200" />
+    </div>
+    <div class="form-actions">
+      <button type="button" class="btn-filled" id="save-pseud-btn">Save</button>
+      <button type="button" class="btn-outlined" id="cancel-pseud-btn">Cancel</button>
+      <span class="inline-feedback" id="edit-pseud-feedback"></span>
+    </div>
+  </div>
+</div>
 
 <script is:inline>
   // ─── User data state ────────────────────────────────────
@@ -238,6 +289,12 @@ const themesJSON = JSON.stringify(
     if (message) {
       setTimeout(function() { el.textContent = ''; el.className = 'inline-feedback'; }, 4000);
     }
+  }
+
+  // ─── Escape HTML for safe innerHTML insertion ─────────────
+  function escapeHtml(str) {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   // ─── Read theme colors from hidden data element ─────────
@@ -524,6 +581,200 @@ const themesJSON = JSON.stringify(
     }
   }
 
+  // ═════════════════════════════════════════════════════════
+  //  PSEUDS / ALIASES MANAGEMENT
+  // ═════════════════════════════════════════════════════════
+  var pseudsList = document.getElementById('pseuds-list');
+  var pseudsData = [];
+
+  function renderPseuds() {
+    if (!pseudsData || pseudsData.length === 0) {
+      pseudsList.innerHTML = '<div class="pseuds-empty" role="status">No aliases yet. Add one below.</div>';
+      return;
+    }
+    var html = '';
+    pseudsData.forEach(function(p) {
+      html += '<div class="pseud-card" data-pseud-id="' + p.id + '">';
+      html += '  <div class="pseud-info">';
+      html += '    <span class="pseud-name">' + escapeHtml(p.name) + '</span>';
+      if (p.description) {
+        html += '    <span class="pseud-desc">' + escapeHtml(p.description) + '</span>';
+      }
+      html += '  </div>';
+      html += '  <div class="pseud-actions">';
+      html += '    <button type="button" class="btn-icon pseud-edit-btn" data-pseud-id="' + p.id + '" title="Edit" aria-label="Edit ' + escapeHtml(p.name) + '">';
+      html += '      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';
+      html += '    </button>';
+      html += '    <button type="button" class="btn-icon btn-icon--danger pseud-delete-btn" data-pseud-id="' + p.id + '" data-pseud-name="' + escapeHtml(p.name) + '" title="Delete" aria-label="Delete ' + escapeHtml(p.name) + '">';
+      html += '      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>';
+      html += '    </button>';
+      html += '  </div>';
+      html += '</div>';
+    });
+    pseudsList.innerHTML = html;
+
+    // Bind edit buttons
+    pseudsList.querySelectorAll('.pseud-edit-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var pseudId = parseInt(btn.dataset.pseudId, 10);
+        var pseud = pseudsData.find(function(p) { return p.id === pseudId; });
+        if (!pseud) return;
+        openEditModal(pseud);
+      });
+    });
+
+    // Bind delete buttons
+    pseudsList.querySelectorAll('.pseud-delete-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var pseudId = parseInt(btn.dataset.pseudId, 10);
+        var pseudName = btn.dataset.pseudName;
+        deletePseud(pseudId, pseudName);
+      });
+    });
+  }
+
+  function loadPseuds() {
+    fetch('/api/pseuds')
+      .then(function(res) { return res.json(); })
+      .then(function(data) {
+        pseudsData = Array.isArray(data) ? data : [];
+        renderPseuds();
+      })
+      .catch(function(err) {
+        console.error('Failed to load pseuds:', err);
+      });
+  }
+
+  // ─── Add new pseud ────────────────────────────────────
+  var addPseudBtn = document.getElementById('add-pseud-btn');
+  var addPseudFeedback = document.getElementById('add-pseud-feedback');
+
+  addPseudBtn.addEventListener('click', function() {
+    var name = document.getElementById('new-pseud-name').value.trim();
+    var desc = document.getElementById('new-pseud-desc').value.trim();
+
+    if (!name) {
+      setFeedback(addPseudFeedback, 'Name is required.', true);
+      return;
+    }
+
+    addPseudBtn.disabled = true;
+    setFeedback(addPseudFeedback, 'Adding…', false);
+
+    fetch('/api/pseuds', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, description: desc || null }),
+    })
+    .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
+    .then(function(result) {
+      addPseudBtn.disabled = false;
+      if (result.ok) {
+        document.getElementById('new-pseud-name').value = '';
+        document.getElementById('new-pseud-desc').value = '';
+        setFeedback(addPseudFeedback, 'Alias added!', false);
+        showToast('Alias created!');
+        loadPseuds();
+      } else {
+        setFeedback(addPseudFeedback, result.data.error || 'Failed to add alias.', true);
+      }
+    })
+    .catch(function() {
+      addPseudBtn.disabled = false;
+      setFeedback(addPseudFeedback, 'Network error.', true);
+    });
+  });
+
+  // ─── Edit modal ───────────────────────────────────────
+  var editModal = document.getElementById('pseud-edit-modal');
+  var savePseudBtn = document.getElementById('save-pseud-btn');
+  var cancelPseudBtn = document.getElementById('cancel-pseud-btn');
+  var editPseudFeedback = document.getElementById('edit-pseud-feedback');
+
+  function openEditModal(pseud) {
+    document.getElementById('edit-pseud-id').value = pseud.id;
+    document.getElementById('edit-pseud-name').value = pseud.name || '';
+    document.getElementById('edit-pseud-desc').value = pseud.description || '';
+    editPseudFeedback.textContent = '';
+    editPseudFeedback.className = 'inline-feedback';
+    editModal.style.display = '';
+    document.getElementById('edit-pseud-name').focus();
+  }
+
+  function closeEditModal() {
+    editModal.style.display = 'none';
+  }
+
+  cancelPseudBtn.addEventListener('click', closeEditModal);
+
+  // Close modal on overlay click
+  editModal.addEventListener('click', function(e) {
+    if (e.target === editModal) closeEditModal();
+  });
+
+  // Close modal on Escape
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && editModal.style.display !== 'none') closeEditModal();
+  });
+
+  savePseudBtn.addEventListener('click', function() {
+    var pseudId = document.getElementById('edit-pseud-id').value;
+    var name = document.getElementById('edit-pseud-name').value.trim();
+    var desc = document.getElementById('edit-pseud-desc').value.trim();
+
+    if (!name) {
+      setFeedback(editPseudFeedback, 'Name is required.', true);
+      return;
+    }
+
+    savePseudBtn.disabled = true;
+    setFeedback(editPseudFeedback, 'Saving…', false);
+
+    fetch('/api/pseuds/' + encodeURIComponent(pseudId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, description: desc || null }),
+    })
+    .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
+    .then(function(result) {
+      savePseudBtn.disabled = false;
+      if (result.ok) {
+        setFeedback(editPseudFeedback, 'Alias updated!', false);
+        showToast('Alias updated!');
+        closeEditModal();
+        loadPseuds();
+      } else {
+        setFeedback(editPseudFeedback, result.data.error || 'Failed to update alias.', true);
+      }
+    })
+    .catch(function() {
+      savePseudBtn.disabled = false;
+      setFeedback(editPseudFeedback, 'Network error.', true);
+    });
+  });
+
+  // ─── Delete pseud ──────────────────────────────────────
+  function deletePseud(pseudId, pseudName) {
+    if (!confirm('Delete alias "' + pseudName + '"? Comments, kudos, bookmarks, and reading progress under this name will also be removed.')) return;
+
+    fetch('/api/pseuds/' + encodeURIComponent(pseudId), {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, status: res.status, data: data }; }); })
+    .then(function(result) {
+      if (result.ok) {
+        showToast('Alias deleted.');
+        loadPseuds();
+      } else {
+        showToast(result.data.error || 'Failed to delete alias.', 'error');
+      }
+    })
+    .catch(function() {
+      showToast('Network error.', 'error');
+    });
+  }
+
   // ─── Load user profile from /api/auth/me ────────────────
   fetch('/api/auth/me')
     .then(function(res) { return res.json(); })
@@ -563,6 +814,9 @@ const themesJSON = JSON.stringify(
     .catch(function(err) {
       console.error('Failed to load user profile:', err);
     });
+
+  // ─── Load pseuds ─────────────────────────────────────
+  loadPseuds();
 
   // ─── Check URL params for Google redirect feedback ──────
   (function() {
@@ -928,6 +1182,126 @@ const themesJSON = JSON.stringify(
   }
 
   /* ═══════════════════════════════════════════════════════ */
+  /*  Pseud list & cards                                   */
+  /* ═══════════════════════════════════════════════════════ */
+  .pseuds-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2, 8px);
+    margin-bottom: var(--space-5, 20px);
+  }
+
+  .pseuds-empty {
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: var(--md-sys-typescale-body-medium-size, 14px);
+    text-align: center;
+    padding: var(--space-5, 20px);
+    background: var(--md-sys-color-surface-container-high);
+    border-radius: var(--md-sys-shape-corner-small, 8px);
+  }
+
+  .pseud-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3, 12px);
+    padding: var(--space-3, 12px) var(--space-4, 16px);
+    background: var(--md-sys-color-surface-container-high);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small, 8px);
+    transition: border-color 200ms;
+  }
+
+  .pseud-card:hover {
+    border-color: var(--md-sys-color-outline);
+  }
+
+  .pseud-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .pseud-name {
+    color: var(--md-sys-color-on-surface);
+    font-size: var(--md-sys-typescale-body-large-size, 16px);
+    font-weight: 500;
+    word-break: break-word;
+  }
+
+  .pseud-desc {
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: var(--md-sys-typescale-body-small-size, 12px);
+    word-break: break-word;
+  }
+
+  .pseud-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1, 4px);
+    flex-shrink: 0;
+  }
+
+  .btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full, 100px);
+    background: transparent;
+    color: var(--md-sys-color-on-surface-variant);
+    cursor: pointer;
+    transition: background 200ms, color 200ms;
+  }
+
+  .btn-icon:hover {
+    background: var(--md-sys-color-surface-container-highest);
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .btn-icon--danger:hover {
+    background: var(--md-sys-color-error-container);
+    color: var(--md-sys-color-error);
+  }
+
+  .pseud-add-form {
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+    padding-top: var(--space-4, 16px);
+  }
+
+  /* ═══════════════════════════════════════════════════════ */
+  /*  Modal                                               */
+  /* ═══════════════════════════════════════════════════════ */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: var(--space-4, 16px);
+  }
+
+  .modal-card {
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large, 16px);
+    padding: var(--space-6, 24px);
+    width: 100%;
+    max-width: 420px;
+  }
+
+  .modal-title {
+    color: var(--md-sys-color-on-surface);
+    font-size: var(--md-sys-typescale-title-large-size, 22px);
+    margin: 0 0 var(--space-4, 16px) 0;
+  }
+
+  /* ═══════════════════════════════════════════════════════ */
   /*  Theme grid (kept from original)                     */
   /* ═══════════════════════════════════════════════════════ */
   .theme-grid {
@@ -1038,6 +1412,19 @@ const themesJSON = JSON.stringify(
 
     .avatar-preview {
       align-self: center;
+    }
+
+    .pseud-card {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .pseud-actions {
+      align-self: flex-end;
+    }
+
+    .modal-card {
+      max-width: 100%;
     }
 
     #toast-container {


### PR DESCRIPTION
## Alias / Pseud Management

Users can now create, edit, and delete their aliases (pseuds) from the Settings page.

### What's New

**API Endpoints**
- `GET /api/pseuds/[id]` — fetch a single pseud (owner-only)
- `PUT /api/pseuds/[id]` — update pseud name/description (owner-only, duplicate name check)
- `DELETE /api/pseuds/[id]` — delete a pseud (owner-only, safety guards)
  - Can't delete if pseud has active creatorships (credited on works)
  - Can't delete user's last pseud
  - Cascades cleanup of comments, kudos, bookmarks, readings
- `GET /api/pseuds` — now returns `work_count` per pseud (LEFT JOIN creatorships)

**Settings Page: Aliases Section**
- New "Aliases" card between Profile and Account sections
- Lists all pseuds with name, description, and edit/delete icon buttons
- "Add Alias" form with name + description fields
- Edit modal (opens inline dialog, Escape or overlay-click to close)
- Delete confirmation with warning about cascading data loss
- M3 Obsidian styling — `.pseud-card` rows, icon buttons, modal overlay
- XSS-safe: all dynamic content goes through `escapeHtml()`

### Safety Guards
- **Creatorship check**: Deleting a pseud credited on works returns a 409 with a clear message
- **Last-pseud check**: Can't delete your only pseud
- **Name validation**: 1–100 characters, trimmed, duplicate name rejection
- **Ownership enforcement**: All endpoints verify `user_id` matches session

### No Schema Changes
The existing `pseuds` table already has all needed columns. No D1 migration required.

### Files Changed
- `src/pages/api/pseuds/[id].ts` — new file (GET, PUT, DELETE)
- `src/pages/api/pseuds/index.ts` — enhanced GET (work_count), POST (name validation)
- `src/pages/settings/index.astro` — Aliases section added with full CRUD UI