### PR TITLE
feat: user bug report form → GitHub issue

### DIFF
--- a/src/components/BugReport.tsx
+++ b/src/components/BugReport.tsx
@@ -1,0 +1,135 @@
+import { useState, useRef, useEffect } from 'preact/hooks';
+
+export default function BugReport() {
+  const [open, setOpen] = useState(false);
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open && dialogRef.current && !dialogRef.current.open) {
+      dialogRef.current.showModal();
+      setTimeout(() => textareaRef.current?.focus(), 100);
+    }
+    if (!open && dialogRef.current?.open) {
+      dialogRef.current.close();
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    setOpen(false);
+    setResult(null);
+    setDescription('');
+  };
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+    if (!description.trim() || submitting) return;
+
+    setSubmitting(true);
+    setResult(null);
+
+    try {
+      const res = await fetch('/api/bugs/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: description.trim(),
+          page: window.location.pathname + window.location.search,
+          userAgent: navigator.userAgent,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (res.ok) {
+        setResult({ ok: true, message: `Report submitted! Issue #${data.issue_number}` });
+        setDescription('');
+      } else {
+        setResult({ ok: false, message: data.error || 'Something went wrong.' });
+      }
+    } catch {
+      setResult({ ok: false, message: 'Network error. Please try again.' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const charCount = description.length;
+  const maxChars = 2000;
+
+  return (
+    <>
+      <button
+        class="bug-report-fab"
+        onClick={() => setOpen(true)}
+        aria-label="Report a bug"
+        title="Report a bug"
+      >
+        🐛
+      </button>
+
+      <dialog ref={dialogRef} class="bug-report-dialog" onClose={handleClose}>
+        <div class="bug-report-content">
+          <div class="bug-report-header">
+            <h2>Report a Bug</h2>
+            <button class="bug-report-close" onClick={handleClose} aria-label="Close">
+              ✕
+            </button>
+          </div>
+
+          <p class="bug-report-page">
+            Page: <code>{typeof window !== 'undefined' ? window.location.pathname : '/'}</code>
+          </p>
+
+          {result?.ok ? (
+            <div class="bug-report-success">
+              <p>✅ {result.message}</p>
+              <button class="bug-report-btn" onClick={handleClose}>Done</button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit}>
+              <label class="bug-report-label" for="bug-description">
+                What went wrong?
+              </label>
+              <textarea
+                ref={textareaRef}
+                id="bug-description"
+                class="bug-report-textarea"
+                value={description}
+                onInput={(e) => setDescription((e.target as HTMLTextAreaElement).value)}
+                placeholder="Describe the bug you encountered…"
+                maxLength={maxChars}
+                rows={4}
+                required
+                disabled={submitting}
+              />
+              <div class="bug-report-char-count">
+                {charCount}/{maxChars}
+              </div>
+
+              {result && !result.ok && (
+                <p class="bug-report-error">{result.message}</p>
+              )}
+
+              <div class="bug-report-actions">
+                <button type="button" class="bug-report-btn-secondary" onClick={handleClose}>
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  class="bug-report-btn"
+                  disabled={!description.trim() || submitting}
+                >
+                  {submitting ? 'Submitting…' : 'Submit Report'}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </dialog>
+    </>
+  );
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,7 @@ export const prerender = false;
 import { queryFirst, queryAll } from '../lib/db';
 import { ROLE_LEVEL, UserRole } from '../lib/types';
 import { THEMES } from '../styles/themes';
+import BugReport from '../components/BugReport';
 
 // Check auth status from cookie
 const cookie = Astro.request.headers.get('cookie') ?? '';
@@ -121,6 +122,7 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
     <footer class="app-footer">
       <p>&copy; 2026 fanfiction.fyi &mdash; bespoke archive for a small circle</p>
     </footer>
+    <BugReport client:load />
   </body>
 </html>
 
@@ -231,6 +233,195 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
       width: 100%;
       overflow-x: auto;
       gap: var(--space-2);
+    }
+  }
+
+  /* ── Bug Report FAB + Dialog ── */
+  .bug-report-fab {
+    position: fixed;
+    bottom: calc(var(--space-6) + env(safe-area-inset-bottom));
+    right: var(--space-6);
+    width: 48px;
+    height: 48px;
+    border-radius: var(--md-sys-shape-corner-full);
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    font-size: 1.25rem;
+    cursor: pointer;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  @media (hover: hover) {
+    .bug-report-fab:hover {
+      background: var(--md-sys-color-surface-container-highest);
+      box-shadow: var(--md-sys-elevation-2);
+    }
+  }
+
+  .bug-report-dialog {
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-extra-large);
+    background: var(--md-sys-color-surface-container-high);
+    color: var(--md-sys-color-on-surface);
+    padding: 0;
+    max-width: 480px;
+    width: calc(100% - var(--space-8));
+    box-shadow: var(--md-sys-elevation-3);
+  }
+
+  .bug-report-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  .bug-report-content {
+    padding: var(--space-6);
+  }
+
+  .bug-report-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-4);
+  }
+
+  .bug-report-header h2 {
+    font: var(--md-sys-typescale-title-large);
+    margin: 0;
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .bug-report-close {
+    background: none;
+    border: none;
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: 1.25rem;
+    cursor: pointer;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--md-sys-shape-corner-full);
+    line-height: 1;
+  }
+
+  @media (hover: hover) {
+    .bug-report-close:hover {
+      background: var(--md-sys-color-surface-container-highest);
+    }
+  }
+
+  .bug-report-page {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-4) 0;
+  }
+
+  .bug-report-page code {
+    background: var(--md-sys-color-surface-container-highest);
+    padding: 2px var(--space-2);
+    border-radius: var(--md-sys-shape-corner-extra-small);
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+  }
+
+  .bug-report-label {
+    display: block;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    margin-bottom: var(--space-2);
+  }
+
+  .bug-report-textarea {
+    width: 100%;
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-3) var(--space-4);
+    font: var(--md-sys-typescale-body-large);
+    resize: vertical;
+    min-height: 100px;
+  }
+
+  .bug-report-textarea:focus {
+    outline: none;
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+  }
+
+  .bug-report-textarea::placeholder {
+    color: var(--md-sys-color-outline);
+  }
+
+  .bug-report-char-count {
+    text-align: right;
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+    margin-top: var(--space-1);
+  }
+
+  .bug-report-error {
+    color: var(--md-sys-color-error);
+    font: var(--md-sys-typescale-body-small);
+    margin: var(--space-2) 0;
+  }
+
+  .bug-report-success {
+    text-align: center;
+    padding: var(--space-4) 0;
+  }
+
+  .bug-report-success p {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-primary);
+    margin: 0 0 var(--space-4) 0;
+  }
+
+  .bug-report-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+  }
+
+  .bug-report-btn {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    padding: var(--space-2) var(--space-6);
+    border-radius: var(--md-sys-shape-corner-full);
+    border: none;
+    cursor: pointer;
+  }
+
+  .bug-report-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (hover: hover) {
+    .bug-report-btn:hover:not(:disabled) {
+      background: var(--md-sys-color-primary-container);
+      color: var(--md-sys-color-on-primary-container);
+    }
+  }
+
+  .bug-report-btn-secondary {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    background: transparent;
+    padding: var(--space-2) var(--space-6);
+    border-radius: var(--md-sys-shape-corner-full);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    cursor: pointer;
+  }
+
+  @media (hover: hover) {
+    .bug-report-btn-secondary:hover {
+      background: var(--md-sys-color-surface-container-highest);
     }
   }
 </style>

--- a/src/pages/api/bugs/report.ts
+++ b/src/pages/api/bugs/report.ts
@@ -1,0 +1,151 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+
+const GITHUB_REPO_OWNER = 'triursa';
+const GITHUB_REPO_NAME = 'fanfiction-fyi';
+const MAX_DESCRIPTION_LENGTH = 2000;
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const MAX_REPORTS_PER_WINDOW = 3;
+
+// In-memory rate limit (per-isolate; good enough for small scale)
+const recentReports = new Map<string, number[]>();
+
+function getClientIP(request: Request): string {
+  // Cloudflare provides the real IP in CF-Connecting-IP
+  return request.headers.get('CF-Connecting-IP') ?? 
+         request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ?? 
+         'unknown';
+}
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const timestamps = recentReports.get(ip) ?? [];
+  // Filter to only timestamps within the window
+  const recent = timestamps.filter(t => now - t < RATE_LIMIT_WINDOW);
+  recentReports.set(ip, recent);
+  return recent.length >= MAX_REPORTS_PER_WINDOW;
+}
+
+function sanitizeForGitHub(text: string): string {
+  // Remove any null bytes and trim
+  return text.replace(/\0/g, '').trim();
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const ip = getClientIP(request);
+
+  // Rate limit check
+  if (isRateLimited(ip)) {
+    return new Response(JSON.stringify({ 
+      error: 'Too many reports. Please wait a minute before submitting another.' 
+    }), { 
+      status: 429, 
+      headers: { 
+        'Content-Type': 'application/json',
+        'Retry-After': '60' 
+      } 
+    });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { 
+      status: 400, 
+      headers: { 'Content-Type': 'application/json' } 
+    });
+  }
+
+  const description = sanitizeForGitHub(String(body.description ?? ''));
+  const page = sanitizeForGitHub(String(body.page ?? ''));
+  const userAgent = sanitizeForGitHub(String(body.userAgent ?? ''));
+  const timestamp = new Date().toISOString();
+
+  if (!description) {
+    return new Response(JSON.stringify({ error: 'Description is required' }), { 
+      status: 400, 
+      headers: { 'Content-Type': 'application/json' } 
+    });
+  }
+
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    return new Response(JSON.stringify({ error: `Description too long (max ${MAX_DESCRIPTION_LENGTH} characters)` }), { 
+      status: 400, 
+      headers: { 'Content-Type': 'application/json' } 
+    });
+  }
+
+  // Get GitHub token from env
+  const githubToken = (locals.runtime.env as any).GITHUB_TOKEN;
+  if (!githubToken) {
+    console.error('GITHUB_TOKEN env var not set — cannot create bug report issue');
+    return new Response(JSON.stringify({ error: 'Bug reporting is not configured. Please try again later.' }), { 
+      status: 503, 
+      headers: { 'Content-Type': 'application/json' } 
+    });
+  }
+
+  // Build issue title and body
+  const title = `Bug: ${description.slice(0, 80)}${description.length > 80 ? '…' : ''}`;
+  const issueBody = [
+    `**Page:** ${page || 'Not provided'}`,
+    `**Reported:** ${timestamp}`,
+    `**User-Agent:** ${userAgent || 'Not provided'}`,
+    '',
+    '---',
+    '',
+    description,
+  ].join('\n');
+
+  // Create GitHub issue
+  try {
+    const ghResponse = await fetch(`https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/issues`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `token ${githubToken}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'fanfiction-fyi-bug-report',
+      },
+      body: JSON.stringify({
+        title,
+        body: issueBody,
+        labels: ['bug', 'user-reported'],
+      }),
+    });
+
+    if (!ghResponse.ok) {
+      const errorText = await ghResponse.text();
+      console.error(`GitHub API error: ${ghResponse.status} ${errorText}`);
+      return new Response(JSON.stringify({ error: 'Failed to submit bug report. Please try again later.' }), { 
+        status: 502, 
+        headers: { 'Content-Type': 'application/json' } 
+      });
+    }
+
+    const issue = await ghResponse.json();
+
+    // Record this report for rate limiting
+    const now = Date.now();
+    const timestamps = recentReports.get(ip) ?? [];
+    timestamps.push(now);
+    recentReports.set(ip, timestamps);
+
+    return new Response(JSON.stringify({ 
+      ok: true, 
+      issue_number: issue.number,
+      issue_url: issue.html_url,
+    }), { 
+      status: 201, 
+      headers: { 'Content-Type': 'application/json' } 
+    });
+  } catch (err: any) {
+    console.error(`GitHub issue creation failed: ${err.message}`);
+    return new Response(JSON.stringify({ error: 'Failed to submit bug report. Please try again later.' }), { 
+      status: 502, 
+      headers: { 'Content-Type': 'application/json' } 
+    });
+  }
+};


### PR DESCRIPTION
## Bug Report Feature

Users can now report bugs directly from any page on fanfiction.fyi. Reports are automatically created as GitHub issues in this repo.

### What's new

- **🐛 Bug Report button** — floating action button (bottom-right) on every page, opens a modal dialog
- **Auto-captures context** — the page URL where the user started the report + their user-agent
- **`POST /api/bugs/report`** — API route that creates a GitHub issue via the REST API
  - Rate-limited: 3 reports per minute per IP
  - Sanitizes all input before submission
  - Labels issues with `bug` + `user-reported`
  - Returns issue number + URL on success
- **M3 Obsidian styling** — matches the site's existing design language
- **Accessible** — native `<dialog>` with backdrop, focus management, keyboard support

### Files changed

| File | Change |
|---|---|
| `src/components/BugReport.tsx` | New Preact island — FAB + modal |
| `src/pages/api/bugs/report.ts` | New API route — GitHub issue creation |
| `src/layouts/Base.astro` | Import BugReport component, add styles |

### Infrastructure

- `GITHUB_TOKEN` env var set on Cloudflare Pages (production) — scoped to repo issues
- `bug` and `user-reported` labels created in repo

### Security considerations

- Rate-limited per IP to prevent abuse
- Input sanitized (null byte stripping, length capping at 2000 chars)
- GitHub token server-side only — never exposed to client
- No auth required — anyone can report (by design, for unauthenticated users)