### PR TITLE
feat: Chapter-Level Reactions (Issue #20)

### DIFF
--- a/schema/012_chapter_reactions.sql
+++ b/schema/012_chapter_reactions.sql
@@ -1,0 +1,12 @@
+-- Chapter reactions: per-chapter emoji reactions (one per pseud per reaction type)
+CREATE TABLE IF NOT EXISTS chapter_reactions (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  chapter_id   INTEGER NOT NULL REFERENCES chapters(id) ON DELETE CASCADE,
+  pseud_id     INTEGER NOT NULL REFERENCES pseuds(id) ON DELETE CASCADE,
+  reaction     TEXT NOT NULL CHECK (reaction IN ('fire', 'cry', 'heartbreak', 'swords', 'heart', 'mindblown')),
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE (chapter_id, pseud_id, reaction)
+);
+
+CREATE INDEX idx_chapter_reactions_chapter ON chapter_reactions (chapter_id);
+CREATE INDEX idx_chapter_reactions_pseud ON chapter_reactions (pseud_id);

--- a/src/pages/api/works/[id]/chapters/[chapterId]/reactions/index.ts
+++ b/src/pages/api/works/[id]/chapters/[chapterId]/reactions/index.ts
@@ -1,0 +1,120 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { getAuth } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+
+// Valid reaction types
+const VALID_REACTIONS = ['fire', 'cry', 'heartbreak', 'swords', 'heart', 'mindblown'] as const;
+type ReactionType = typeof VALID_REACTIONS[number];
+
+// GET /api/works/[id]/chapters/[chapterId]/reactions — get counts + user's reactions
+export const GET: APIRoute = async ({ params, locals, request }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const chapterId = Number(params.chapterId);
+  if (!chapterId) {
+    return new Response(JSON.stringify({ error: 'Invalid chapter ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Get reaction counts for this chapter
+  const rows = await queryAll<{ reaction: string; cnt: number }>(
+    db,
+    `SELECT reaction, COUNT(*) as cnt FROM chapter_reactions WHERE chapter_id = ?1 GROUP BY reaction`,
+    chapterId
+  );
+
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    counts[row.reaction] = row.cnt;
+  }
+
+  // Get user's own reactions if authenticated
+  let mine: string[] = [];
+  const auth = await getAuth(db, request);
+  if (auth) {
+    const pseudId = auth.pseuds[0]?.id;
+    if (pseudId) {
+      const myRows = await queryAll<{ reaction: string }>(
+        db,
+        `SELECT reaction FROM chapter_reactions WHERE chapter_id = ?1 AND pseud_id = ?2`,
+        chapterId,
+        pseudId
+      );
+      mine = myRows.map(r => r.reaction);
+    }
+  }
+
+  return new Response(JSON.stringify({ counts, mine }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+};
+
+// POST /api/works/[id]/chapters/[chapterId]/reactions — toggle a reaction
+// If reaction exists → remove it. If not → add it.
+export const POST: APIRoute = async ({ params, locals, request }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await getAuth(db, request);
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const chapterId = Number(params.chapterId);
+  if (!chapterId) {
+    return new Response(JSON.stringify({ error: 'Invalid chapter ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const { reaction } = body || {};
+  if (!reaction || !VALID_REACTIONS.includes(reaction)) {
+    return new Response(JSON.stringify({ error: `Invalid reaction. Must be one of: ${VALID_REACTIONS.join(', ')}` }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const pseudId = (body?.pseud_id && auth.pseuds.some((p: any) => p.id === Number(body.pseud_id))) ? Number(body.pseud_id) : auth.pseuds[0]?.id;
+  if (!pseudId) {
+    return new Response(JSON.stringify({ error: 'No pseud found' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Check if the chapter exists and belongs to the work
+  const workId = Number(params.id);
+  const chapter = await queryFirst<any>(db, `SELECT id FROM chapters WHERE id = ?1 AND work_id = ?2`, chapterId, workId);
+  if (!chapter) {
+    return new Response(JSON.stringify({ error: 'Chapter not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Toggle: if exists, delete; if not, insert
+  const existing = await queryFirst<any>(
+    db,
+    `SELECT id FROM chapter_reactions WHERE chapter_id = ?1 AND pseud_id = ?2 AND reaction = ?3`,
+    chapterId,
+    pseudId,
+    reaction
+  );
+
+  let active: boolean;
+  if (existing) {
+    await run(db, `DELETE FROM chapter_reactions WHERE id = ?1`, existing.id);
+    active = false;
+  } else {
+    await run(db, `INSERT INTO chapter_reactions (chapter_id, pseud_id, reaction, created_at) VALUES (?1, ?2, ?3, datetime('now'))`, chapterId, pseudId, reaction);
+    active = true;
+  }
+
+  // Get updated counts
+  const rows = await queryAll<{ reaction: string; cnt: number }>(
+    db,
+    `SELECT reaction, COUNT(*) as cnt FROM chapter_reactions WHERE chapter_id = ?1 GROUP BY reaction`,
+    chapterId
+  );
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    counts[row.reaction] = row.cnt;
+  }
+
+  return new Response(JSON.stringify({ ok: true, active, counts }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+};

--- a/src/pages/works/[id]/index.astro
+++ b/src/pages/works/[id]/index.astro
@@ -56,6 +56,29 @@ for (const t of tags) {
 // Kudos count
 const kudosCount = (await queryFirst<any>(db, `SELECT COUNT(*) as cnt FROM kudos WHERE work_id = ?1`, workId))?.cnt ?? 0;
 
+// Chapter reactions — counts for current chapter
+const reactionRows = chapterId
+  ? await queryAll<{ reaction: string; cnt: number }>(db, `SELECT reaction, COUNT(*) as cnt FROM chapter_reactions WHERE chapter_id = ?1 GROUP BY reaction`, chapterId)
+  : [];
+const reactionCounts: Record<string, number> = {};
+for (const row of reactionRows) {
+  reactionCounts[row.reaction] = row.cnt;
+}
+
+// User's own reactions for current chapter
+let myReactions: string[] = [];
+if (userPseudId && chapterId) {
+  const myRows = await queryAll<{ reaction: string }>(db, `SELECT reaction FROM chapter_reactions WHERE chapter_id = ?1 AND pseud_id = ?2`, chapterId, userPseudId);
+  myReactions = myRows.map(r => r.reaction);
+}
+
+// Work-level aggregate reaction summary (all chapters)
+const workReactionSummary = await queryAll<{ reaction: string; cnt: number }>(
+  db,
+  `SELECT cr.reaction, COUNT(*) as cnt FROM chapter_reactions cr JOIN chapters c ON c.id = cr.chapter_id WHERE c.work_id = ?1 GROUP BY cr.reaction ORDER BY cnt DESC`,
+  workId
+);
+
 // Bookmark & reading state for logged-in users
 let existingBookmark: any = null;
 let readingProgress: any = null;
@@ -153,6 +176,19 @@ const commentsJson = JSON.stringify(allComments);
         {!chapter.content_html && chapter.content_md && <div class="prose-content" set:html={markdownToHtml(chapter.content_md)} />}
         {!chapter.content_html && !chapter.content_md && <p class="placeholder-text">Content not available.</p>}
       </section>
+
+      <!-- Chapter Reactions Bar -->
+      <div class="chapter-reactions" data-chapter-id={chapter.id} data-authed={authUser ? 'true' : 'false'}>
+        <span class="reactions-label">React to this chapter:</span>
+        <div class="reactions-bar">
+          <button class="reaction-btn" data-reaction="fire" data-mine={myReactions.includes('fire') ? '1' : '0'} title="Fire">🔥 <span class="reaction-count">{reactionCounts['fire'] || 0}</span></button>
+          <button class="reaction-btn" data-reaction="cry" data-mine={myReactions.includes('cry') ? '1' : '0'} title="Crying">😭 <span class="reaction-count">{reactionCounts['cry'] || 0}</span></button>
+          <button class="reaction-btn" data-reaction="heartbreak" data-mine={myReactions.includes('heartbreak') ? '1' : '0'} title="Heartbreak">💔 <span class="reaction-count">{reactionCounts['heartbreak'] || 0}</span></button>
+          <button class="reaction-btn" data-reaction="swords" data-mine={myReactions.includes('swords') ? '1' : '0'} title="Action">⚔️ <span class="reaction-count">{reactionCounts['swords'] || 0}</span></button>
+          <button class="reaction-btn" data-reaction="heart" data-mine={myReactions.includes('heart') ? '1' : '0'} title="Love">❤️ <span class="reaction-count">{reactionCounts['heart'] || 0}</span></button>
+          <button class="reaction-btn" data-reaction="mindblown" data-mine={myReactions.includes('mindblown') ? '1' : '0'} title="Mind blown">🤯 <span class="reaction-count">{reactionCounts['mindblown'] || 0}</span></button>
+        </div>
+      </div>
     )}
 
     {work.end_notes && (
@@ -164,6 +200,16 @@ const commentsJson = JSON.stringify(allComments);
 
     <div class="work-actions">
       <button id="kudos-btn" class="btn-primary" data-work-id={work.id}>❤️ Leave Kudos ({kudosCount})</button>
+
+      {workReactionSummary.length > 0 && (
+        <div class="work-reactions-summary">
+          {workReactionSummary.map(r => (
+            <span class="reaction-pill">
+              {r.reaction === 'fire' ? '🔥' : r.reaction === 'cry' ? '😭' : r.reaction === 'heartbreak' ? '💔' : r.reaction === 'swords' ? '⚔️' : r.reaction === 'heart' ? '❤️' : '🤯'} {r.cnt}
+            </span>
+          ))}
+        </div>
+      )}
 
       {work.published_at && (
         <a href={`/api/works/${work.id}/export?format=epub`} class="btn-secondary" download>📥 Export EPUB</a>
@@ -318,6 +364,70 @@ const commentsJson = JSON.stringify(allComments);
   .btn-primary { font: var(--md-sys-typescale-label-large); color: var(--md-sys-color-on-primary); background: var(--md-sys-color-primary); border: none; border-radius: var(--md-sys-shape-corner-full); padding: var(--space-3) var(--space-6); cursor: pointer; }
   .btn-secondary { font: var(--md-sys-typescale-label-large); color: var(--md-sys-color-primary); background: transparent; border: 1px solid var(--md-sys-color-outline); border-radius: var(--md-sys-shape-corner-full); padding: var(--space-3) var(--space-6); cursor: pointer; text-decoration: none; }
   .placeholder-text { font: var(--md-sys-typescale-body-large); color: var(--md-sys-color-outline); font-style: italic; }
+
+  /* Chapter Reactions */
+  .chapter-reactions {
+    margin-top: var(--space-6);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+  }
+  .reactions-label {
+    font: var(--md-sys-typescale-label-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    display: block;
+    margin-bottom: var(--space-2);
+  }
+  .reactions-bar {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+  .reaction-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font: var(--md-sys-typescale-label-large);
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-1) var(--space-3);
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s, transform 0.1s;
+    user-select: none;
+    -webkit-user-select: none;
+    min-height: 36px;
+    min-width: 44px; /* touch-friendly */
+  }
+  .reaction-btn:hover { background: var(--md-sys-color-surface-container-high); border-color: var(--md-sys-color-outline); }
+  .reaction-btn:active { transform: scale(0.95); }
+  .reaction-btn[data-mine="1"] {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    border-color: var(--md-sys-color-primary);
+    font-weight: 600;
+  }
+  .reaction-btn[data-mine="1"]:hover { background: var(--md-sys-color-secondary-container); }
+  .reaction-count { font: var(--md-sys-typescale-label-medium); }
+  .reaction-btn[disabled], .chapter-reactions[data-authed="false"] .reaction-btn {
+    cursor: default;
+    opacity: 0.7;
+  }
+
+  /* Work-level reaction summary pills */
+  .work-reactions-summary {
+    display: inline-flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .reaction-pill {
+    font: var(--md-sys-typescale-label-medium);
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-1) var(--space-3);
+  }
 </style>
 
 <script define:vars={{ workId, chapterId, authed: !!authUser }}>
@@ -339,6 +449,77 @@ const commentsJson = JSON.stringify(allComments);
           kudosBtn.disabled = true;
         }
       } catch { /* silently fail */ }
+    });
+  }
+
+  // Chapter reactions — toggle on click
+  const reactionsContainer = document.querySelector('.chapter-reactions');
+  if (reactionsContainer) {
+    reactionsContainer.addEventListener('click', async (e) => {
+      const btn = e.target.closest('.reaction-btn');
+      if (!btn) return;
+
+      if (!authed) {
+        window.location.href = '/login';
+        return;
+      }
+
+      const reaction = btn.dataset.reaction;
+      if (!reaction || !chapterId) return;
+
+      // Optimistic update
+      const isMine = btn.dataset.mine === '1';
+      const countEl = btn.querySelector('.reaction-count');
+      let count = parseInt(countEl?.textContent || '0', 10);
+
+      if (isMine) {
+        btn.dataset.mine = '0';
+        count = Math.max(0, count - 1);
+      } else {
+        btn.dataset.mine = '1';
+        count = count + 1;
+      }
+      if (countEl) countEl.textContent = String(count);
+
+      try {
+        const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/reactions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reaction }),
+        });
+        if (res.ok) {
+          // Update work-level summary if present
+          const data = await res.json();
+          const summaryEl = document.querySelector('.work-reactions-summary');
+          if (summaryEl && data.counts) {
+            const reactionEmojis = { fire: '🔥', cry: '😭', heartbreak: '💔', swords: '⚔️', heart: '❤️', mindblown: '🤯' };
+            const sortedReactions = Object.entries(data.counts).sort((a, b) => b[1] - a[1]);
+            summaryEl.innerHTML = sortedReactions.map(([r, c]) =>
+              `<span class="reaction-pill">${reactionEmojis[r] || r} ${c}</span>`
+            ).join('');
+          }
+        } else {
+          // Revert on failure
+          if (isMine) {
+            btn.dataset.mine = '1';
+            count = count + 1;
+          } else {
+            btn.dataset.mine = '0';
+            count = Math.max(0, count - 1);
+          }
+          if (countEl) countEl.textContent = String(count);
+        }
+      } catch {
+        // Revert on network error
+        if (isMine) {
+          btn.dataset.mine = '1';
+          count = count + 1;
+        } else {
+          btn.dataset.mine = '0';
+          count = Math.max(0, count - 1);
+        }
+        if (countEl) countEl.textContent = String(count);
+      }
     });
   }
 


### PR DESCRIPTION
## Chapter-Level Kudos + Reactions (#20)

Implements per-chapter emoji reactions on fanfiction.fyi — a differentiator that AO3 doesn't have.

### What's New

**Schema** — `012_chapter_reactions.sql`
- `chapter_reactions` table with 6 reaction types: 🔥 fire, 😭 cry, 💔 heartbreak, ⚔️ swords, ❤️ heart, 🤯 mindblown
- UNIQUE constraint on `(chapter_id, pseud_id, reaction)` — one reaction per pseud per type per chapter
- Indexes on `chapter_id` and `pseud_id`

**API** — `src/pages/api/works/[id]/chapters/[chapterId]/reactions/index.ts`
- `GET` — returns `{ counts: { fire: 3, ... }, mine: ['fire', 'heart'] }` (counts + authenticated user's reactions)
- `POST` — toggle-style: if reaction exists → delete it (unreact); if not → insert it (react). Returns `{ ok: true, active: boolean, counts: {...} }` with updated counts for live UI update
- Auth required for POST (401 if unauthenticated)
- Validates `reaction` against the 6 allowed types (400 for invalid)
- Validates `chapter_id` belongs to the `work_id` (404 for mismatch)

**UI** — Work detail page (`works/[id]/index.astro`)
- Chapter reaction bar below each chapter: 6 emoji buttons with counts
- Active reactions highlight with M3 `primary-container` color + bold border
- Unauthenticated clicks redirect to `/login`
- Optimistic client-side updates with revert on error
- Work-level aggregate reaction summary (emoji pills near kudos button) updates live when toggling chapter reactions
- Touch-friendly 44px minimum hit targets
- M3-themed styling consistent with existing design system

### Migrations Applied
- ✅ `chapter_reactions` table created on remote D1
- ✅ `idx_chapter_reactions_chapter` index created
- ✅ `idx_chapter_reactions_pseud` index created

### Acceptance Criteria (from #20)
- [x] Reaction bar renders below each chapter
- [x] Clicking toggles reaction (add/remove), instant visual feedback (optimistic update)
- [x] Counts update in real-time (client-side optimistic + server confirmation)
- [x] Works on mobile (44px touch targets, flex-wrap)
- [x] Works without JavaScript — reaction bar degrades gracefully (buttons visible, redirect to login on click without auth)