### PR TITLE
fix: login 500 crash on OAuth-only accounts + publish UX

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -53,7 +53,8 @@ export async function hashPassword(password: string): Promise<string> {
   return `${salt}$${PBKDF2_ITERATIONS}$${hash}`;
 }
 
-export async function verifyPassword(password: string, stored: string): Promise<{ valid: boolean; needsRehash: boolean }> {
+export async function verifyPassword(password: string, stored: string | null): Promise<{ valid: boolean; needsRehash: boolean }> {
+  if (!stored) return { valid: false, needsRehash: false };
   const parts = stored.split('$');
 
   if (parts.length === 3) {

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -33,6 +33,11 @@ export const POST: APIRoute = async ({ request, locals, clientAddress }) => {
     return new Response(JSON.stringify({ error: 'Invalid credentials' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   }
 
+  // OAuth-only users have no password set — guide them to sign in with Google
+  if (user.password_hash === null) {
+    return new Response(JSON.stringify({ error: 'no_password', message: 'This account uses Google sign-in' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+
   const { valid, needsRehash } = await verifyPassword(password, user.password_hash);
   if (!valid) {
     await recordFailedAttempt(db, email.toLowerCase(), 'login');

--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -208,9 +208,18 @@ import Base from '../../layouts/Base.astro';
           window.location.href = '/';
         }
       } else {
-        const data = await res.json();
-        if (data.error === 'banned') {
+        let data: any;
+        try {
+          data = await res.json();
+        } catch {
+          data = {};
+        }
+        if (data.error === 'no_password') {
+          errorEl.textContent = 'Your account was created with Google. Please use the "Sign in with Google" button above.';
+        } else if (data.error === 'banned') {
           errorEl.textContent = 'This account has been suspended';
+        } else if (res.status >= 500) {
+          errorEl.textContent = 'Something went wrong. If you signed up with Google, try signing in with Google instead.';
         } else {
           errorEl.textContent = data.error || 'Sign in failed';
         }


### PR DESCRIPTION
## Fixes

### Bug #1: `verifyPassword` crash on null `password_hash` (P0 — 500 error)

Users who signed up via Google OAuth have `password_hash = null` in the database. When they try to log in with email/password, `verifyPassword(password, null)` crashes with `TypeError: null.split is not a function`, which Cloudflare returns as a 500 with empty body.

**Fix**: Add null guard at the top of `verifyPassword` — if `stored` is null, return `{ valid: false, needsRehash: false }` instead of crashing. Also widened the type signature to `string | null`.

### Bug #2: Login API returns opaque error for OAuth-only users

Even with Bug #1 fixed (returning "invalid credentials"), users with Google-only accounts get a confusing "Invalid credentials" message. They should be told to use the Google sign-in button.

**Fix**: In `login.ts`, check `user.password_hash === null` before calling `verifyPassword` and return a 401 with `{ error: 'no_password', message: 'This account uses Google sign-in' }`.

### Bug #3: Login page shows "Network error" on 500 responses

When the API returns 500 with an empty body (the `verifyPassword` crash), `res.json()` throws and the catch block shows "Network error" — which tells the user nothing useful.

**Fix**: Wrap `res.json()` in try/catch with fallback to `{}`. Added specific handling for:
- `no_password` → "Your account was created with Google. Please use the 'Sign in with Google' button above."
- 5xx status → "Something went wrong. If you signed up with Google, try signing in with Google instead."

### Publish flow — verified working ✅

Checked the full publish chain:
- **New work form**: Sends `draft: 0` when "Save & Publish" is clicked ✅
- **Edit form**: Sends `publish: true` via click-tracked button ✅
- **PUT handler**: Sets `published_at` AND publishes all draft chapters (`draft = 0`) + recalculates word count ✅

## Files Changed

- `src/lib/auth.ts` — null guard in `verifyPassword`
- `src/pages/api/auth/login.ts` — early return for null password_hash accounts
- `src/pages/login/index.astro` — error message handling for no_password and 5xx