### PR TITLE
fix: remove nonexistent created_at from creatorships INSERT (500 on work creation)

### DIFF
--- a/src/pages/api/works/index.ts
+++ b/src/pages/api/works/index.ts
@@ -73,7 +73,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   const workId = workResult.meta.last_row_id;
 
-  await run(db, `INSERT INTO creatorships (pseud_id, work_id, role, created_at) VALUES (?1, ?2, 'author', datetime('now'))`, pseudId, workId);
+  await run(db, `INSERT INTO creatorships (pseud_id, work_id, role) VALUES (?1, ?2, 'author')`, pseudId, workId);
 
   const chapterResult = await run(db, `INSERT INTO chapters (work_id, position, title, content_md, content_html, draft, word_count, images, created_at, updated_at) VALUES (?1, 1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'), datetime('now'))`,
     workId, chapter_title || 'Chapter 1', contentMd, contentHtml, isDraft, wordCount, imagesJson);


### PR DESCRIPTION
## Fix

The `creatorships` table has no `created_at` column — not in the initial schema (`001_initial.sql`) and not added by any of the 13 subsequent migrations. The `INSERT INTO creatorships (pseud_id, work_id, role, created_at)` was referencing a nonexistent column, causing D1 to throw `table creatorships has no column named created_at`.

Since `POST /api/works` has no try/catch around this INSERT, the exception propagated as an unhandled 500 with empty body — no JSON error message, just a blank server error.

This was the **root cause** of works not being publishable. The entire work creation flow crashed at the creatorship insert (line 76 of the POST handler), before the response could be sent.

## Change

Remove `created_at` from the INSERT column list and its `datetime('now')` value.

```diff
- await run(db, `INSERT INTO creatorships (pseud_id, work_id, role, created_at) VALUES (?1, ?2, 'author', datetime('now'))`, pseudId, workId);
+ await run(db, `INSERT INTO creatorships (pseud_id, work_id, role) VALUES (?1, ?2, 'author')`, pseudId, workId);
```

Verified that all other INSERT statements reference columns that exist in the D1 schema.