### PR TITLE
feat: Lineage Graph — Recursive Fanwork Linking (Issue #17)

### DIFF
--- a/schema/015_work_relations.sql
+++ b/schema/015_work_relations.sql
@@ -1,0 +1,22 @@
+-- Work Relations: Lineage Graph — Recursive Fanwork Linking (Issue #17)
+-- Tracks relationships between works: inspired_by, remix_of, response_to, alternate_pov, continuation_of, fix_it_for
+
+CREATE TABLE IF NOT EXISTS work_relations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  work_id INTEGER NOT NULL,
+  related_work_id INTEGER NOT NULL,
+  relation_type TEXT NOT NULL CHECK(relation_type IN ('inspired_by', 'remix_of', 'response_to', 'alternate_pov', 'continuation_of', 'fix_it_for')),
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (work_id) REFERENCES works(id) ON DELETE CASCADE,
+  FOREIGN KEY (related_work_id) REFERENCES works(id) ON DELETE CASCADE,
+  UNIQUE(work_id, related_work_id, relation_type)
+);
+
+-- Index for looking up relations from a work's perspective
+CREATE INDEX IF NOT EXISTS idx_work_relations_work_id ON work_relations(work_id);
+
+-- Index for reverse lookups (what works point TO this work)
+CREATE INDEX IF NOT EXISTS idx_work_relations_related_work_id ON work_relations(related_work_id);
+
+-- Index for filtering by relation type
+CREATE INDEX IF NOT EXISTS idx_work_relations_type ON work_relations(relation_type);

--- a/src/pages/api/works/[id]/lineage/index.ts
+++ b/src/pages/api/works/[id]/lineage/index.ts
@@ -1,0 +1,108 @@
+export const prerender = false;
+
+import { queryFirst, queryAll } from '@/lib/db';
+import type { APIRoute } from 'astro';
+
+// GET /api/works/[id]/lineage — recursive graph data (depth-limited to 3 hops)
+// Returns nodes (works) and edges (relations) for visualization
+export const GET: APIRoute = async ({ params, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const workId = Number(params.id);
+  if (!workId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  const work = await queryFirst<any>(db, `SELECT id FROM works WHERE id = ?1`, workId);
+  if (!work) return new Response(JSON.stringify({ error: 'Work not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  const MAX_DEPTH = 3;
+  const visited = new Set<number>();
+  const nodes: any[] = [];
+  const edges: any[] = [];
+
+  // BFS traversal collecting works and relations
+  async function traverse(currentId: number, depth: number) {
+    if (depth > MAX_DEPTH || visited.has(currentId)) return;
+    visited.add(currentId);
+
+    // Fetch work info
+    const w = await queryFirst<any>(
+      db,
+      `SELECT w.id, w.title, w.word_count, w.published_at,
+              GROUP_CONCAT(p.name, ', ') as authors
+       FROM works w
+       LEFT JOIN creatorships c ON c.work_id = w.id
+       LEFT JOIN pseuds p ON p.id = c.pseud_id AND c.role = 'author'
+       WHERE w.id = ?1
+       GROUP BY w.id`,
+      currentId
+    );
+
+    if (!w) return;
+
+    nodes.push({
+      id: w.id,
+      title: w.title,
+      word_count: w.word_count,
+      published: !!w.published_at,
+      authors: w.authors || '',
+      isRoot: w.id === workId,
+    });
+
+    // Fetch outgoing relations (this work → other works)
+    const outgoing = await queryAll<any>(
+      db,
+      `SELECT wr.id as edge_id, wr.work_id, wr.related_work_id, wr.relation_type
+       FROM work_relations wr
+       WHERE wr.work_id = ?1`,
+      currentId
+    );
+
+    for (const edge of outgoing) {
+      edges.push({
+        id: edge.edge_id,
+        source: edge.work_id,
+        target: edge.related_work_id,
+        relation_type: edge.relation_type,
+        direction: 'outgoing',
+      });
+      if (!visited.has(edge.related_work_id)) {
+        await traverse(edge.related_work_id, depth + 1);
+      }
+    }
+
+    // Fetch incoming relations (other works → this work)
+    const incoming = await queryAll<any>(
+      db,
+      `SELECT wr.id as edge_id, wr.work_id, wr.related_work_id, wr.relation_type
+       FROM work_relations wr
+       WHERE wr.related_work_id = ?1`,
+      currentId
+    );
+
+    for (const edge of incoming) {
+      edges.push({
+        id: edge.edge_id,
+        source: edge.work_id,
+        target: edge.related_work_id,
+        relation_type: edge.relation_type,
+        direction: 'incoming',
+      });
+      if (!visited.has(edge.work_id)) {
+        await traverse(edge.work_id, depth + 1);
+      }
+    }
+  }
+
+  await traverse(workId, 0);
+
+  // Deduplicate edges (same edge_id can appear twice if we traverse both directions)
+  const seenEdges = new Set<number>();
+  const uniqueEdges = edges.filter(e => {
+    if (seenEdges.has(e.id)) return false;
+    seenEdges.add(e.id);
+    return true;
+  });
+
+  return new Response(JSON.stringify({ nodes, edges: uniqueEdges }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/works/[id]/relations/[relationId].ts
+++ b/src/pages/api/works/[id]/relations/[relationId].ts
@@ -1,0 +1,36 @@
+export const prerender = false;
+
+import { queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+
+// DELETE /api/works/[id]/relations/[relationId] — remove a relation (author-only)
+export const DELETE: APIRoute = async ({ params, request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(db, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const workId = Number(params.id);
+  const relationId = Number(params.relationId);
+  if (!workId || !relationId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  // Verify the relation exists and belongs to this work
+  const relation = await queryFirst<any>(db, `SELECT * FROM work_relations WHERE id = ?1 AND work_id = ?2`, relationId, workId);
+  if (!relation) {
+    return new Response(JSON.stringify({ error: 'Relation not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Verify ownership — user must be an author of the source work
+  const creatorship = await queryFirst<any>(
+    db,
+    `SELECT * FROM creatorships WHERE work_id = ?1 AND pseud_id IN (SELECT id FROM pseuds WHERE user_id = ?2)`,
+    workId, auth.user.id
+  );
+  if (!creatorship) {
+    return new Response(JSON.stringify({ error: 'Forbidden — only the author can remove relations' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  await run(db, `DELETE FROM work_relations WHERE id = ?1`, relationId);
+
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/works/[id]/relations/index.ts
+++ b/src/pages/api/works/[id]/relations/index.ts
@@ -1,0 +1,150 @@
+export const prerender = false;
+
+import { queryFirst, queryAll, run } from '@/lib/db';
+import { getAuth, requireAuth } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+
+const VALID_RELATION_TYPES = ['inspired_by', 'remix_of', 'response_to', 'alternate_pov', 'continuation_of', 'fix_it_for'];
+
+// Inverse relation labels for bidirectional display
+const INVERSE_LABELS: Record<string, string> = {
+  inspired_by: 'inspired',
+  remix_of: 'remixed by',
+  response_to: 'responded to by',
+  alternate_pov: 'alternate pov of',
+  continuation_of: 'continued by',
+  fix_it_for: 'fix-it for',
+};
+
+export function getInverseLabel(relationType: string): string {
+  return INVERSE_LABELS[relationType] || relationType;
+}
+
+// GET /api/works/[id]/relations — list all relations (outgoing + incoming) for a work
+export const GET: APIRoute = async ({ params, locals, request }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const workId = Number(params.id);
+  if (!workId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  const work = await queryFirst<any>(db, `SELECT id FROM works WHERE id = ?1`, workId);
+  if (!work) return new Response(JSON.stringify({ error: 'Work not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  // Outgoing relations: this work → other works
+  const outgoing = await queryAll<any>(
+    db,
+    `SELECT wr.id, wr.work_id, wr.related_work_id, wr.relation_type, wr.created_at,
+            w.title as related_title, w.word_count as related_word_count
+     FROM work_relations wr
+     JOIN works w ON w.id = wr.related_work_id
+     WHERE wr.work_id = ?1
+     ORDER BY wr.created_at DESC`,
+    workId
+  );
+
+  // Incoming relations: other works → this work
+  const incoming = await queryAll<any>(
+    db,
+    `SELECT wr.id, wr.work_id, wr.related_work_id, wr.relation_type, wr.created_at,
+            w.title as source_title, w.word_count as source_word_count
+     FROM work_relations wr
+     JOIN works w ON w.id = wr.work_id
+     WHERE wr.related_work_id = ?1
+     ORDER BY wr.created_at DESC`,
+    workId
+  );
+
+  // Format incoming with inverse labels
+  const incomingFormatted = incoming.map(r => ({
+    id: r.id,
+    work_id: r.related_work_id,
+    related_work_id: r.work_id,
+    relation_type: r.relation_type,
+    inverse_label: getInverseLabel(r.relation_type),
+    direction: 'incoming',
+    related_title: r.source_title,
+    related_word_count: r.source_word_count,
+    created_at: r.created_at,
+  }));
+
+  // Format outgoing
+  const outgoingFormatted = outgoing.map(r => ({
+    id: r.id,
+    work_id: r.work_id,
+    related_work_id: r.related_work_id,
+    relation_type: r.relation_type,
+    direction: 'outgoing',
+    related_title: r.related_title,
+    related_word_count: r.related_word_count,
+    created_at: r.created_at,
+  }));
+
+  return new Response(JSON.stringify({ outgoing: outgoingFormatted, incoming: incomingFormatted }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+// POST /api/works/[id]/relations — add a relation (author-only)
+export const POST: APIRoute = async ({ params, request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(db, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const workId = Number(params.id);
+  if (!workId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  let body: any;
+  try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
+
+  const { related_work_id, relation_type } = body;
+  if (!related_work_id || !relation_type) {
+    return new Response(JSON.stringify({ error: 'related_work_id and relation_type are required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  if (!VALID_RELATION_TYPES.includes(relation_type)) {
+    return new Response(JSON.stringify({ error: `Invalid relation_type. Valid types: ${VALID_RELATION_TYPES.join(', ')}` }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  if (Number(related_work_id) === workId) {
+    return new Response(JSON.stringify({ error: 'A work cannot relate to itself' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Verify target work exists
+  const targetWork = await queryFirst<any>(db, `SELECT id, published_at FROM works WHERE id = ?1`, related_work_id);
+  if (!targetWork) {
+    return new Response(JSON.stringify({ error: 'Related work not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Verify ownership — user must be an author of the source work
+  const creatorship = await queryFirst<any>(
+    db,
+    `SELECT * FROM creatorships WHERE work_id = ?1 AND pseud_id IN (SELECT id FROM pseuds WHERE user_id = ?2)`,
+    workId, auth.user.id
+  );
+  if (!creatorship) {
+    return new Response(JSON.stringify({ error: 'Forbidden — only the author can add relations' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Check for duplicate
+  const existing = await queryFirst<any>(
+    db,
+    `SELECT id FROM work_relations WHERE work_id = ?1 AND related_work_id = ?2 AND relation_type = ?3`,
+    workId, related_work_id, relation_type
+  );
+  if (existing) {
+    return new Response(JSON.stringify({ error: 'This relation already exists' }), { status: 409, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Insert the relation
+  const result = await run(
+    db,
+    `INSERT INTO work_relations (work_id, related_work_id, relation_type) VALUES (?1, ?2, ?3)`,
+    workId, related_work_id, relation_type
+  );
+
+  return new Response(JSON.stringify({
+    id: result.meta.last_row_id,
+    work_id: workId,
+    related_work_id: Number(related_work_id),
+    relation_type,
+  }), { status: 201, headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/works/[id]/index.astro
+++ b/src/pages/works/[id]/index.astro
@@ -46,6 +46,40 @@ const seriesLinks = await queryAll<any>(
   workId
 );
 
+// Work relations (lineage)
+const RELATION_LABELS: Record<string, string> = {
+  inspired_by: 'Inspired by',
+  remix_of: 'Remix of',
+  response_to: 'Response to',
+  alternate_pov: 'Alternate POV of',
+  continuation_of: 'Continuation of',
+  fix_it_for: 'Fix-it for',
+};
+const INVERSE_LABELS: Record<string, string> = {
+  inspired_by: 'Inspired',
+  remix_of: 'Remixed by',
+  response_to: 'Response by',
+  alternate_pov: 'Alternate POV',
+  continuation_of: 'Continued by',
+  fix_it_for: 'Fix-it for',
+};
+
+const outgoingRelations = await queryAll<any>(
+  db,
+  `SELECT wr.id, wr.related_work_id, wr.relation_type, w.title as related_title, w.published_at as related_published
+   FROM work_relations wr JOIN works w ON w.id = wr.related_work_id
+   WHERE wr.work_id = ?1 ORDER BY wr.created_at DESC`,
+  workId
+);
+const incomingRelations = await queryAll<any>(
+  db,
+  `SELECT wr.id, wr.work_id, wr.relation_type, w.title as source_title, w.published_at as source_published
+   FROM work_relations wr JOIN works w ON w.id = wr.work_id
+   WHERE wr.related_work_id = ?1 ORDER BY wr.created_at DESC`,
+  workId
+);
+const hasRelations = outgoingRelations.length > 0 || incomingRelations.length > 0;
+
 // Group tags by type
 const tagsByType: Record<string, string[]> = {};
 for (const t of tags) {
@@ -139,6 +173,27 @@ const commentsJson = JSON.stringify(allComments);
       )}
 
       {tagsByType.rating && <div class="tag-group"><span class="tag-label">Rating:</span> {tagsByType.rating.map(t => <span class="tag-pill tag-rating">{t}</span>)}</div>}
+
+      {hasRelations && (
+        <div class="work-relations">
+          <h4 class="relations-heading">Related Works</h4>
+          <ul class="relations-list">
+            {outgoingRelations.map(r => (
+              <li class="relation-item">
+                <span class="relation-label">{RELATION_LABELS[r.relation_type] || r.relation_type}</span>
+                <a href={`/works/${r.related_work_id}`} class="relation-link">{r.related_title}</a>
+              </li>
+            ))}
+            {incomingRelations.map(r => (
+              <li class="relation-item">
+                <span class="relation-label inverse">{INVERSE_LABELS[r.relation_type] || r.relation_type}</span>
+                <a href={`/works/${r.work_id}`} class="relation-link">{r.source_title}</a>
+              </li>
+            ))}
+          </ul>
+          <a href={`/works/${workId}/lineage`} class="lineage-link">View Lineage Graph ↗</a>
+        </div>
+      )}
       {tagsByType.warning && <div class="tag-group"><span class="tag-label">Warnings:</span> {tagsByType.warning.map(t => <span class="tag-pill tag-warning">{t}</span>)}</div>}
       {tagsByType.category && <div class="tag-group"><span class="tag-label">Category:</span> {tagsByType.category.map(t => <span class="tag-pill">{t}</span>)}</div>}
       {tagsByType.fandom && <div class="tag-group"><span class="tag-label">Fandom:</span> {tagsByType.fandom.map(t => <span class="tag-pill">{t}</span>)}</div>}
@@ -308,6 +363,17 @@ const commentsJson = JSON.stringify(allComments);
   .work-series { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-2); }
   .series-link { font: var(--md-sys-typescale-body-medium); color: var(--md-sys-color-on-surface-variant); }
   .series-link a { color: var(--md-sys-color-primary); }
+
+  .work-relations { margin-top: var(--space-3); }
+  .relations-heading { font: var(--md-sys-typescale-title-small); color: var(--md-sys-color-on-surface-variant); margin: 0 0 var(--space-2); }
+  .relations-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--space-1); }
+  .relation-item { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+  .relation-label { font: var(--md-sys-typescale-label-medium); background: var(--md-sys-color-tertiary-container); color: var(--md-sys-color-on-tertiary-container); padding: 1px var(--space-2); border-radius: var(--md-sys-shape-corner-full); white-space: nowrap; }
+  .relation-label.inverse { background: var(--md-sys-color-secondary-container); color: var(--md-sys-color-on-secondary-container); }
+  .relation-link { color: var(--md-sys-color-primary); font: var(--md-sys-typescale-body-medium); text-decoration: none; }
+  .relation-link:hover { text-decoration: underline; }
+  .lineage-link { font: var(--md-sys-typescale-label-medium); color: var(--md-sys-color-primary); display: inline-block; margin-top: var(--space-2); text-decoration: none; }
+  .lineage-link:hover { text-decoration: underline; }
 
   .tag-group { display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: center; margin: var(--space-1) 0; }
   .tag-label { font: var(--md-sys-typescale-label-large); color: var(--md-sys-color-on-surface-variant); }

--- a/src/pages/works/[id]/lineage/index.astro
+++ b/src/pages/works/[id]/lineage/index.astro
@@ -1,0 +1,467 @@
+---
+export const prerender = false;
+import Base from '../../../../layouts/Base.astro';
+import { queryFirst, queryAll } from '../../../../lib/db';
+
+const workId = Number(Astro.params.id);
+if (!workId) return Astro.redirect('/works');
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+
+const work = await queryFirst<any>(db, `SELECT id, title FROM works WHERE id = ?1`, workId);
+if (!work) return Astro.redirect('/works');
+---
+
+<Base title={`Lineage: ${work.title} — fanfiction.fyi`}>
+  <section class="lineage-page">
+    <header class="lineage-header">
+      <h1 class="lineage-title">Lineage Graph</h1>
+      <p class="lineage-subtitle">
+        The creative constellation of <a href={`/works/${workId}`} class="m3-link">{work.title}</a>
+      </p>
+    </header>
+
+    <div id="lineage-graph" class="lineage-graph" data-work-id={workId}>
+      <div class="graph-loading">Loading constellation…</div>
+    </div>
+
+    <div id="graph-legend" class="graph-legend">
+      <h3>Relation Types</h3>
+      <div class="legend-items">
+        <span class="legend-item"><span class="legend-line inspired"></span> Inspired by</span>
+        <span class="legend-item"><span class="legend-line remix"></span> Remix of</span>
+        <span class="legend-item"><span class="legend-line response"></span> Response to</span>
+        <span class="legend-item"><span class="legend-line alt-pov"></span> Alternate POV</span>
+        <span class="legend-item"><span class="legend-line continuation"></span> Continuation</span>
+        <span class="legend-item"><span class="legend-line fix-it"></span> Fix-it for</span>
+      </div>
+    </div>
+
+    <a href={`/works/${workId}`} class="m3-btn-outlined" style="margin-top: var(--space-4); display: inline-block;">← Back to Work</a>
+  </section>
+</Base>
+
+<style is:global>
+  @import '../../../../styles/theme.css';
+
+  .lineage-page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: var(--space-6) var(--space-4);
+  }
+
+  .lineage-header {
+    margin-bottom: var(--space-6);
+  }
+
+  .lineage-title {
+    font: var(--md-sys-typescale-headline-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-1);
+  }
+
+  .lineage-subtitle {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0;
+  }
+
+  .lineage-subtitle a {
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+  }
+
+  .lineage-subtitle a:hover {
+    text-decoration: underline;
+  }
+
+  .lineage-graph {
+    width: 100%;
+    height: 500px;
+    background: var(--md-sys-color-surface-container);
+    border-radius: var(--md-sys-shape-corner-large);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .graph-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-outline);
+  }
+
+  .lineage-graph svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Graph nodes */
+  .graph-node {
+    cursor: pointer;
+  }
+
+  .graph-node circle {
+    fill: var(--md-sys-color-secondary-container);
+    stroke: var(--md-sys-color-outline-variant);
+    stroke-width: 1.5px;
+    transition: fill 0.15s, stroke-width 0.15s;
+  }
+
+  .graph-node:hover circle {
+    fill: var(--md-sys-color-primary-container);
+    stroke: var(--md-sys-color-primary);
+    stroke-width: 2px;
+  }
+
+  .graph-node.root circle {
+    fill: var(--md-sys-color-primary-container);
+    stroke: var(--md-sys-color-primary);
+    stroke-width: 2.5px;
+  }
+
+  .graph-node text {
+    fill: var(--md-sys-color-on-surface);
+    font: var(--md-sys-typescale-label-medium);
+    pointer-events: none;
+    text-anchor: middle;
+  }
+
+  /* Graph edges */
+  .graph-edge {
+    stroke: var(--md-sys-color-outline);
+    stroke-width: 1.5px;
+    fill: none;
+    opacity: 0.6;
+  }
+
+  .graph-edge.inspired { stroke: #7B8FA8; }
+  .graph-edge.remix { stroke: #9C7B8F; }
+  .graph-edge.response { stroke: #8FA87B; }
+  .graph-edge.alt-pov { stroke: #A87B7B; }
+  .graph-edge.continuation { stroke: #7BA8A8; }
+  .graph-edge.fix-it { stroke: #A8A07B; }
+
+  .graph-edge-label {
+    fill: var(--md-sys-color-on-surface-variant);
+    font-size: 10px;
+    pointer-events: none;
+  }
+
+  /* Graph legend */
+  .graph-legend {
+    margin-top: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    background: var(--md-sys-color-surface-container);
+    border-radius: var(--md-sys-shape-corner-medium);
+  }
+
+  .graph-legend h3 {
+    font: var(--md-sys-typescale-title-small);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-2);
+  }
+
+  .legend-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .legend-line {
+    display: inline-block;
+    width: 24px;
+    height: 3px;
+    border-radius: 2px;
+  }
+
+  .legend-line.inspired { background: #7B8FA8; }
+  .legend-line.remix { background: #9C7B8F; }
+  .legend-line.response { background: #8FA87B; }
+  .legend-line.alt-pov { background: #A87B7B; }
+  .legend-line.continuation { background: #7BA8A8; }
+  .legend-line.fix-it { background: #A8A07B; }
+
+  .graph-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: var(--space-3);
+    text-align: center;
+  }
+
+  .graph-empty p {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-outline);
+    margin: 0;
+  }
+
+  .graph-empty a {
+    color: var(--md-sys-color-primary);
+  }
+
+  .m3-btn-outlined {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+  }
+</style>
+
+<script define:vars={{ workId }}>
+  const RELATION_COLORS = {
+    inspired_by: 'inspired',
+    remix_of: 'remix',
+    response_to: 'response',
+    alternate_pov: 'alt-pov',
+    continuation_of: 'continuation',
+    fix_it_for: 'fix-it',
+  };
+
+  const RELATION_LABELS = {
+    inspired_by: 'inspired by',
+    remix_of: 'remix of',
+    response_to: 'response to',
+    alternate_pov: 'alt POV',
+    continuation_of: 'continuation',
+    fix_it_for: 'fix-it for',
+  };
+
+  async function buildGraph() {
+    const container = document.getElementById('lineage-graph');
+    if (!container) return;
+
+    try {
+      const res = await fetch(`/api/works/${workId}/lineage`);
+      if (!res.ok) throw new Error('Failed to load lineage data');
+      const { nodes, edges } = await res.json();
+
+      if (!nodes || nodes.length === 0) {
+        container.innerHTML = '';
+        const empty = document.createElement('div');
+        empty.className = 'graph-empty';
+        empty.innerHTML = `<p>This work has no relations yet.</p><p><a href="/works/${workId}/settings">Add relations in Settings</a></p>`;
+        container.appendChild(empty);
+        return;
+      }
+
+      // Simple force-directed layout (no d3 dependency)
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+
+      // Initialize positions
+      const nodeMap = new Map();
+      nodes.forEach((n, i) => {
+        const angle = (2 * Math.PI * i) / nodes.length;
+        const radius = Math.min(width, height) * 0.3;
+        nodeMap.set(n.id, {
+          ...n,
+          x: width / 2 + radius * Math.cos(angle),
+          y: height / 2 + radius * Math.sin(angle),
+          vx: 0,
+          vy: 0,
+        });
+      });
+
+      // Force simulation (simple spring + repulsion)
+      const REPULSION = 8000;
+      const ATTRACTION = 0.005;
+      const DAMPING = 0.85;
+      const CENTER_FORCE = 0.01;
+      const ITERATIONS = 120;
+
+      for (let iter = 0; iter < ITERATIONS; iter++) {
+        const nodeArr = Array.from(nodeMap.values());
+
+        // Repulsion between all pairs
+        for (let i = 0; i < nodeArr.length; i++) {
+          for (let j = i + 1; j < nodeArr.length; j++) {
+            const a = nodeArr[i], b = nodeArr[j];
+            let dx = b.x - a.x;
+            let dy = b.y - a.y;
+            const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+            const force = REPULSION / (dist * dist);
+            const fx = (dx / dist) * force;
+            const fy = (dy / dist) * force;
+            a.vx -= fx; a.vy -= fy;
+            b.vx += fx; b.vy += fy;
+          }
+        }
+
+        // Attraction along edges
+        for (const edge of edges) {
+          const a = nodeMap.get(edge.source);
+          const b = nodeMap.get(edge.target);
+          if (!a || !b) continue;
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          const force = dist * ATTRACTION;
+          const fx = (dx / dist) * force;
+          const fy = (dy / dist) * force;
+          a.vx += fx; a.vy += fy;
+          b.vx -= fx; b.vy -= fy;
+        }
+
+        // Center gravity
+        for (const n of nodeArr) {
+          n.vx += (width / 2 - n.x) * CENTER_FORCE;
+          n.vy += (height / 2 - n.y) * CENTER_FORCE;
+        }
+
+        // Apply velocity with damping
+        for (const n of nodeArr) {
+          n.vx *= DAMPING;
+          n.vy *= DAMPING;
+          n.x += n.vx;
+          n.y += n.vy;
+          // Bounds
+          n.x = Math.max(40, Math.min(width - 40, n.x));
+          n.y = Math.max(30, Math.min(height - 30, n.y));
+        }
+      }
+
+      // Render SVG
+      const svgNS = 'http://www.w3.org/2000/svg';
+      const svg = document.createElementNS(svgNS, 'svg');
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      svg.setAttribute('width', '100%');
+      svg.setAttribute('height', '100%');
+
+      // Defs for arrowheads
+      const defs = document.createElementNS(svgNS, 'defs');
+      for (const [type, cls] of Object.entries(RELATION_COLORS)) {
+        const marker = document.createElementNS(svgNS, 'marker');
+        marker.setAttribute('id', `arrow-${cls}`);
+        marker.setAttribute('markerWidth', '8');
+        marker.setAttribute('markerHeight', '6');
+        marker.setAttribute('refX', '24');
+        marker.setAttribute('refY', '3');
+        marker.setAttribute('orient', 'auto');
+        const polygon = document.createElementNS(svgNS, 'polygon');
+        polygon.setAttribute('points', '0 0, 8 3, 0 6');
+        polygon.setAttribute('fill', 'var(--md-sys-color-outline)');
+        marker.appendChild(polygon);
+        defs.appendChild(marker);
+      }
+      svg.appendChild(defs);
+
+      // Edges
+      for (const edge of edges) {
+        const source = nodeMap.get(edge.source);
+        const target = nodeMap.get(edge.target);
+        if (!source || !target) continue;
+
+        const colorClass = RELATION_COLORS[edge.relation_type] || '';
+        const line = document.createElementNS(svgNS, 'line');
+        line.setAttribute('x1', source.x);
+        line.setAttribute('y1', source.y);
+        line.setAttribute('x2', target.x);
+        line.setAttribute('y2', target.y);
+        line.setAttribute('class', `graph-edge ${colorClass}`);
+        svg.appendChild(line);
+
+        // Edge label (midpoint)
+        const label = document.createElementNS(svgNS, 'text');
+        label.setAttribute('x', (source.x + target.x) / 2);
+        label.setAttribute('y', (source.y + target.y) / 2 - 5);
+        label.setAttribute('class', 'graph-edge-label');
+        label.setAttribute('text-anchor', 'middle');
+        label.textContent = RELATION_LABELS[edge.relation_type] || edge.relation_type;
+        svg.appendChild(label);
+      }
+
+      // Nodes
+      for (const [id, node] of nodeMap) {
+        const g = document.createElementNS(svgNS, 'g');
+        g.setAttribute('class', `graph-node${node.isRoot ? ' root' : ''}`);
+        g.setAttribute('transform', `translate(${node.x}, ${node.y})`);
+
+        const circle = document.createElementNS(svgNS, 'circle');
+        circle.setAttribute('r', node.isRoot ? '18' : '14');
+        g.appendChild(circle);
+
+        const text = document.createElementNS(svgNS, 'text');
+        text.setAttribute('dy', '30');
+        // Truncate long titles
+        const title = node.title.length > 25 ? node.title.slice(0, 22) + '…' : node.title;
+        text.textContent = title;
+        g.appendChild(text);
+
+        g.addEventListener('click', () => {
+          window.location.href = `/works/${node.id}`;
+        });
+
+        svg.appendChild(g);
+      }
+
+      container.replaceChildren(svg);
+
+      // Make graph pannable/zoomable with mouse
+      let viewBox = { x: 0, y: 0, w: width, h: height };
+      let isPanning = false;
+      let startPoint = { x: 0, y: 0 };
+
+      svg.addEventListener('mousedown', (e) => {
+        if (e.target.closest('.graph-node')) return;
+        isPanning = true;
+        startPoint = { x: e.clientX, y: e.clientY };
+        svg.style.cursor = 'grabbing';
+      });
+
+      svg.addEventListener('mousemove', (e) => {
+        if (!isPanning) return;
+        const dx = e.clientX - startPoint.x;
+        const dy = e.clientY - startPoint.y;
+        viewBox.x -= dx;
+        viewBox.y -= dy;
+        svg.setAttribute('viewBox', `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`);
+        startPoint = { x: e.clientX, y: e.clientY };
+      });
+
+      svg.addEventListener('mouseup', () => {
+        isPanning = false;
+        svg.style.cursor = 'default';
+      });
+
+      svg.addEventListener('mouseleave', () => {
+        isPanning = false;
+        svg.style.cursor = 'default';
+      });
+
+      svg.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        const scale = e.deltaY > 0 ? 1.1 : 0.9;
+        viewBox.w *= scale;
+        viewBox.h *= scale;
+        svg.setAttribute('viewBox', `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`);
+      }, { passive: false });
+
+    } catch (err) {
+      container.innerHTML = '';
+      const errorDiv = document.createElement('div');
+      errorDiv.className = 'graph-empty';
+      errorDiv.innerHTML = `<p>Failed to load lineage graph.</p>`;
+      container.appendChild(errorDiv);
+    }
+  }
+
+  buildGraph();
+</script>

--- a/src/pages/works/[id]/settings.astro
+++ b/src/pages/works/[id]/settings.astro
@@ -36,6 +36,25 @@ const categoryTag = tags.find(t => t.type === 'category');
 const warningTag = tags.find(t => t.type === 'warning');
 
 const initialTagsJson = JSON.stringify(initialTagState);
+
+// Fetch existing relations for this work
+const existingRelations = await queryAll<any>(
+  db,
+  `SELECT wr.id, wr.related_work_id, wr.relation_type, w.title as related_title
+   FROM work_relations wr JOIN works w ON w.id = wr.related_work_id
+   WHERE wr.work_id = ?1 ORDER BY wr.created_at DESC`,
+  workId
+);
+const existingRelationsJson = JSON.stringify(existingRelations);
+
+const RELATION_TYPES = [
+  { value: 'inspired_by', label: 'Inspired by' },
+  { value: 'remix_of', label: 'Remix of' },
+  { value: 'response_to', label: 'Response to' },
+  { value: 'alternate_pov', label: 'Alternate POV of' },
+  { value: 'continuation_of', label: 'Continuation of' },
+  { value: 'fix_it_for', label: 'Fix-it for' },
+];
 ---
 
 <Base title={`Settings: ${work.title} — fanfiction.fyi`}>
@@ -120,6 +139,35 @@ const initialTagsJson = JSON.stringify(initialTagState);
         </div>
       </div>
 
+      <!-- Card 4: Lineage (Relations) -->
+      <div class="m3-card">
+        <h2 class="m3-card-title">Lineage</h2>
+        <p class="m3-card-desc">Link this work to others it's related to — inspirations, remixes, continuations.</p>
+
+        <div id="existing-relations" class="relations-list" data-work-id={workId}>
+          {existingRelations.length === 0 && <p class="m3-hint">No relations yet. Add one below.</p>}
+          {existingRelations.map(r => {
+            const typeLabel = RELATION_TYPES.find(t => t.value === r.relation_type)?.label || r.relation_type;
+            return (
+              <div class="relation-row" data-relation-id={r.id}>
+                <span class="relation-type-badge">{typeLabel}</span>
+                <a href={`/works/${r.related_work_id}`} class="relation-work-link">{r.related_title}</a>
+                <button type="button" class="relation-remove-btn" data-relation-id={r.id} data-work-id={workId} title="Remove relation">✕</button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div class="add-relation-form">
+          <select id="relation-type" class="m3-select">
+            {RELATION_TYPES.map(t => <option value={t.value}>{t.label}</option>)}
+          </select>
+          <input type="number" id="relation-work-id" class="m3-input" placeholder="Work ID" min="1" />
+          <button type="button" id="add-relation-btn" class="m3-btn-filled">Add Relation</button>
+        </div>
+        <p class="m3-hint">Enter the ID of the work you want to link. You can find it in the work's URL.</p>
+      </div>
+
       <div class="form-actions">
         <a href={`/works/${workId}/draft`} class="m3-btn-outlined">Back to Writing</a>
         <button type="submit" class="m3-btn-filled" id="save-btn">Save Changes</button>
@@ -162,6 +210,87 @@ const initialTagsJson = JSON.stringify(initialTagState);
 
   .tag-chips-field {
     position: relative;
+  }
+
+  .m3-card-desc {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-4) 0;
+  }
+
+  .relations-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+  }
+
+  .relation-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    background: var(--md-sys-color-surface-container);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .relation-type-badge {
+    font: var(--md-sys-typescale-label-medium);
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+    padding: 2px var(--space-2);
+    border-radius: var(--md-sys-shape-corner-full);
+    white-space: nowrap;
+  }
+
+  .relation-work-link {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .relation-work-link:hover { text-decoration: underline; }
+
+  .relation-remove-btn {
+    background: none;
+    border: none;
+    color: var(--md-sys-color-error);
+    cursor: pointer;
+    font-size: 16px;
+    padding: 4px;
+    border-radius: var(--md-sys-shape-corner-full);
+    line-height: 1;
+  }
+
+  .relation-remove-btn:hover {
+    background: var(--md-sys-color-error-container);
+    color: var(--md-sys-color-on-error-container);
+  }
+
+  .add-relation-form {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .add-relation-form .m3-select {
+    min-width: 160px;
+  }
+
+  .add-relation-form .m3-input {
+    width: 120px;
+  }
+
+  .m3-hint {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+    margin: var(--space-2) 0 0 0;
   }
 </style>
 
@@ -244,6 +373,67 @@ const initialTagsJson = JSON.stringify(initialTagState);
       } else {
         const data = await res.json();
         errorEl.textContent = data.error || 'Failed to delete work';
+      }
+    } catch {
+      errorEl.textContent = 'Network error';
+    }
+  });
+
+  // Lineage: Add relation
+  const addRelationBtn = document.getElementById('add-relation-btn');
+  const relationTypeSelect = document.getElementById('relation-type') as HTMLSelectElement;
+  const relationWorkIdInput = document.getElementById('relation-work-id') as HTMLInputElement;
+  const relationsContainer = document.getElementById('existing-relations')!;
+
+  if (addRelationBtn) {
+    addRelationBtn.addEventListener('click', async () => {
+      const relatedWorkId = Number(relationWorkIdInput.value);
+      const relationType = relationTypeSelect.value;
+      if (!relatedWorkId || relatedWorkId <= 0) {
+        errorEl.textContent = 'Enter a valid Work ID';
+        return;
+      }
+      try {
+        const res = await fetch(`/api/works/${workId}/relations`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ related_work_id: relatedWorkId, relation_type: relationType }),
+        });
+        if (res.ok) {
+          relationWorkIdInput.value = '';
+          // Reload to refresh the relations list
+          window.location.reload();
+        } else {
+          const data = await res.json();
+          errorEl.textContent = data.error || 'Failed to add relation';
+        }
+      } catch {
+        errorEl.textContent = 'Network error';
+      }
+    });
+  }
+
+  // Lineage: Remove relation
+  relationsContainer.addEventListener('click', async (e) => {
+    const target = e.target as HTMLElement;
+    if (!target.classList.contains('relation-remove-btn')) return;
+    const relationId = target.getAttribute('data-relation-id');
+    const wid = target.getAttribute('data-work-id');
+    if (!relationId || !wid) return;
+    if (!confirm('Remove this relation?')) return;
+    try {
+      const res = await fetch(`/api/works/${wid}/relations/${relationId}`, { method: 'DELETE' });
+      if (res.ok) {
+        // Remove the row from the DOM
+        const row = target.closest('.relation-row') as HTMLElement;
+        if (row) row.remove();
+        // If no relations left, show the hint
+        if (!relationsContainer.querySelector('.relation-row')) {
+          const hint = document.createElement('p');
+          hint.className = 'm3-hint';
+          hint.textContent = 'No relations yet. Add one below.';
+          relationsContainer.appendChild(hint);
+        }
       }
     } catch {
       errorEl.textContent = 'Network error';


### PR DESCRIPTION
## Lineage Graph — Recursive Fanwork Linking

Implements [Issue #17](https://github.com/triursa/fanfiction-fyi/issues/17) — a category-defining feature that lets every work declare its relationship to other works, creating a visual constellation graph.

### What's New

**Schema**
- `work_relations` table with 6 relation types: `inspired_by`, `remix_of`, `response_to`, `alternate_pov`, `continuation_of`, `fix_it_for`
- Unique constraint on `(work_id, related_work_id, relation_type)` to prevent duplicates
- Indexes for both forward and reverse lookups

**API Endpoints**
- `GET /api/works/[id]/relations` — List all relations (outgoing + incoming) with bidirectional labels
- `POST /api/works/[id]/relations` — Add a relation (author-only, validates work exists, prevents self-relation)
- `DELETE /api/works/[id]/relations/[relationId]` — Remove a relation (author-only)
- `GET /api/works/[id]/lineage` — Recursive BFS graph traversal (3-hop depth limit), returns nodes + edges for visualization

**UI — Work Detail Page**
- "Related Works" section appears when a work has relations
- Shows both outgoing (e.g., "Inspired by: [Work Title]") and incoming (e.g., "Inspired: [Work Title]") with distinct label styling
- "View Lineage Graph ↗" link to the visualization

**UI — Work Settings Page**
- New "Lineage" card with relation type dropdown + Work ID input
- Existing relations displayed as removable rows (type badge + work title link)
- Add/remove relations inline without page save

**UI — Lineage Graph Page (`/works/[id]/lineage`)**
- Interactive SVG force-directed graph (no d3 dependency — pure canvas-style simulation)
- Color-coded edges by relation type with legend
- Pan/drag to explore, scroll to zoom
- Click nodes to navigate to related works
- Root node highlighted with primary accent
- Empty state with link to Settings when no relations exist

**Bidirectional Display**
- If Work A is "inspired_by" Work B:
  - A's page shows: "Inspired by: **Work B**" (tertiary label)
  - B's page shows: "Inspired: **Work A**" (secondary label — inverse)

### Acceptance Criteria Status
- [x] Author can add relations when editing a work
- [x] Work detail page shows related works with relationship labels
- [x] Lineage graph page renders interactive SVG constellation
- [x] Graph supports click-to-navigate to related works
- [x] Bidirectional: if A is "inspired by" B, B shows "inspired" in its relations

### Deployment Notes
- **D1 Migration:** `schema/015_work_relations.sql` must be applied to remote D1 before deployment
- Uses sequential REST API calls with existence checks (per established migration pattern)