### PR TITLE
feat: Pseud as Portfolio — Living Author Pages (#18)

### DIFF
--- a/schema/016_pseud_portfolio.sql
+++ b/schema/016_pseud_portfolio.sql
@@ -1,0 +1,5 @@
+-- Pseud as Portfolio — Living Author Pages (Issue #18)
+-- Adds pinned_work_ids (JSON array of work IDs) and banner_key (R2 storage key) to pseuds table
+
+ALTER TABLE pseuds ADD COLUMN pinned_work_ids TEXT DEFAULT '[]';
+ALTER TABLE pseuds ADD COLUMN banner_key TEXT;

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -1,0 +1,170 @@
+import { h } from 'preact';
+import { useState, useEffect, useRef } from 'preact/hooks';
+
+interface HeatmapProps {
+  activity: Record<string, number>; // YYYY-MM-DD → count
+  year?: number;
+}
+
+const CELL_SIZE = 12;
+const CELL_GAP = 2;
+const CELL_STEP = CELL_SIZE + CELL_GAP;
+const WEEKS = 53;
+const DAYS = 7;
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function getColor(count: number, maxCount: number): string {
+  if (count === 0) return 'var(--md-sys-color-surface-container)';
+  const ratio = maxCount > 0 ? count / maxCount : 0;
+  if (ratio < 0.25) return 'var(--md-sys-color-primary-container, rgba(123,143,168,0.2))';
+  if (ratio < 0.5) return 'var(--md-sys-color-primary, rgba(123,143,168,0.4))';
+  if (ratio < 0.75) return 'var(--md-sys-color-primary, rgba(123,143,168,0.65))';
+  return 'var(--md-sys-color-primary, rgba(123,143,168,0.9))';
+}
+
+export default function ActivityHeatmap({ activity, year }: HeatmapProps) {
+  const currentYear = year ?? new Date().getFullYear();
+  const [tooltip, setTooltip] = useState<{ text: string; x: number; y: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Build grid data: 53 weeks × 7 days starting from Jan 1
+  const startDate = new Date(currentYear, 0, 1);
+  // Shift to Sunday start
+  const startDay = startDate.getDay();
+  const gridStart = new Date(currentYear, 0, 1 - startDay);
+
+  const maxCount = Math.max(1, ...Object.values(activity));
+  const cells: { date: string; count: number; week: number; day: number }[] = [];
+
+  for (let week = 0; week < WEEKS; week++) {
+    for (let day = 0; day < DAYS; day++) {
+      const d = new Date(gridStart);
+      d.setDate(d.getDate() + week * 7 + day);
+      const dateStr = d.toISOString().substring(0, 10);
+      const count = activity[dateStr] || 0;
+      if (d.getFullYear() === currentYear) {
+        cells.push({ date: dateStr, count, week, day });
+      }
+    }
+  }
+
+  // Month labels positioning
+  const monthPositions: { label: string; week: number }[] = [];
+  let lastMonth = -1;
+  for (const cell of cells) {
+    const d = new Date(cell.date);
+    const month = d.getMonth();
+    if (month !== lastMonth && cell.day === 0) {
+      monthPositions.push({ label: MONTH_LABELS[month], week: cell.week });
+      lastMonth = month;
+    }
+  }
+
+  const handleMouseEnter = (e: MouseEvent, cell: typeof cells[0]) => {
+    const rect = (e.target as SVGRectElement).getBoundingClientRect();
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (!containerRect) return;
+    const text = cell.count > 0
+      ? `${cell.count} publication${cell.count > 1 ? 's' : ''} on ${cell.date}`
+      : `No publications on ${cell.date}`;
+    setTooltip({
+      text,
+      x: rect.left - containerRect.left + CELL_SIZE / 2,
+      y: rect.top - containerRect.top - 8,
+    });
+  };
+
+  const handleMouseLeave = () => setTooltip(null);
+
+  const totalPublications = Object.values(activity).reduce((a, b) => a + b, 0);
+  const activeDays = Object.values(activity).filter(v => v > 0).length;
+
+  return (
+    <div class="heatmap-container" ref={containerRef}>
+      <div class="heatmap-header">
+        <span class="heatmap-title">Activity</span>
+        <span class="heatmap-summary">{totalPublications} publications in {activeDays} days</span>
+      </div>
+      <div class="heatmap-chart" style={{ position: 'relative' }}>
+        <svg
+          width={WEEKS * CELL_STEP + 30}
+          height={DAYS * CELL_STEP + 20}
+          style={{ overflow: 'visible' }}
+        >
+          {/* Day labels */}
+          {DAY_LABELS.map((label, i) =>
+            label ? (
+              <text
+                key={i}
+                x={0}
+                y={i * CELL_STEP + CELL_SIZE}
+                fill="var(--md-sys-color-on-surface-variant)"
+                font-size="9"
+                font-family="Inter, sans-serif"
+              >
+                {label}
+              </text>
+            ) : null
+          )}
+          {/* Month labels */}
+          {monthPositions.map((m, i) => (
+            <text
+              key={`m-${i}`}
+              x={30 + m.week * CELL_STEP}
+              y={-2}
+              fill="var(--md-sys-color-on-surface-variant)"
+              font-size="9"
+              font-family="Inter, sans-serif"
+            >
+              {m.label}
+            </text>
+          ))}
+          {/* Cells */}
+          {cells.map((cell) => (
+            <rect
+              key={cell.date}
+              x={30 + cell.week * CELL_STEP}
+              y={cell.day * CELL_STEP}
+              width={CELL_SIZE}
+              height={CELL_SIZE}
+              rx={2}
+              fill={getColor(cell.count, maxCount)}
+              onMouseEnter={(e: any) => handleMouseEnter(e, cell)}
+              onMouseLeave={handleMouseLeave}
+              style={{ cursor: 'pointer' }}
+            />
+          ))}
+        </svg>
+        {tooltip && (
+          <div
+            class="heatmap-tooltip"
+            style={{
+              position: 'absolute',
+              left: tooltip.x,
+              top: tooltip.y,
+              transform: 'translate(-50%, -100%)',
+              pointerEvents: 'none',
+            }}
+          >
+            {tooltip.text}
+          </div>
+        )}
+      </div>
+      <div class="heatmap-legend">
+        <span class="heatmap-legend-label">Less</span>
+        {[0, 0.25, 0.5, 0.75, 1].map((ratio, i) => (
+          <svg key={i} width={CELL_SIZE} height={CELL_SIZE}>
+            <rect
+              width={CELL_SIZE}
+              height={CELL_SIZE}
+              rx={2}
+              fill={getColor(ratio * maxCount, maxCount)}
+            />
+          </svg>
+        ))}
+        <span class="heatmap-legend-label">More</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GenrePie.tsx
+++ b/src/components/GenrePie.tsx
@@ -1,0 +1,83 @@
+import { h } from 'preact';
+
+interface GenrePieProps {
+  data: { name: string; count: number }[];
+  size?: number;
+}
+
+const PALETTE = [
+  '#7B8FA8', '#94A7BC', '#6B7D94', '#8FA3B8', '#A3B5C8',
+  '#5F7289', '#8396AC', '#98ABBE', '#6E8398', '#B0C0D0',
+];
+
+export default function GenrePie({ data, size = 100 }: GenrePieProps) {
+  if (!data.length) return null;
+
+  const total = data.reduce((sum, d) => sum + d.count, 0);
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size / 2 - 4;
+
+  let cumulativeAngle = -90; // start from top
+  const slices: { name: string; count: number; startAngle: number; endAngle: number; color: string }[] = [];
+
+  data.forEach((d, i) => {
+    const angle = (d.count / total) * 360;
+    slices.push({
+      name: d.name,
+      count: d.count,
+      startAngle: cumulativeAngle,
+      endAngle: cumulativeAngle + angle,
+      color: PALETTE[i % PALETTE.length],
+    });
+    cumulativeAngle += angle;
+  });
+
+  function polarToCartesian(angle: number): { x: number; y: number } {
+    const rad = (angle * Math.PI) / 180;
+    return {
+      x: cx + r * Math.cos(rad),
+      y: cy + r * Math.sin(rad),
+    };
+  }
+
+  function arcPath(startAngle: number, endAngle: number): string {
+    if (endAngle - startAngle >= 359.9) {
+      // Full circle — draw two arcs
+      const mid = startAngle + 180;
+      const s1 = polarToCartesian(startAngle);
+      const m = polarToCartesian(mid);
+      const e = polarToCartesian(endAngle);
+      return `M ${cx} ${cy} L ${s1.x} ${s1.y} A ${r} ${r} 0 1 1 ${m.x} ${m.y} A ${r} ${r} 0 1 1 ${e.x} ${e.y} Z`;
+    }
+    const s = polarToCartesian(startAngle);
+    const e = polarToCartesian(endAngle);
+    const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+    return `M ${cx} ${cy} L ${s.x} ${s.y} A ${r} ${r} 0 ${largeArc} 1 ${e.x} ${e.y} Z`;
+  }
+
+  return (
+    <div class="genre-pie-container">
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {slices.map((s, i) => (
+          <path
+            key={i}
+            d={arcPath(s.startAngle, s.endAngle)}
+            fill={s.color}
+            stroke="var(--md-sys-color-surface, #1a1a2e)"
+            stroke-width="1"
+          />
+        ))}
+      </svg>
+      <div class="genre-pie-legend">
+        {slices.map((s, i) => (
+          <div key={i} class="genre-pie-legend-item">
+            <span class="genre-pie-dot" style={{ background: s.color }} />
+            <span class="genre-pie-label">{s.name}</span>
+            <span class="genre-pie-count">{s.count}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PseudPortfolio.tsx
+++ b/src/components/PseudPortfolio.tsx
@@ -1,0 +1,222 @@
+import { h } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+import ActivityHeatmap from './ActivityHeatmap';
+import Sparkline from './Sparkline';
+import GenrePie from './GenrePie';
+
+interface PortfolioData {
+  pseud: {
+    id: number;
+    name: string;
+    description: string | null;
+    icon_key: string | null;
+    banner_key: string | null;
+    created_at: string;
+  };
+  pinnedWorks: any[];
+  works: any[];
+  kudos: Record<number, number>;
+  stats: {
+    totalWorks: number;
+    totalWords: number;
+    completedWorks: number;
+    totalKudos: number;
+    avgUpdateCadence: number;
+    genreDistribution: { name: string; count: number }[];
+    wordCountTimeline: { month: string; words: number }[];
+  };
+  activity: Record<string, number>;
+}
+
+export default function PseudPortfolio({ pseudId }: { pseudId: number }) {
+  const [data, setData] = useState<PortfolioData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch(`/api/pseuds/${pseudId}/public`)
+      .then(r => r.json())
+      .then(d => { setData(d); setLoading(false); })
+      .catch(e => { setError('Failed to load portfolio'); setLoading(false); });
+  }, [pseudId]);
+
+  if (loading) {
+    return (
+      <div class="portfolio-loading">
+        <div class="portfolio-skeleton" />
+        <div class="portfolio-skeleton" style={{ height: '200px' }} />
+        <div class="portfolio-skeleton" style={{ height: '120px' }} />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return <div class="portfolio-error">{error || 'Pseud not found'}</div>;
+  }
+
+  const { pseud, pinnedWorks, works, kudos, stats, activity } = data;
+  const iconUrl = pseud.icon_key ? `/api/storage/${encodeURIComponent(pseud.icon_key)}` : null;
+  const bannerUrl = pseud.banner_key ? `/api/storage/${encodeURIComponent(pseud.banner_key)}` : null;
+
+  // Determine current and previous year for heat map
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <div class="portfolio">
+      {/* Banner */}
+      <div class="portfolio-banner" style={bannerUrl ? { backgroundImage: `url(${bannerUrl})` } : {}}>
+        <div class="portfolio-banner-overlay" />
+      </div>
+
+      {/* Profile Header */}
+      <div class="portfolio-header">
+        <div class="portfolio-avatar">
+          {iconUrl ? (
+            <img src={iconUrl} alt={pseud.name} class="portfolio-avatar-img" />
+          ) : (
+            <div class="portfolio-avatar-placeholder">
+              {pseud.name.charAt(0).toUpperCase()}
+            </div>
+          )}
+        </div>
+        <div class="portfolio-header-info">
+          <h1 class="portfolio-name">{pseud.name}</h1>
+          {pseud.description && (
+            <p class="portfolio-description">{pseud.description}</p>
+          )}
+          <div class="portfolio-meta">
+            <span>Member since {new Date(pseud.created_at).getFullYear()}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats Bar */}
+      <div class="portfolio-stats-bar">
+        <div class="stat-item">
+          <span class="stat-value">{stats.totalWorks}</span>
+          <span class="stat-label">Works</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">{stats.totalWords.toLocaleString()}</span>
+          <span class="stat-label">Words</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">{stats.completedWorks}</span>
+          <span class="stat-label">Complete</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">{stats.totalKudos.toLocaleString()}</span>
+          <span class="stat-label">Kudos</span>
+        </div>
+        {stats.avgUpdateCadence > 0 && (
+          <div class="stat-item">
+            <span class="stat-value">{stats.avgUpdateCadence}d</span>
+            <span class="stat-label">Avg Cadence</span>
+          </div>
+        )}
+      </div>
+
+      {/* Pinned Works */}
+      {pinnedWorks.length > 0 && (
+        <section class="portfolio-section">
+          <h2 class="portfolio-section-title">Featured Works</h2>
+          <div class="pinned-works-grid">
+            {pinnedWorks.map(work => (
+              <a href={`/works/${work.id}`} class="pinned-work-card" key={work.id}>
+                <div class="pinned-work-title">{work.title}</div>
+                {work.summary && (
+                  <div class="pinned-work-summary">{work.summary.length > 140 ? work.summary.substring(0, 140) + '…' : work.summary}</div>
+                )}
+                <div class="pinned-work-meta">
+                  <span>{work.word_count.toLocaleString()} words</span>
+                  {work.complete ? <span class="badge-complete">Complete</span> : <span class="badge-wip">WIP</span>}
+                  {kudos[work.id] > 0 && <span>♥ {kudos[work.id]}</span>}
+                </div>
+                {work.tags && work.tags.length > 0 && (
+                  <div class="pinned-work-tags">
+                    {work.tags.filter((t: any) => t.type === 'fandom').slice(0, 2).map((t: any) => (
+                      <span class="tag-chip tag-fandom" key={t.id}>{t.name}</span>
+                    ))}
+                  </div>
+                )}
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Stats Visualizations */}
+      <section class="portfolio-section">
+        <h2 class="portfolio-section-title">Statistics</h2>
+        <div class="stats-grid">
+          {/* Word Count Sparkline */}
+          <div class="stat-card">
+            <div class="stat-card-header">
+              <span class="stat-card-title">Words Over Time</span>
+            </div>
+            <div class="stat-card-body">
+              {stats.wordCountTimeline.length > 0 ? (
+                <Sparkline data={stats.wordCountTimeline} width={240} height={50} />
+              ) : (
+                <div class="stat-empty">No data yet</div>
+              )}
+            </div>
+          </div>
+
+          {/* Genre Distribution */}
+          <div class="stat-card">
+            <div class="stat-card-header">
+              <span class="stat-card-title">Tag Distribution</span>
+            </div>
+            <div class="stat-card-body">
+              {stats.genreDistribution.length > 0 ? (
+                <GenrePie data={stats.genreDistribution} size={90} />
+              ) : (
+                <div class="stat-empty">No tags yet</div>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Activity Heat Map */}
+      <section class="portfolio-section">
+        <ActivityHeatmap activity={activity} year={currentYear} />
+      </section>
+
+      {/* All Works */}
+      <section class="portfolio-section">
+        <h2 class="portfolio-section-title">All Works ({works.length})</h2>
+        {works.length === 0 ? (
+          <div class="portfolio-empty">No published works yet.</div>
+        ) : (
+          <div class="works-list">
+            {works.map(work => (
+              <a href={`/works/${work.id}`} class="work-list-item" key={work.id}>
+                <div class="work-list-item-main">
+                  <div class="work-list-item-title">{work.title}</div>
+                  {work.summary && (
+                    <div class="work-list-item-summary">{work.summary.length > 200 ? work.summary.substring(0, 200) + '…' : work.summary}</div>
+                  )}
+                  <div class="work-list-item-tags">
+                    {(work.tags || []).filter((t: any) => t.type === 'fandom').slice(0, 3).map((t: any) => (
+                      <span class="tag-chip tag-fandom" key={t.id}>{t.name}</span>
+                    ))}
+                    {(work.tags || []).filter((t: any) => t.type === 'rating').slice(0, 1).map((t: any) => (
+                      <span class="tag-chip tag-rating" key={t.id}>{t.name}</span>
+                    ))}
+                  </div>
+                </div>
+                <div class="work-list-item-stats">
+                  <span>{work.word_count.toLocaleString()} words</span>
+                  {work.complete ? <span class="badge-complete">✓</span> : <span class="badge-wip">…</span>}
+                  {kudos[work.id] > 0 && <span>♥ {kudos[work.id]}</span>}
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,0 +1,44 @@
+import { h } from 'preact';
+
+interface SparklineProps {
+  data: { month: string; words: number }[];
+  width?: number;
+  height?: number;
+}
+
+export default function Sparkline({ data, width = 200, height = 40 }: SparklineProps) {
+  if (!data.length) return null;
+
+  const maxVal = Math.max(...data.map(d => d.words), 1);
+  const padding = 2;
+  const chartW = width - padding * 2;
+  const chartH = height - padding * 2;
+  const step = data.length > 1 ? chartW / (data.length - 1) : chartW;
+
+  const points = data.map((d, i) => ({
+    x: padding + i * step,
+    y: padding + chartH - (d.words / maxVal) * chartH,
+  }));
+
+  const pathD = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`)
+    .join(' ');
+
+  // Fill area under the line
+  const areaD = `${pathD} L ${points[points.length - 1].x} ${height} L ${points[0].x} ${height} Z`;
+
+  return (
+    <div class="sparkline-container">
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        <defs>
+          <linearGradient id="sparkline-grad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="var(--md-sys-color-primary, #7B8FA8)" stop-opacity="0.3" />
+            <stop offset="100%" stop-color="var(--md-sys-color-primary, #7B8FA8)" stop-opacity="0.05" />
+          </linearGradient>
+        </defs>
+        <path d={areaD} fill="url(#sparkline-grad)" />
+        <path d={pathD} fill="none" stroke="var(--md-sys-color-primary, #7B8FA8)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </div>
+  );
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -93,6 +93,7 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
       <a href="/" class="app-bar__title">fanfiction.fyi</a>
       <nav class="app-bar__nav">
         <a href="/works">Works</a>
+        <a href="/pseuds">Authors</a>
         <a href="/characters">Characters</a>
         <a href="/tags">Tags</a>
         <a href="/series">Series</a>
@@ -134,6 +135,7 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
 
 <style is:global>
   @import '../styles/theme.css';
+  @import '../styles/portfolio.css';
 
   .app-bar {
     display: flex;

--- a/src/pages/api/pseuds/[id].ts
+++ b/src/pages/api/pseuds/[id].ts
@@ -37,10 +37,36 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
-  const { name, description, icon_key } = body || {};
+  const { name, description, icon_key, pinned_work_ids, banner_key } = body || {};
   const newName = (typeof name === 'string' ? name.trim() : existing.name);
   const newDesc = (description !== undefined ? (typeof description === 'string' ? description : null) : existing.description);
   const newIconKey = (icon_key !== undefined ? (typeof icon_key === 'string' ? icon_key : null) : existing.icon_key);
+
+  // Pinned work IDs validation: must be array of max 6 integers
+  let newPinnedWorkIds = existing.pinned_work_ids || '[]';
+  if (pinned_work_ids !== undefined) {
+    if (!Array.isArray(pinned_work_ids)) {
+      return new Response(JSON.stringify({ error: 'pinned_work_ids must be an array' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (pinned_work_ids.length > 6) {
+      return new Response(JSON.stringify({ error: 'Maximum 6 pinned works' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    // Validate all are integers
+    const validIds = pinned_work_ids.filter((id: any) => Number.isInteger(id) && id > 0);
+    // Validate the pseud owns these works
+    if (validIds.length > 0) {
+      const placeholders = validIds.map(() => '?').join(',');
+      const ownedWorks = await queryAll<any>(db, `SELECT work_id FROM creatorships WHERE pseud_id = ?1 AND work_id IN (${placeholders})`, pseudId, ...validIds);
+      const ownedSet = new Set(ownedWorks.map((w: any) => w.work_id));
+      const filtered = validIds.filter((id: number) => ownedSet.has(id));
+      newPinnedWorkIds = JSON.stringify(filtered);
+    } else {
+      newPinnedWorkIds = '[]';
+    }
+  }
+
+  // Banner key validation
+  const newBannerKey = (banner_key !== undefined ? (typeof banner_key === 'string' ? banner_key : null) : existing.banner_key);
 
   // Name validation
   if (!newName || newName.length === 0) {
@@ -58,7 +84,7 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     }
   }
 
-  await run(db, `UPDATE pseuds SET name = ?1, description = ?2, icon_key = ?3 WHERE id = ?4 AND user_id = ?5`, newName, newDesc, newIconKey, pseudId, auth.user.id);
+  await run(db, `UPDATE pseuds SET name = ?1, description = ?2, icon_key = ?3, pinned_work_ids = ?4, banner_key = ?5 WHERE id = ?6 AND user_id = ?7`, newName, newDesc, newIconKey, newPinnedWorkIds, newBannerKey, pseudId, auth.user.id);
 
   const updated = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1`, pseudId);
   return new Response(JSON.stringify(updated), { headers: { 'Content-Type': 'application/json' } });
@@ -101,13 +127,14 @@ export const DELETE: APIRoute = async ({ request, locals, params }) => {
   await run(db, `DELETE FROM bookmarks WHERE pseud_id = ?1`, pseudId);
   await run(db, `DELETE FROM readings WHERE pseud_id = ?1`, pseudId);
 
-  // Clean up R2 icon if present
-  if (existing.icon_key) {
-    try {
-      const bucket = locals.runtime.env.MEDIA as R2Bucket | undefined;
-      if (bucket) await bucket.delete(existing.icon_key);
-    } catch { /* non-critical */ }
-  }
+  // Clean up R2 icon + banner if present
+  try {
+    const bucket = locals.runtime.env.MEDIA as R2Bucket | undefined;
+    if (bucket) {
+      if (existing.icon_key) await bucket.delete(existing.icon_key);
+      if (existing.banner_key) await bucket.delete(existing.banner_key);
+    }
+  } catch { /* non-critical */ }
 
   // Delete the pseud itself
   await run(db, `DELETE FROM pseuds WHERE id = ?1 AND user_id = ?2`, pseudId, auth.user.id);

--- a/src/pages/api/pseuds/[id]/public.ts
+++ b/src/pages/api/pseuds/[id]/public.ts
@@ -1,0 +1,207 @@
+export const prerender = false;
+
+import { queryAll, queryFirst } from '@/lib/db';
+import type { APIRoute } from 'astro';
+
+/**
+ * GET /api/pseuds/[id]/public — public pseud portfolio data
+ * Returns pseud info, pinned works, all works (with tags), stats, and activity dates.
+ * No auth required — this is a public endpoint.
+ */
+export const GET: APIRoute = async ({ locals, params }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const pseudId = parseInt(params.id ?? '', 10);
+  if (isNaN(pseudId)) {
+    return new Response(JSON.stringify({ error: 'Invalid pseud ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Get pseud details
+  const pseud = await queryFirst<any>(db, `SELECT id, name, description, icon_key, banner_key, pinned_work_ids, created_at FROM pseuds WHERE id = ?1`, pseudId);
+  if (!pseud) {
+    return new Response(JSON.stringify({ error: 'Pseud not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Parse pinned_work_ids JSON
+  let pinnedIds: number[] = [];
+  try {
+    pinnedIds = JSON.parse(pseud.pinned_work_ids || '[]');
+    if (!Array.isArray(pinnedIds)) pinnedIds = [];
+  } catch { pinnedIds = []; }
+
+  // Get all published works by this pseud
+  const works = await queryAll<any>(db, `
+    SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at, w.language,
+      c.role as creatorship_role
+    FROM works w
+    JOIN creatorships c ON c.work_id = w.id
+    WHERE c.pseud_id = ?1 AND w.published_at IS NOT NULL
+    ORDER BY w.updated_at DESC
+  `, pseudId);
+
+  const workIds = works.map((w: any) => w.id);
+
+  // Get tags for all works
+  const workTags: Record<number, any[]> = {};
+  if (workIds.length > 0) {
+    const placeholders = workIds.map(() => '?').join(',');
+    const tags = await queryAll<any>(db, `
+      SELECT tg.work_id, t.id, t.name, t.type
+      FROM tags t
+      JOIN taggings tg ON t.id = tg.tag_id
+      WHERE tg.work_id IN (${placeholders})
+    `, ...workIds);
+    for (const tag of tags) {
+      if (!workTags[tag.work_id]) workTags[tag.work_id] = [];
+      workTags[tag.work_id].push({ id: tag.id, name: tag.name, type: tag.type });
+    }
+  }
+
+  // Get pinned works (separate query to maintain pin order)
+  let pinnedWorks: any[] = [];
+  if (pinnedIds.length > 0) {
+    // Filter pinnedIds to only include published works by this pseud
+    const validPinnedIds = pinnedIds.filter((id: number) => workIds.includes(id));
+    if (validPinnedIds.length > 0) {
+      const placeholders = validPinnedIds.map(() => '?').join(',');
+      pinnedWorks = await queryAll<any>(db, `
+        SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at, w.language
+        FROM works w
+        WHERE w.id IN (${placeholders}) AND w.published_at IS NOT NULL
+        ORDER BY CASE w.id ${validPinnedIds.map((id: number, i: number) => `WHEN ? THEN ${i}`).join(' ')} END
+      `, ...validPinnedIds, ...validPinnedIds);
+    }
+    // Get tags for pinned works
+    if (pinnedWorks.length > 0) {
+      const pinnedWorkIds = pinnedWorks.map(w => w.id);
+      const placeholders = pinnedWorkIds.map(() => '?').join(',');
+      const pinnedTags = await queryAll<any>(db, `
+        SELECT tg.work_id, t.id, t.name, t.type
+        FROM tags t
+        JOIN taggings tg ON t.id = tg.tag_id
+        WHERE tg.work_id IN (${placeholders})
+      `, ...pinnedWorkIds);
+      const pinnedWorkTags: Record<number, any[]> = {};
+      for (const tag of pinnedTags) {
+        if (!pinnedWorkTags[tag.work_id]) pinnedWorkTags[tag.work_id] = [];
+        pinnedWorkTags[tag.work_id].push({ id: tag.id, name: tag.name, type: tag.type });
+      }
+      pinnedWorks = pinnedWorks.map(w => ({ ...w, tags: pinnedWorkTags[w.id] || [] }));
+    }
+  }
+
+  // Attach tags to all works
+  const worksWithTags = works.map((w: any) => ({
+    ...w,
+    tags: workTags[w.id] || [],
+  }));
+
+  // Get kudos count per work (for portfolio display)
+  const kudosMap: Record<number, number> = {};
+  if (workIds.length > 0) {
+    const placeholders = workIds.map(() => '?').join(',');
+    const kudosRows = await queryAll<any>(db, `
+      SELECT work_id, COUNT(*) as cnt FROM kudos WHERE work_id IN (${placeholders}) GROUP BY work_id
+    `, ...workIds);
+    for (const row of kudosRows) kudosMap[row.work_id] = row.cnt;
+  }
+
+  // Stats computation
+  const totalWords = works.reduce((sum: number, w: any) => sum + (w.word_count || 0), 0);
+  const totalWorks = works.length;
+  const completedWorks = works.filter((w: any) => w.complete === 1).length;
+
+  // Genre distribution (tag type = fandom + freeform)
+  const genreCounts: Record<string, number> = {};
+  for (const w of worksWithTags) {
+    const fandoms = (w.tags || []).filter((t: any) => t.type === 'fandom');
+    const freeforms = (w.tags || []).filter((t: any) => t.type === 'freeform');
+    for (const tag of [...fandoms, ...freeforms]) {
+      genreCounts[tag.name] = (genreCounts[tag.name] || 0) + 1;
+    }
+  }
+  // Top 8 genres for the pie chart
+  const genreDistribution = Object.entries(genreCounts)
+    .sort(([, a]: any, [, b]: any) => b - a)
+    .slice(0, 8)
+    .map(([name, count]) => ({ name, count }));
+
+  // Word count over time (sparkline data) — by month
+  const wordsByMonth: Record<string, number> = {};
+  if (workIds.length > 0) {
+    const placeholders = workIds.map(() => '?').join(',');
+    const chapterData = await queryAll<any>(db, `
+      SELECT c.word_count, c.updated_at
+      FROM chapters c
+      WHERE c.work_id IN (${placeholders}) AND c.draft = 0
+    `, ...workIds);
+    for (const ch of chapterData) {
+      if (!ch.updated_at) continue;
+      const month = ch.updated_at.substring(0, 7); // YYYY-MM
+      wordsByMonth[month] = (wordsByMonth[month] || 0) + (ch.word_count || 0);
+    }
+  }
+  const wordCountTimeline = Object.entries(wordsByMonth)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, words]) => ({ month, words }));
+
+  // Activity dates for heat map (publication dates of chapters)
+  const activityDates: Record<string, number> = {};
+  if (workIds.length > 0) {
+    const placeholders = workIds.map(() => '?').join(',');
+    // Use published_at from works + updated_at from published chapters
+    const pubDates = await queryAll<any>(db, `
+      SELECT published_at FROM works WHERE id IN (${placeholders}) AND published_at IS NOT NULL
+    `, ...workIds);
+    for (const row of pubDates) {
+      if (row.published_at) {
+        const day = row.published_at.substring(0, 10); // YYYY-MM-DD
+        activityDates[day] = (activityDates[day] || 0) + 1;
+      }
+    }
+  }
+
+  // Update cadence (average days between published works)
+  let avgUpdateCadence = 0;
+  if (works.length >= 2) {
+    const pubDates = works
+      .map((w: any) => w.published_at)
+      .filter(Boolean)
+      .sort();
+    if (pubDates.length >= 2) {
+      let totalDays = 0;
+      for (let i = 1; i < pubDates.length; i++) {
+        const d1 = new Date(pubDates[i - 1]);
+        const d2 = new Date(pubDates[i]);
+        totalDays += (d2.getTime() - d1.getTime()) / (1000 * 60 * 60 * 24);
+      }
+      avgUpdateCadence = Math.round(totalDays / (pubDates.length - 1));
+    }
+  }
+
+  // Total kudos received
+  const totalKudos = Object.values(kudosMap).reduce((sum: number, n: any) => sum + n, 0);
+
+  return new Response(JSON.stringify({
+    pseud: {
+      id: pseud.id,
+      name: pseud.name,
+      description: pseud.description,
+      icon_key: pseud.icon_key,
+      banner_key: pseud.banner_key,
+      created_at: pseud.created_at,
+    },
+    pinnedWorks,
+    works: worksWithTags,
+    kudos: kudosMap,
+    stats: {
+      totalWorks,
+      totalWords,
+      completedWorks,
+      totalKudos,
+      avgUpdateCadence,
+      genreDistribution,
+      wordCountTimeline,
+    },
+    activity: activityDates,
+  }), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/upload/index.ts
+++ b/src/pages/api/upload/index.ts
@@ -57,8 +57,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
   }
 
   const type = fields.get('type');
-  if (!type || (type !== 'avatar' && type !== 'pseud' && type !== 'chapter')) {
-    return new Response(JSON.stringify({ error: 'Invalid type. Must be "avatar", "pseud", or "chapter".' }), {
+  if (!type || (type !== 'avatar' && type !== 'pseud' && type !== 'chapter' && type !== 'banner')) {
+    return new Response(JSON.stringify({ error: 'Invalid type. Must be "avatar", "pseud", "chapter", or "banner".' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -194,6 +194,53 @@ export const POST: APIRoute = async ({ locals, request }) => {
       });
     }
 
+    if (type === 'banner') {
+      const pseudIdStr = fields.get('id');
+      if (!pseudIdStr) {
+        return new Response(JSON.stringify({ error: 'Pseud ID required for banner uploads.' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const pseudId = parseInt(pseudIdStr, 10);
+      if (isNaN(pseudId)) {
+        return new Response(JSON.stringify({ error: 'Invalid pseud ID.' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Verify pseud ownership
+      const pseud = await queryFirst<any>(db, 'SELECT banner_key FROM pseuds WHERE id = ? AND user_id = ?', pseudId, auth.user.id);
+      if (!pseud) {
+        return new Response(JSON.stringify({ error: 'Pseud not found or not yours.' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Upload banner — stored under pseuds/ prefix (same bucket, different convention)
+      // Banners are wider images, 5MB limit is fine
+      const result = await uploadImage(bucket, 'pseuds', pseudId, {
+        arrayBuffer: async () => file.data,
+        type: file.type,
+        size: file.size,
+      });
+
+      // Clean up old banner
+      if (pseud.banner_key) {
+        await deleteImage(bucket, pseud.banner_key).catch(() => {});
+      }
+
+      // Update DB
+      await run(db, 'UPDATE pseuds SET banner_key = ? WHERE id = ? AND user_id = ?', result.key, pseudId, auth.user.id);
+
+      return new Response(JSON.stringify({ key: result.key, url: `/api/storage/${result.key}` }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     return new Response(JSON.stringify({ error: 'Invalid upload type' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
@@ -253,7 +300,7 @@ export const DELETE: APIRoute = async ({ locals, request }) => {
         headers: { 'Content-Type': 'application/json' },
       });
     }
-    const pseud = await queryFirst<any>(db, 'SELECT icon_key FROM pseuds WHERE id = ? AND user_id = ?', pseudId, auth.user.id);
+    const pseud = await queryFirst<any>(db, 'SELECT icon_key, banner_key FROM pseuds WHERE id = ? AND user_id = ?', pseudId, auth.user.id);
     if (!pseud) {
       return new Response(JSON.stringify({ error: 'Pseud not found' }), {
         status: 404,
@@ -263,6 +310,29 @@ export const DELETE: APIRoute = async ({ locals, request }) => {
     if (pseud.icon_key) {
       await deleteImage(bucket, pseud.icon_key);
       await run(db, 'UPDATE pseuds SET icon_key = NULL WHERE id = ? AND user_id = ?', pseudId, auth.user.id);
+    }
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (type === 'banner') {
+    if (!pseudId) {
+      return new Response(JSON.stringify({ error: 'Pseud ID required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const pseud = await queryFirst<any>(db, 'SELECT banner_key FROM pseuds WHERE id = ? AND user_id = ?', pseudId, auth.user.id);
+    if (!pseud) {
+      return new Response(JSON.stringify({ error: 'Pseud not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (pseud.banner_key) {
+      await deleteImage(bucket, pseud.banner_key);
+      await run(db, 'UPDATE pseuds SET banner_key = NULL WHERE id = ? AND user_id = ?', pseudId, auth.user.id);
     }
     return new Response(JSON.stringify({ success: true }), {
       headers: { 'Content-Type': 'application/json' },
@@ -332,7 +402,7 @@ export const DELETE: APIRoute = async ({ locals, request }) => {
     });
   }
 
-  return new Response(JSON.stringify({ error: 'Invalid type. Must be "avatar", "pseud", or "chapter".' }), {
+  return new Response(JSON.stringify({ error: 'Invalid type. Must be "avatar", "pseud", "banner", or "chapter".' }), {
     status: 400,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/src/pages/pseuds/[id].astro
+++ b/src/pages/pseuds/[id].astro
@@ -1,0 +1,29 @@
+---
+export const prerender = false;
+import Base from '../../layouts/Base.astro';
+import { queryFirst } from '../../lib/db';
+import PseudPortfolio from '../../components/PseudPortfolio';
+
+const pseudId = Number(Astro.params.id);
+if (!pseudId) return Astro.redirect('/');
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+
+// Verify pseud exists
+const pseud = await queryFirst<any>(db, `SELECT id, name FROM pseuds WHERE id = ?1`, pseudId);
+if (!pseud) return Astro.redirect('/');
+---
+
+<Base title={`${pseud.name} — Author Page`}>
+  <div class="pseud-page">
+    <PseudPortfolio client:load pseudId={pseudId} />
+  </div>
+</Base>
+
+<style>
+  .pseud-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 var(--md-sys-typescale-body-large-tracking, 1rem) 3rem;
+  }
+</style>

--- a/src/pages/pseuds/index.astro
+++ b/src/pages/pseuds/index.astro
@@ -1,0 +1,129 @@
+---
+export const prerender = false;
+import Base from '../../layouts/Base.astro';
+import { queryAll } from '../../lib/db';
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+
+// Get all pseuds that have published works
+const pseuds = await queryAll<any>(db, `
+  SELECT p.id, p.name, p.description, p.icon_key, COUNT(c.id) as work_count
+  FROM pseuds p
+  JOIN creatorships c ON c.pseud_id = p.id
+  JOIN works w ON c.work_id = w.id AND w.published_at IS NOT NULL
+  GROUP BY p.id
+  HAVING work_count > 0
+  ORDER BY work_count DESC, p.name ASC
+`);
+---
+
+<Base title="Authors — fanfiction.fyi">
+  <div class="pseuds-page">
+    <h1 class="page-title">Authors</h1>
+    {pseuds.length === 0 ? (
+      <p class="empty-state">No authors with published works yet.</p>
+    ) : (
+      <div class="pseuds-grid">
+        {pseuds.map(p => {
+          const iconUrl = p.icon_key ? `/api/storage/${encodeURIComponent(p.icon_key)}` : null;
+          return (
+            <a href={`/pseuds/${p.id}`} class="pseud-card" key={p.id}>
+              <div class="pseud-card-avatar">
+                {iconUrl ? (
+                  <img src={iconUrl} alt={p.name} />
+                ) : (
+                  <div class="pseud-card-initial">{p.name.charAt(0).toUpperCase()}</div>
+                )}
+              </div>
+              <div class="pseud-card-info">
+                <div class="pseud-card-name">{p.name}</div>
+                {p.description && <div class="pseud-card-desc">{p.description.length > 80 ? p.description.substring(0, 80) + '…' : p.description}</div>}
+                <div class="pseud-card-works">{p.work_count} work{p.work_count !== 1 ? 's' : ''}</div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    )}
+  </div>
+</Base>
+
+<style>
+  .pseuds-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1rem var(--md-sys-typescale-body-large-tracking, 1rem) 3rem;
+  }
+  .page-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0 0 1.5rem;
+    color: var(--md-sys-color-on-surface);
+    font-family: 'Inter', sans-serif;
+  }
+  .empty-state {
+    text-align: center;
+    padding: 3rem;
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .pseuds-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1rem;
+  }
+  .pseud-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    background: var(--md-sys-color-surface-container);
+    border-radius: 12px;
+    text-decoration: none;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    transition: background 0.15s;
+  }
+  .pseud-card:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+  .pseud-card-avatar {
+    flex-shrink: 0;
+  }
+  .pseud-card-avatar img {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+  .pseud-card-initial {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    font-weight: 600;
+    font-family: 'Inter', sans-serif;
+  }
+  .pseud-card-info {
+    min-width: 0;
+  }
+  .pseud-card-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface);
+    font-family: 'Inter', sans-serif;
+  }
+  .pseud-card-desc {
+    font-size: 0.8rem;
+    color: var(--md-sys-color-on-surface-variant);
+    margin-top: 0.15rem;
+  }
+  .pseud-card-works {
+    font-size: 0.75rem;
+    color: var(--md-sys-color-on-surface-variant);
+    margin-top: 0.2rem;
+  }
+</style>

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -283,6 +283,27 @@ const themesJSON = JSON.stringify(
       <label for="edit-pseud-desc" class="form-label">Description <span class="form-hint" style="display:inline">(optional)</span></label>
       <input type="text" id="edit-pseud-desc" class="form-input" maxlength="200" />
     </div>
+    <div class="form-group">
+      <label class="form-label">Banner Image</label>
+      <div class="pseud-banner-upload">
+        <div class="pseud-banner-preview" id="edit-pseud-banner-preview">
+          <img id="edit-pseud-banner-img" src="" alt="Pseud banner" />
+        </div>
+        <div class="pseud-icon-actions">
+          <label for="edit-pseud-banner-file" class="btn-outlined pseud-icon-btn">Upload Banner</label>
+          <input type="file" id="edit-pseud-banner-file" accept="image/gif,image/png,image/jpeg,image/webp" style="display:none" />
+          <button type="button" class="btn-text btn-text--danger" id="edit-pseud-banner-remove" style="display:none">Remove Banner</button>
+        </div>
+        <p class="form-hint">Wide image displayed at the top of your author page. Max 5 MB.</p>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="form-label">Pinned Works <span class="form-hint" style="display:inline">(up to 6)</span></label>
+      <div id="edit-pseud-pins-list" class="pinned-works-edit-list">
+        <!-- populated by JS -->
+      </div>
+      <p class="form-hint">Choose works to feature on your author portfolio page.</p>
+    </div>
     <div class="form-actions">
       <button type="button" class="btn-filled" id="save-pseud-btn">Save</button>
       <button type="button" class="btn-outlined" id="cancel-pseud-btn">Cancel</button>
@@ -799,6 +820,8 @@ const themesJSON = JSON.stringify(
   var editPseudFeedback = document.getElementById('edit-pseud-feedback');
 
   var editingPseudIconKey = null; // tracks current R2 key for pseud icon being edited
+  var editingPseudBannerKey = null; // tracks current R2 key for pseud banner
+  var editingPseudPinnedIds = []; // tracks pinned work IDs
 
   function openEditModal(pseud) {
     document.getElementById('edit-pseud-id').value = pseud.id;
@@ -820,6 +843,26 @@ const themesJSON = JSON.stringify(
       iconFallback.style.display = '';
       iconRemoveBtn.style.display = 'none';
     }
+
+    // Update banner preview
+    editingPseudBannerKey = pseud.banner_key || null;
+    var bannerImg = document.getElementById('edit-pseud-banner-img');
+    var bannerRemoveBtn = document.getElementById('edit-pseud-banner-remove');
+    if (pseud.banner_key) {
+      bannerImg.src = '/api/storage/' + encodeURIComponent(pseud.banner_key);
+      bannerImg.style.display = 'block';
+      bannerRemoveBtn.style.display = '';
+    } else {
+      bannerImg.style.display = 'none';
+      bannerRemoveBtn.style.display = 'none';
+    }
+
+    // Load pinned works
+    try {
+      editingPseudPinnedIds = JSON.parse(pseud.pinned_work_ids || '[]');
+      if (!Array.isArray(editingPseudPinnedIds)) editingPseudPinnedIds = [];
+    } catch { editingPseudPinnedIds = []; }
+    loadPinnedWorks(pseud.id);
 
     editPseudFeedback.textContent = '';
     editPseudFeedback.className = 'inline-feedback';
@@ -906,6 +949,132 @@ const themesJSON = JSON.stringify(
     .catch(function() { showToast('Network error.', 'error'); });
   });
 
+  // ─── Pseud banner upload ──────────────────────────────────────
+  var pseudBannerFileInput = document.getElementById('edit-pseud-banner-file');
+
+  pseudBannerFileInput.addEventListener('change', function() {
+    var file = pseudBannerFileInput.files[0];
+    if (!file) return;
+
+    var allowedTypes = ['image/gif', 'image/png', 'image/jpeg', 'image/webp'];
+    if (allowedTypes.indexOf(file.type) === -1) {
+      showToast('Invalid file type. Use GIF, PNG, JPG, or WebP.', 'error');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      showToast('File too large. Maximum 5 MB.', 'error');
+      return;
+    }
+
+    var pseudId = document.getElementById('edit-pseud-id').value;
+    if (!pseudId) return;
+
+    var formData = new FormData();
+    formData.append('file', file);
+    formData.append('type', 'banner');
+    formData.append('id', pseudId);
+
+    fetch('/api/upload', { method: 'POST', body: formData })
+      .then(function(res) { return res.json().then(function(d) { return { ok: res.ok, data: d }; }); })
+      .then(function(result) {
+        if (result.ok) {
+          editingPseudBannerKey = result.data.key;
+          var bannerImg = document.getElementById('edit-pseud-banner-img');
+          var bannerRemoveBtn = document.getElementById('edit-pseud-banner-remove');
+          bannerImg.src = result.data.url;
+          bannerImg.style.display = 'block';
+          bannerRemoveBtn.style.display = '';
+          showToast('Banner uploaded!');
+        } else {
+          showToast(result.data.error || 'Upload failed.', 'error');
+        }
+      })
+      .catch(function() { showToast('Network error during upload.', 'error'); });
+  });
+
+  document.getElementById('edit-pseud-banner-remove').addEventListener('click', function() {
+    var pseudId = document.getElementById('edit-pseud-id').value;
+    if (!pseudId) return;
+
+    fetch('/api/upload', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'banner', id: parseInt(pseudId, 10) }),
+    })
+    .then(function(res) { return res.json().then(function(d) { return { ok: res.ok, data: d }; }); })
+    .then(function(result) {
+      if (result.ok) {
+        editingPseudBannerKey = null;
+        var bannerImg = document.getElementById('edit-pseud-banner-img');
+        var bannerRemoveBtn = document.getElementById('edit-pseud-banner-remove');
+        bannerImg.style.display = 'none';
+        bannerRemoveBtn.style.display = 'none';
+        pseudBannerFileInput.value = '';
+        showToast('Banner removed.');
+      } else {
+        showToast(result.data.error || 'Failed to remove banner.', 'error');
+      }
+    })
+    .catch(function() { showToast('Network error.', 'error'); });
+  });
+
+  // ─── Pinned works management ───────────────────────────────
+  var pseudWorksCache = []; // all works by this pseud
+
+  function loadPinnedWorks(pseudId) {
+    var pinsList = document.getElementById('edit-pseud-pins-list');
+    pinsList.innerHTML = '<span class="form-hint">Loading works…</span>';
+
+    // Fetch this pseud's public data to get their works
+    fetch('/api/pseuds/' + pseudId + '/public')
+      .then(function(res) { return res.json(); })
+      .then(function(data) {
+        pseudWorksCache = data.works || [];
+        renderPinnedWorksList();
+      })
+      .catch(function() {
+        pinsList.innerHTML = '<span class="form-hint">Could not load works.</span>';
+      });
+  }
+
+  function renderPinnedWorksList() {
+    var pinsList = document.getElementById('edit-pseud-pins-list');
+    if (pseudWorksCache.length === 0) {
+      pinsList.innerHTML = '<span class="form-hint">No published works to pin.</span>';
+      return;
+    }
+
+    var html = '';
+    pseudWorksCache.forEach(function(w) {
+      var isPinned = editingPseudPinnedIds.indexOf(w.id) !== -1;
+      html += '<label class="pin-work-item">';
+      html += '  <input type="checkbox" class="pin-work-checkbox" data-work-id="' + w.id + '"' + (isPinned ? ' checked' : '') + ' />';
+      html += '  <span class="pin-work-title">' + escapeHtml(w.title) + '</span>';
+      html += '  <span class="pin-work-meta">' + w.word_count.toLocaleString() + ' words</span>';
+      html += '</label>';
+    });
+    pinsList.innerHTML = html;
+
+    // Bind checkboxes
+    pinsList.querySelectorAll('.pin-work-checkbox').forEach(function(cb) {
+      cb.addEventListener('change', function() {
+        var workId = parseInt(cb.dataset.workId, 10);
+        if (cb.checked) {
+          if (editingPseudPinnedIds.length >= 6) {
+            cb.checked = false;
+            showToast('Maximum 6 pinned works.', 'error');
+            return;
+          }
+          if (editingPseudPinnedIds.indexOf(workId) === -1) {
+            editingPseudPinnedIds.push(workId);
+          }
+        } else {
+          editingPseudPinnedIds = editingPseudPinnedIds.filter(function(id) { return id !== workId; });
+        }
+      });
+    });
+  }
+
   // Close modal on overlay click
   editModal.addEventListener('click', function(e) {
     if (e.target === editModal) closeEditModal();
@@ -932,7 +1101,13 @@ const themesJSON = JSON.stringify(
     fetch('/api/pseuds/' + encodeURIComponent(pseudId), {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name, description: desc || null }),
+      body: JSON.stringify({
+        name: name,
+        description: desc || null,
+        icon_key: editingPseudIconKey,
+        banner_key: editingPseudBannerKey,
+        pinned_work_ids: editingPseudPinnedIds,
+      }),
     })
     .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
     .then(function(result) {
@@ -1267,6 +1442,72 @@ const themesJSON = JSON.stringify(
   .pseud-icon-btn {
     cursor: pointer;
     font-size: var(--md-sys-typescale-label-medium-size, 12px);
+  }
+
+  /* ─── Banner upload ───────────────────────────────── */
+  .pseud-banner-upload {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2, 8px);
+  }
+
+  .pseud-banner-preview {
+    width: 100%;
+    max-width: 400px;
+    height: 80px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--md-sys-color-surface-container-highest);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .pseud-banner-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  /* ─── Pinned works ────────────────────────────────── */
+  .pinned-works-edit-list {
+    max-height: 240px;
+    overflow-y: auto;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: 8px;
+    padding: 0.5rem;
+  }
+
+  .pin-work-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.35rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+
+  .pin-work-item:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+
+  .pin-work-checkbox {
+    flex-shrink: 0;
+  }
+
+  .pin-work-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .pin-work-meta {
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: 0.75rem;
+    flex-shrink: 0;
   }
 
   .pseud-icon {

--- a/src/styles/portfolio.css
+++ b/src/styles/portfolio.css
@@ -1,0 +1,477 @@
+/* ═══ Pseud Portfolio ═══ */
+
+/* Banner */
+.portfolio-banner {
+  width: calc(100% + 2rem);
+  margin-left: -1rem;
+  height: 200px;
+  background-color: var(--md-sys-color-surface-container);
+  background-size: cover;
+  background-position: center;
+  border-radius: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.portfolio-banner-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    var(--md-sys-color-surface, rgba(26,26,46,0.6)) 100%
+  );
+}
+
+/* Header */
+.portfolio-header {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-top: -48px;
+  padding: 0 0.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.portfolio-avatar {
+  flex-shrink: 0;
+}
+
+.portfolio-avatar-img {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 3px solid var(--md-sys-color-surface, #1a1a2e);
+  object-fit: cover;
+}
+
+.portfolio-avatar-placeholder {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 3px solid var(--md-sys-color-surface, #1a1a2e);
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 600;
+  font-family: 'Inter', sans-serif;
+}
+
+.portfolio-header-info {
+  flex: 1;
+  padding-bottom: 0.25rem;
+}
+
+.portfolio-name {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--md-sys-color-on-surface);
+  font-family: 'Inter', sans-serif;
+}
+
+.portfolio-description {
+  margin: 0.25rem 0 0;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.portfolio-meta {
+  margin-top: 0.25rem;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.8rem;
+}
+
+/* Stats Bar */
+.portfolio-stats-bar {
+  display: flex;
+  gap: 1px;
+  margin-top: 1.5rem;
+  background: var(--md-sys-color-outline-variant);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.stat-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.75rem 0.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.stat-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--md-sys-color-on-surface);
+  font-family: 'Inter', sans-serif;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: var(--md-sys-color-on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.15rem;
+}
+
+/* Sections */
+.portfolio-section {
+  margin-top: 2rem;
+}
+
+.portfolio-section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+  margin: 0 0 1rem;
+  font-family: 'Inter', sans-serif;
+}
+
+/* Pinned Works Grid */
+.pinned-works-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.pinned-work-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  background: var(--md-sys-color-surface-container);
+  border-radius: 12px;
+  text-decoration: none;
+  transition: background 0.15s, transform 0.15s;
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.pinned-work-card:hover {
+  background: var(--md-sys-color-surface-container-high);
+  transform: translateY(-1px);
+}
+
+.pinned-work-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+  font-family: 'Inter', sans-serif;
+  margin-bottom: 0.35rem;
+}
+
+.pinned-work-summary {
+  font-size: 0.8rem;
+  color: var(--md-sys-color-on-surface-variant);
+  line-height: 1.4;
+  flex: 1;
+  margin-bottom: 0.5rem;
+}
+
+.pinned-work-meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+  align-items: center;
+  margin-bottom: 0.35rem;
+}
+
+.pinned-work-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+/* Tags */
+.tag-chip {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 6px;
+  font-family: 'Inter', sans-serif;
+}
+
+.tag-fandom {
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.tag-rating {
+  background: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+}
+
+/* Complete / WIP Badges */
+.badge-complete {
+  color: var(--md-sys-color-primary);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.badge-wip {
+  color: var(--md-sys-color-tertiary);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+/* Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: var(--md-sys-color-surface-container);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.stat-card-header {
+  margin-bottom: 0.75rem;
+}
+
+.stat-card-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-card-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+}
+
+.stat-empty {
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+/* Heatmap */
+.heatmap-container {
+  background: var(--md-sys-color-surface-container);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  overflow-x: auto;
+}
+
+.heatmap-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.heatmap-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.heatmap-summary {
+  font-size: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.heatmap-chart {
+  margin-left: 0.5rem;
+}
+
+.heatmap-tooltip {
+  background: var(--md-sys-color-inverse-surface);
+  color: var(--md-sys-color-inverse-on-surface);
+  font-size: 0.75rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  z-index: 10;
+  font-family: 'Inter', sans-serif;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 0.5rem;
+  justify-content: flex-end;
+}
+
+.heatmap-legend-label {
+  font-size: 0.7rem;
+  color: var(--md-sys-color-on-surface-variant);
+  margin-right: 0.25rem;
+}
+
+/* Genre Pie */
+.genre-pie-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.genre-pie-legend {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.genre-pie-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+}
+
+.genre-pie-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.genre-pie-label {
+  color: var(--md-sys-color-on-surface);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.genre-pie-count {
+  color: var(--md-sys-color-on-surface-variant);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+/* Works List */
+.works-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.work-list-item {
+  display: flex;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--md-sys-color-surface-container);
+  border-radius: 12px;
+  text-decoration: none;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  transition: background 0.15s;
+}
+
+.work-list-item:hover {
+  background: var(--md-sys-color-surface-container-high);
+}
+
+.work-list-item-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.work-list-item-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+  font-family: 'Inter', sans-serif;
+}
+
+.work-list-item-summary {
+  font-size: 0.8rem;
+  color: var(--md-sys-color-on-surface-variant);
+  line-height: 1.4;
+  margin-top: 0.2rem;
+}
+
+.work-list-item-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.4rem;
+}
+
+.work-list-item-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: flex-end;
+  font-size: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* Loading / Empty States */
+.portfolio-loading {
+  padding: 2rem 0;
+}
+
+.portfolio-skeleton {
+  height: 60px;
+  background: var(--md-sys-color-surface-container);
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+.portfolio-error,
+.portfolio-empty {
+  text-align: center;
+  padding: 3rem;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.95rem;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .portfolio-banner {
+    height: 140px;
+  }
+  .portfolio-header {
+    margin-top: -36px;
+  }
+  .portfolio-avatar-img,
+  .portfolio-avatar-placeholder {
+    width: 64px;
+    height: 64px;
+    font-size: 1.5rem;
+  }
+  .portfolio-name {
+    font-size: 1.35rem;
+  }
+  .portfolio-stats-bar {
+    flex-wrap: wrap;
+  }
+  .stat-item {
+    min-width: 30%;
+  }
+  .pinned-works-grid {
+    grid-template-columns: 1fr;
+  }
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+  .genre-pie-container {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Pseud as Portfolio — Living Author Pages

Closes #18

### What's New

**Public Author Pages** (`/pseuds/[id]`)
- Portfolio layout with banner image, avatar, name, description
- Stats bar: total works, words, completed, kudos, avg update cadence
- Featured Works section (pinned works, max 6)
- Statistics section: word count sparkline, genre/tag distribution pie chart
- Activity heat map (GitHub-style contribution graph) for publication history
- Full works list with tags, word count, completion status

**Authors Browse Page** (`/pseuds`)
- Lists all pseuds that have published works
- Card layout with avatar, name, description, work count

**API Endpoints**
- `GET /api/pseuds/[id]/public` — public portfolio data (no auth required)
- `PUT /api/pseuds/[id]` — now accepts `pinned_work_ids` and `banner_key`
- `POST /api/upload` — `type=banner` for pseud banner images
- `DELETE /api/upload` — `type=banner` removal

**Schema**
- Migration 016: `pinned_work_ids TEXT DEFAULT '[]'` and `banner_key TEXT` on `pseuds` table
- Applied to remote D1 ✅

**Settings Integration**
- Banner upload/preview/remove in pseud edit modal
- Pinned works checkboxes (with max 6 validation) in pseud edit modal
- Save includes banner_key + pinned_work_ids

**Preact Components**
- `PseudPortfolio` — main portfolio island
- `ActivityHeatmap` — SVG heatmap grid with tooltips
- `Sparkline` — SVG area chart for word count over time
- `GenrePie` — SVG donut chart for tag distribution

**Nav**
- "Authors" link added to main navigation bar

### Acceptance Criteria
- [x] Pseud profile page has portfolio layout with sections
- [x] Author can pin/unpin works from settings
- [x] Stats visualizations render (sparkline, distribution chart)
- [x] Banner upload works via existing R2 storage pipeline
- [x] Activity heat map shows publication history