### PR TITLE
Canon Layer — Collaborative Worldbuilding Wiki

### DIFF
--- a/schema/017_canon_layer.sql
+++ b/schema/017_canon_layer.sql
@@ -1,0 +1,140 @@
+-- fanfiction.fyi — Canon Layer (Collaborative Worldbuilding Wiki)
+-- Issue #19: Characters, locations, and lore as first-class wiki entities
+
+-- ─── Lore Entries ──────────────────────────────────────
+-- Wiki-style entries for any narrative concept: magic systems,
+-- historical events, organizations, concepts, etc.
+-- Scoped to fandoms via the existing tags table (fandom type).
+
+CREATE TABLE IF NOT EXISTS lore_entries (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  title         TEXT NOT NULL,
+  slug          TEXT NOT NULL UNIQUE,
+  body_md       TEXT,
+  body_html     TEXT,
+  category      TEXT NOT NULL DEFAULT 'general' CHECK (category IN ('general', 'magic', 'history', 'organization', 'concept', 'item', 'event', 'culture', 'species')),
+  fandom_tag_id INTEGER REFERENCES tags(id) ON DELETE SET NULL,
+  created_by    INTEGER REFERENCES pseuds(id) ON DELETE SET NULL,
+  updated_by    INTEGER REFERENCES pseuds(id) ON DELETE SET NULL,
+  created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_lore_entries_fandom ON lore_entries (fandom_tag_id);
+CREATE INDEX idx_lore_entries_category ON lore_entries (category);
+CREATE INDEX idx_lore_entries_slug ON lore_entries (slug);
+CREATE INDEX idx_lore_entries_title ON lore_entries (title);
+
+-- ─── Locations ─────────────────────────────────────────
+-- Places within a fandom's world — cities, regions, buildings.
+-- Hierarchical via parent_location_id (e.g. Paris → France → Europe).
+
+CREATE TABLE IF NOT EXISTS locations (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  name                TEXT NOT NULL,
+  slug                TEXT NOT NULL UNIQUE,
+  description_md      TEXT,
+  description_html    TEXT,
+  fandom_tag_id       INTEGER REFERENCES tags(id) ON DELETE SET NULL,
+  parent_location_id  INTEGER REFERENCES locations(id) ON DELETE SET NULL,
+  created_by          INTEGER REFERENCES pseuds(id) ON DELETE SET NULL,
+  updated_by          INTEGER REFERENCES pseuds(id) ON DELETE SET NULL,
+  created_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_locations_fandom ON locations (fandom_tag_id);
+CREATE INDEX idx_locations_parent ON locations (parent_location_id);
+CREATE INDEX idx_locations_slug ON locations (slug);
+CREATE INDEX idx_locations_name ON locations (name);
+
+-- ─── Entity References ─────────────────────────────────
+-- Generic join table linking any entity (character, lore, location)
+-- to works that reference it. Enables "Works referencing X" pages.
+
+CREATE TABLE IF NOT EXISTS entity_references (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  work_id      INTEGER NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+  entity_type  TEXT NOT NULL CHECK (entity_type IN ('character', 'lore', 'location')),
+  entity_id    INTEGER NOT NULL,
+  created_at   TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (work_id, entity_type, entity_id)
+);
+
+CREATE INDEX idx_entity_references_work ON entity_references (work_id);
+CREATE INDEX idx_entity_references_entity ON entity_references (entity_type, entity_id);
+
+-- ─── Lore Edit History ──────────────────────────────────
+-- Track changes to lore entries (like AO3 tag wrangling, but for lore).
+
+CREATE TABLE IF NOT EXISTS lore_edits (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  lore_entry_id INTEGER NOT NULL REFERENCES lore_entries(id) ON DELETE CASCADE,
+  pseud_id      INTEGER REFERENCES pseuds(id) ON DELETE SET NULL,
+  field         TEXT NOT NULL,
+  old_value     TEXT,
+  new_value     TEXT,
+  created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_lore_edits_entry ON lore_edits (lore_entry_id);
+
+-- ─── Location Edit History ──────────────────────────────
+
+CREATE TABLE IF NOT EXISTS location_edits (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  location_id   INTEGER NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  pseud_id      INTEGER REFERENCES pseuds(id) ON DELETE SET NULL,
+  field         TEXT NOT NULL,
+  old_value     TEXT,
+  new_value     TEXT,
+  created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_location_edits_location ON location_edits (location_id);
+
+-- ─── FTS for lore_entries ──────────────────────────────
+
+CREATE VIRTUAL TABLE IF NOT EXISTS lore_entries_fts USING fts5(
+  title,
+  body_md,
+  content='lore_entries',
+  content_rowid='id',
+  tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS lore_entries_fts_insert AFTER INSERT ON lore_entries BEGIN
+  INSERT INTO lore_entries_fts (rowid, title, body_md) VALUES (NEW.id, NEW.title, NEW.body_md);
+END;
+
+CREATE TRIGGER IF NOT EXISTS lore_entries_fts_update AFTER UPDATE ON lore_entries BEGIN
+  INSERT INTO lore_entries_fts (lore_entries_fts, rowid, title, body_md) VALUES ('delete', OLD.id, OLD.title, OLD.body_md);
+  INSERT INTO lore_entries_fts (rowid, title, body_md) VALUES (NEW.id, NEW.title, NEW.body_md);
+END;
+
+CREATE TRIGGER IF NOT EXISTS lore_entries_fts_delete AFTER DELETE ON lore_entries BEGIN
+  INSERT INTO lore_entries_fts (lore_entries_fts, rowid, title, body_md) VALUES ('delete', OLD.id, OLD.title, OLD.body_md);
+END;
+
+-- ─── FTS for locations ──────────────────────────────────
+
+CREATE VIRTUAL TABLE IF NOT EXISTS locations_fts USING fts5(
+  name,
+  description_md,
+  content='locations',
+  content_rowid='id',
+  tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS locations_fts_insert AFTER INSERT ON locations BEGIN
+  INSERT INTO locations_fts (rowid, name, description_md) VALUES (NEW.id, NEW.name, NEW.description_md);
+END;
+
+CREATE TRIGGER IF NOT EXISTS locations_fts_update AFTER UPDATE ON locations BEGIN
+  INSERT INTO locations_fts (locations_fts, rowid, name, description_md) VALUES ('delete', OLD.id, OLD.name, OLD.description_md);
+  INSERT INTO locations_fts (rowid, name, description_md) VALUES (NEW.id, NEW.name, NEW.description_md);
+END;
+
+CREATE TRIGGER IF NOT EXISTS locations_fts_delete AFTER DELETE ON locations BEGIN
+  INSERT INTO locations_fts (locations_fts, rowid, name, description_md) VALUES ('delete', OLD.id, OLD.name, OLD.description_md);
+END;

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,9 +1,16 @@
 import { marked } from 'marked';
 import TurndownService from 'turndown';
 import sanitizeHtml from 'sanitize-html';
+import { parseWikiLinks } from './wiki-links';
 
 export function markdownToHtml(md: string): string {
-  const raw = marked.parse(md, { async: false, gfm: true }) as string;
+  // Step 1: Parse wiki-links BEFORE markdown → HTML conversion
+  const withWikiLinks = parseWikiLinks(md);
+
+  // Step 2: Convert markdown to HTML
+  const raw = marked.parse(withWikiLinks, { async: false, gfm: true }) as string;
+
+  // Step 3: Sanitize HTML, allowing wiki-link attributes and classes
   return sanitizeHtml(raw, {
     allowedTags: [
       'h1','h2','h3','h4','h5','h6','p','br','hr','blockquote','pre','code',
@@ -11,10 +18,13 @@ export function markdownToHtml(md: string): string {
       'img','figure','figcaption','sup','sub','details','summary','input',
     ],
     allowedAttributes: {
-      'a': ['href', 'title', 'target', 'rel'],
+      'a': ['href', 'title', 'target', 'rel', 'data-entity', 'data-type'],
       'img': ['src', 'alt', 'title', 'width', 'height'],
       'input': ['checked', 'disabled', 'type'],
       '*': ['class', 'id'],
+    },
+    allowedClasses: {
+      'a': ['wiki-link', 'wiki-link-location', 'wiki-link-lore'],
     },
     allowedSchemes: ['http', 'https', 'mailto'],
     // Allow data URIs for images only (base64 inline images from editor paste)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -212,3 +212,65 @@ export interface SerialWork {
   work_id: number;
   position: number;
 }
+
+// ─── Canon Layer ──────────────────────────────────
+
+export type LoreCategory = 'general' | 'magic' | 'history' | 'organization' | 'concept' | 'item' | 'event' | 'culture' | 'species';
+
+export type EntityType = 'character' | 'lore' | 'location';
+
+export interface LoreEntry {
+  id: number;
+  title: string;
+  slug: string;
+  body_md?: string | null;
+  body_html?: string | null;
+  category: LoreCategory;
+  fandom_tag_id?: number | null;
+  created_by?: number | null;
+  updated_by?: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Location {
+  id: number;
+  name: string;
+  slug: string;
+  description_md?: string | null;
+  description_html?: string | null;
+  fandom_tag_id?: number | null;
+  parent_location_id?: number | null;
+  created_by?: number | null;
+  updated_by?: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EntityReference {
+  id: number;
+  work_id: number;
+  entity_type: EntityType;
+  entity_id: number;
+  created_at: string;
+}
+
+export interface LoreEdit {
+  id: number;
+  lore_entry_id: number;
+  pseud_id?: number | null;
+  field: string;
+  old_value?: string | null;
+  new_value?: string | null;
+  created_at: string;
+}
+
+export interface LocationEdit {
+  id: number;
+  location_id: number;
+  pseud_id?: number | null;
+  field: string;
+  old_value?: string | null;
+  new_value?: string | null;
+  created_at: string;
+}

--- a/src/lib/wiki-links.ts
+++ b/src/lib/wiki-links.ts
@@ -1,0 +1,140 @@
+/**
+ * Wiki-link parser for fanfiction.fyi Canon Layer
+ *
+ * Transforms `[[:...]]` wiki-link syntax into HTML anchor tags
+ * BEFORE markdown-to-HTML conversion in the rendering pipeline.
+ *
+ * Syntax:
+ *   [[:Character Name]]        → generic wiki-link
+ *   [[:Location:Paris]]       → location wiki-link
+ *   [[:Lore:Magic System]]    → explicit lore wiki-link
+ */
+
+/** Known type prefixes that modify the link href and classes */
+const TYPE_PREFIXES = ['Location', 'Lore'] as const;
+type TypePrefix = (typeof TYPE_PREFIXES)[number];
+
+/** Regex that matches `[[:...]]` wiki-link patterns */
+const WIKI_LINK_RE = /\[\[:([^\n\[\]]+?)\]\]/g;
+
+/** Matches fenced code block opening (``` or ~~~ with optional lang) */
+const FENCED_OPEN_RE = /^\s{0,3}(`{3,}|~{3,})/;
+/** Matches indented code block (4+ spaces at line start) */
+const INDENTED_CODE_RE = /^ {4,}/;
+
+/**
+ * Escape special HTML characters in entity names to prevent injection.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * URL-encode a string for use in query parameters.
+ */
+function encodeQueryParam(s: string): string {
+  return encodeURIComponent(s);
+}
+
+/**
+ * Parse a single wiki-link inner content into type prefix + entity name.
+ *
+ * Examples:
+ *   "Location:Paris"       → { type: 'Location', entity: 'Paris' }
+ *   "Lore:Magic System"    → { type: 'Lore', entity: 'Magic System' }
+ *   "Character Name"       → { type: null, entity: 'Character Name' }
+ */
+function parseInnerContent(inner: string): { type: TypePrefix | null; entity: string } {
+  for (const prefix of TYPE_PREFIXES) {
+    const prefixStr = prefix + ':';
+    if (inner.startsWith(prefixStr)) {
+      const entity = inner.slice(prefixStr.length).trim();
+      if (entity.length > 0) {
+        return { type: prefix, entity };
+      }
+    }
+  }
+  // No recognized type prefix → default (character / generic lore)
+  return { type: null, entity: inner.trim() };
+}
+
+/**
+ * Build the HTML anchor for a parsed wiki-link.
+ */
+function buildWikiLink(type: TypePrefix | null, entity: string): string {
+  const escapedEntity = escapeHtml(entity);
+  const encodedQ = encodeQueryParam(entity);
+
+  if (type === 'Location') {
+    return `<a class="wiki-link wiki-link-location" href="/canon/locations?q=${encodedQ}" data-entity="${escapedEntity}" data-type="location">${escapedEntity}</a>`;
+  }
+
+  if (type === 'Lore') {
+    return `<a class="wiki-link wiki-link-lore" href="/canon?q=${encodedQ}" data-entity="${escapedEntity}" data-type="lore">${escapedEntity}</a>`;
+  }
+
+  // Default: generic wiki-link (character/lore entry)
+  return `<a class="wiki-link" href="/canon?q=${encodedQ}" data-entity="${escapedEntity}">${escapedEntity}</a>`;
+}
+
+/**
+ * Parse wiki-link syntax in markdown content and replace with HTML links.
+ *
+ * IMPORTANT: This runs BEFORE marked.parse(), so the markdown is still raw.
+ * We must skip wiki-links inside code blocks:
+ *   - Lines starting with 4+ spaces (indented code)
+ *   - Content inside fenced code blocks (``` ... ```)
+ */
+export function parseWikiLinks(md: string): string {
+  if (!md || !md.includes('[[:')) {
+    return md;
+  }
+
+  // Split content into segments: code blocks vs non-code blocks
+  const lines = md.split('\n');
+  const resultLines: string[] = [];
+  let insideFenced = false;
+  let fenceMarker = '';
+
+  for (const line of lines) {
+    // Check for fenced code block boundaries
+    const fenceMatch = line.match(FENCED_OPEN_RE);
+    if (fenceMatch) {
+      if (!insideFenced) {
+        // Opening fence
+        insideFenced = true;
+        fenceMarker = fenceMatch[1][0]; // ` or ~
+        resultLines.push(line);
+        continue;
+      } else if (fenceMatch[1][0] === fenceMarker && fenceMatch[1].length >= 3) {
+        // Closing fence (must match opening character)
+        insideFenced = false;
+        fenceMarker = '';
+        resultLines.push(line);
+        continue;
+      }
+    }
+
+    // Inside a fenced code block or indented code block → skip wiki-link processing
+    if (insideFenced || INDENTED_CODE_RE.test(line)) {
+      resultLines.push(line);
+      continue;
+    }
+
+    // Process wiki-links on this line
+    resultLines.push(line.replace(WIKI_LINK_RE, (match, inner: string) => {
+      const { type, entity } = parseInnerContent(inner);
+      if (!entity) {
+        // Edge case: empty entity → return the original match unchanged
+        return match;
+      }
+      return buildWikiLink(type, entity);
+    }));
+  }
+
+  return resultLines.join('\n');
+}

--- a/src/pages/api/canon/locations/[id].ts
+++ b/src/pages/api/canon/locations/[id].ts
@@ -1,0 +1,312 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import { markdownToHtml } from '@/lib/markdown';
+import type { APIRoute } from 'astro';
+import { UserRole, hasRoleLevel } from '@/lib/types';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+function slugify(name: string): string {
+  let slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+  if (!slug) slug = `entry-${Date.now()}`;
+  return slug;
+}
+
+async function ensureUniqueSlug(
+  db: D1Database,
+  baseSlug: string,
+  excludeId?: number,
+): Promise<string> {
+  let slug = baseSlug;
+  let suffix = 2;
+  while (true) {
+    let sql = `SELECT id FROM locations WHERE slug = ?1`;
+    const params: unknown[] = [slug];
+    if (excludeId) {
+      sql += ` AND id != ?2`;
+      params.push(excludeId);
+    }
+    const existing = await queryFirst<{ id: number }>(db, sql, ...params);
+    if (!existing) return slug;
+    slug = `${baseSlug}-${suffix++}`;
+  }
+}
+
+// GET /api/canon/locations/[id] — Single location
+export const GET: APIRoute = async ({ params, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid location ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const location = await queryFirst<any>(
+      db,
+      `SELECT l.*, p.name as parent_name, t.name as fandom_name
+       FROM locations l
+       LEFT JOIN locations p ON l.parent_location_id = p.id
+       LEFT JOIN tags t ON l.fandom_tag_id = t.id
+       WHERE l.id = ?1`,
+      id,
+    );
+    if (!location) {
+      return new Response(
+        JSON.stringify({ error: 'Location not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Children locations
+    const children = await queryAll<any>(
+      db,
+      `SELECT id, name, slug FROM locations WHERE parent_location_id = ?1 ORDER BY name ASC`,
+      id,
+    );
+    location.children = children;
+
+    // Works referencing this location
+    const works = await queryAll<any>(
+      db,
+      `SELECT w.id, w.title, w.summary, w.word_count, w.published_at
+       FROM entity_references er
+       JOIN works w ON er.work_id = w.id
+       WHERE er.entity_type = 'location' AND er.entity_id = ?1
+       ORDER BY w.updated_at DESC`,
+      id,
+    );
+    location.works_referencing = works;
+
+    return new Response(
+      JSON.stringify(location),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// PUT /api/canon/locations/[id] — Update location
+export const PUT: APIRoute = async ({ params, request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid location ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const existing = await queryFirst<any>(
+      db,
+      `SELECT * FROM locations WHERE id = ?1`,
+      id,
+    );
+    if (!existing) {
+      return new Response(
+        JSON.stringify({ error: 'Location not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Permission: creator or admin/mod
+    const isCreator =
+      existing.created_by &&
+      auth.pseuds.some((p) => p.id === existing.created_by);
+    const isPrivileged = hasRoleLevel(auth.user.role as UserRole, UserRole.Mod);
+    if (!isCreator && !isPrivileged) {
+      return new Response(
+        JSON.stringify({ error: 'Forbidden' }),
+        { status: 403, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: 'Invalid JSON' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    const pseudId = auth.pseuds[0]?.id ?? null;
+    const updates: string[] = [];
+    const bindings: unknown[] = [];
+    let idx = 1;
+    const changedFields: { field: string; oldValue: string | null; newValue: string | null }[] = [];
+
+    if (body.name !== undefined && body.name !== existing.name) {
+      const newSlug = await ensureUniqueSlug(db, slugify(body.name), id);
+      changedFields.push({ field: 'name', oldValue: existing.name, newValue: body.name });
+      updates.push(`name = ?${idx++}`);
+      bindings.push(body.name);
+      updates.push(`slug = ?${idx++}`);
+      bindings.push(newSlug);
+    }
+
+    if (body.description_md !== undefined && body.description_md !== existing.description_md) {
+      const descHtml = markdownToHtml(body.description_md);
+      changedFields.push({ field: 'description_md', oldValue: existing.description_md, newValue: body.description_md });
+      changedFields.push({ field: 'description_html', oldValue: existing.description_html, newValue: descHtml });
+      updates.push(`description_md = ?${idx++}`);
+      bindings.push(body.description_md);
+      updates.push(`description_html = ?${idx++}`);
+      bindings.push(descHtml);
+    }
+
+    if (body.fandom_tag_id !== undefined) {
+      const newVal = body.fandom_tag_id ? Number(body.fandom_tag_id) : null;
+      const oldVal = existing.fandom_tag_id;
+      if (newVal !== oldVal) {
+        changedFields.push({
+          field: 'fandom_tag_id',
+          oldValue: String(oldVal ?? ''),
+          newValue: String(newVal ?? ''),
+        });
+        updates.push(`fandom_tag_id = ?${idx++}`);
+        bindings.push(newVal);
+      }
+    }
+
+    if (body.parent_location_id !== undefined) {
+      const newVal = body.parent_location_id ? Number(body.parent_location_id) : null;
+      const oldVal = existing.parent_location_id;
+      if (newVal !== oldVal) {
+        changedFields.push({
+          field: 'parent_location_id',
+          oldValue: String(oldVal ?? ''),
+          newValue: String(newVal ?? ''),
+        });
+        updates.push(`parent_location_id = ?${idx++}`);
+        bindings.push(newVal);
+      }
+    }
+
+    if (updates.length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'No fields to update' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    updates.push(`updated_by = ?${idx++}`);
+    bindings.push(pseudId);
+    updates.push(`updated_at = CURRENT_TIMESTAMP`);
+
+    bindings.push(id);
+    const sql = `UPDATE locations SET ${updates.join(', ')} WHERE id = ?${idx}`;
+    await run(db, sql, ...bindings);
+
+    // Create location_edits for each changed field
+    for (const change of changedFields) {
+      await run(
+        db,
+        `INSERT INTO location_edits (location_id, pseud_id, field, old_value, new_value)
+         VALUES (?1, ?2, ?3, ?4, ?5)`,
+        id, pseudId, change.field, change.oldValue, change.newValue,
+      );
+    }
+
+    const updated = await queryFirst<any>(
+      db,
+      `SELECT l.*, p.name as parent_name, t.name as fandom_name
+       FROM locations l
+       LEFT JOIN locations p ON l.parent_location_id = p.id
+       LEFT JOIN tags t ON l.fandom_tag_id = t.id
+       WHERE l.id = ?1`,
+      id,
+    );
+
+    return new Response(
+      JSON.stringify(updated),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// DELETE /api/canon/locations/[id] — Delete location (admin/mod only)
+export const DELETE: APIRoute = async ({ params, request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const isPrivileged = hasRoleLevel(auth.user.role as UserRole, UserRole.Mod);
+  if (!isPrivileged) {
+    return new Response(
+      JSON.stringify({ error: 'Forbidden: admin/mod role required' }),
+      { status: 403, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid location ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const existing = await queryFirst<any>(
+      db,
+      `SELECT * FROM locations WHERE id = ?1`,
+      id,
+    );
+    if (!existing) {
+      return new Response(
+        JSON.stringify({ error: 'Location not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // location_edits and entity_references cascade on delete
+    await run(db, `DELETE FROM locations WHERE id = ?1`, id);
+    return new Response(
+      JSON.stringify({ ok: true }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/locations/[id]/history.ts
+++ b/src/pages/api/canon/locations/[id]/history.ts
@@ -1,0 +1,44 @@
+export const prerender = false;
+
+import { queryAll } from '@/lib/db';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import type { APIRoute } from 'astro';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+// GET /api/canon/locations/[id]/history — Edit history for a location
+export const GET: APIRoute = async ({ params, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid location ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const edits = await queryAll<any>(
+      db,
+      `SELECT le.*, p.name as pseud_name
+       FROM location_edits le
+       LEFT JOIN pseuds p ON le.pseud_id = p.id
+       WHERE le.location_id = ?1
+       ORDER BY le.created_at DESC`,
+      id,
+    );
+
+    return new Response(
+      JSON.stringify({ edits }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/locations/index.ts
+++ b/src/pages/api/canon/locations/index.ts
@@ -1,0 +1,186 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import { markdownToHtml } from '@/lib/markdown';
+import type { APIRoute } from 'astro';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+function sanitizeFts(q: string): string {
+  return q
+    .replace(/["()*+^:-]/g, '')
+    .replace(/\b(AND|OR|NOT|NEAR)\b/gi, '')
+    .trim();
+}
+
+function slugify(name: string): string {
+  let slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+  if (!slug) slug = `entry-${Date.now()}`;
+  return slug;
+}
+
+async function ensureUniqueSlug(
+  db: D1Database,
+  baseSlug: string,
+  excludeId?: number,
+): Promise<string> {
+  let slug = baseSlug;
+  let suffix = 2;
+  while (true) {
+    let sql = `SELECT id FROM locations WHERE slug = ?1`;
+    const params: unknown[] = [slug];
+    if (excludeId) {
+      sql += ` AND id != ?2`;
+      params.push(excludeId);
+    }
+    const existing = await queryFirst<{ id: number }>(db, sql, ...params);
+    if (!existing) return slug;
+    slug = `${baseSlug}-${suffix++}`;
+  }
+}
+
+// GET /api/canon/locations — Browse/search locations
+export const GET: APIRoute = async ({ url, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+
+  const rawQ = url.searchParams.get('q')?.trim() || '';
+  const fandomTagId = url.searchParams.get('fandom_tag_id') || '';
+  const parentLocationId = url.searchParams.get('parent_location_id') || '';
+  const page = Math.max(Number(url.searchParams.get('page') || 1), 1);
+  const limit = Math.min(Number(url.searchParams.get('limit') || 20), 100);
+  const offset = (page - 1) * limit;
+
+  try {
+    const sanitizedQ = rawQ ? sanitizeFts(rawQ) : '';
+    let fromClause: string;
+    const conditions: string[] = [];
+    const bindings: unknown[] = [];
+    let idx = 1;
+
+    if (sanitizedQ) {
+      fromClause = `locations_fts f JOIN locations l ON f.rowid = l.id`;
+      conditions.push(`locations_fts MATCH ?${idx++}`);
+      bindings.push(sanitizedQ);
+    } else {
+      fromClause = `locations l`;
+    }
+
+    if (fandomTagId) {
+      conditions.push(`l.fandom_tag_id = ?${idx++}`);
+      bindings.push(Number(fandomTagId));
+    }
+
+    if (parentLocationId) {
+      conditions.push(`l.parent_location_id = ?${idx++}`);
+      bindings.push(Number(parentLocationId));
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    // Count
+    const countSql = `SELECT COUNT(*) as total FROM ${fromClause} ${whereClause}`;
+    const countRow = await queryFirst<{ total: number }>(db, countSql, ...bindings);
+    const total = countRow?.total ?? 0;
+
+    // Data with parent name and fandom name
+    const dataSql = `
+      SELECT l.*, p.name as parent_name, t.name as fandom_name
+      FROM ${fromClause}
+      LEFT JOIN locations p ON l.parent_location_id = p.id
+      LEFT JOIN tags t ON l.fandom_tag_id = t.id
+      ${whereClause}
+      ORDER BY l.updated_at DESC
+      LIMIT ?${idx++} OFFSET ?${idx++}
+    `;
+    const dataBindings = [...bindings, limit, offset];
+
+    const locations = await queryAll<any>(db, dataSql, ...dataBindings);
+
+    return new Response(
+      JSON.stringify({ locations, total, page, limit }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// POST /api/canon/locations — Create location
+export const POST: APIRoute = async ({ request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const { name, description_md, fandom_tag_id, parent_location_id } = body || {};
+  if (!name) {
+    return new Response(
+      JSON.stringify({ error: 'name is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const descriptionHtml = description_md ? markdownToHtml(description_md) : null;
+  const baseSlug = slugify(name);
+  const pseudId = auth.pseuds[0]?.id ?? null;
+
+  try {
+    const slug = await ensureUniqueSlug(db, baseSlug);
+
+    const result = await run(
+      db,
+      `INSERT INTO locations (name, slug, description_md, description_html, fandom_tag_id, parent_location_id, created_by, updated_by)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
+      name, slug, description_md ?? null, descriptionHtml,
+      fandom_tag_id ? Number(fandom_tag_id) : null,
+      parent_location_id ? Number(parent_location_id) : null,
+      pseudId, pseudId,
+    );
+
+    const location = await queryFirst<any>(
+      db,
+      `SELECT l.*, p.name as parent_name, t.name as fandom_name
+       FROM locations l
+       LEFT JOIN locations p ON l.parent_location_id = p.id
+       LEFT JOIN tags t ON l.fandom_tag_id = t.id
+       WHERE l.id = ?1`,
+      result.meta.last_row_id,
+    );
+
+    return new Response(
+      JSON.stringify(location),
+      { status: 201, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/lore/[id].ts
+++ b/src/pages/api/canon/lore/[id].ts
@@ -1,0 +1,304 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import { markdownToHtml } from '@/lib/markdown';
+import type { APIRoute } from 'astro';
+import type { LoreCategory } from '@/lib/types';
+import { UserRole, hasRoleLevel } from '@/lib/types';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+const VALID_CATEGORIES: LoreCategory[] = [
+  'general', 'magic', 'history', 'organization', 'concept',
+  'item', 'event', 'culture', 'species',
+];
+
+function slugify(title: string): string {
+  let slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+  if (!slug) slug = `entry-${Date.now()}`;
+  return slug;
+}
+
+async function ensureUniqueSlug(
+  db: D1Database,
+  baseSlug: string,
+  excludeId?: number,
+): Promise<string> {
+  let slug = baseSlug;
+  let suffix = 2;
+  while (true) {
+    let sql = `SELECT id FROM lore_entries WHERE slug = ?1`;
+    const params: unknown[] = [slug];
+    if (excludeId) {
+      sql += ` AND id != ?2`;
+      params.push(excludeId);
+    }
+    const existing = await queryFirst<{ id: number }>(db, sql, ...params);
+    if (!existing) return slug;
+    slug = `${baseSlug}-${suffix++}`;
+  }
+}
+
+// GET /api/canon/lore/[id] — Single lore entry
+export const GET: APIRoute = async ({ params, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid lore ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const entry = await queryFirst<any>(
+      db,
+      `SELECT le.*, t.name as fandom_name
+       FROM lore_entries le
+       LEFT JOIN tags t ON le.fandom_tag_id = t.id
+       WHERE le.id = ?1`,
+      id,
+    );
+    if (!entry) {
+      return new Response(
+        JSON.stringify({ error: 'Lore entry not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Works referencing this lore entry
+    const works = await queryAll<any>(
+      db,
+      `SELECT w.id, w.title, w.summary, w.word_count, w.published_at
+       FROM entity_references er
+       JOIN works w ON er.work_id = w.id
+       WHERE er.entity_type = 'lore' AND er.entity_id = ?1
+       ORDER BY w.updated_at DESC`,
+      id,
+    );
+    entry.works_referencing = works;
+
+    return new Response(
+      JSON.stringify(entry),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// PUT /api/canon/lore/[id] — Update lore entry
+export const PUT: APIRoute = async ({ params, request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid lore ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const existing = await queryFirst<any>(
+      db,
+      `SELECT * FROM lore_entries WHERE id = ?1`,
+      id,
+    );
+    if (!existing) {
+      return new Response(
+        JSON.stringify({ error: 'Lore entry not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Permission: creator or admin/mod
+    const isCreator =
+      existing.created_by &&
+      auth.pseuds.some((p) => p.id === existing.created_by);
+    const isPrivileged = hasRoleLevel(auth.user.role as UserRole, UserRole.Mod);
+    if (!isCreator && !isPrivileged) {
+      return new Response(
+        JSON.stringify({ error: 'Forbidden' }),
+        { status: 403, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: 'Invalid JSON' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    const pseudId = auth.pseuds[0]?.id ?? null;
+    const updates: string[] = [];
+    const bindings: unknown[] = [];
+    let idx = 1;
+    const changedFields: { field: string; oldValue: string | null; newValue: string | null }[] = [];
+
+    if (body.title !== undefined && body.title !== existing.title) {
+      const newSlug = await ensureUniqueSlug(db, slugify(body.title), id);
+      changedFields.push({ field: 'title', oldValue: existing.title, newValue: body.title });
+      updates.push(`title = ?${idx++}`);
+      bindings.push(body.title);
+      updates.push(`slug = ?${idx++}`);
+      bindings.push(newSlug);
+    }
+
+    if (body.body_md !== undefined && body.body_md !== existing.body_md) {
+      const bodyHtml = markdownToHtml(body.body_md);
+      changedFields.push({ field: 'body_md', oldValue: existing.body_md, newValue: body.body_md });
+      changedFields.push({ field: 'body_html', oldValue: existing.body_html, newValue: bodyHtml });
+      updates.push(`body_md = ?${idx++}`);
+      bindings.push(body.body_md);
+      updates.push(`body_html = ?${idx++}`);
+      bindings.push(bodyHtml);
+    }
+
+    if (
+      body.category !== undefined &&
+      body.category !== existing.category &&
+      VALID_CATEGORIES.includes(body.category)
+    ) {
+      changedFields.push({ field: 'category', oldValue: existing.category, newValue: body.category });
+      updates.push(`category = ?${idx++}`);
+      bindings.push(body.category);
+    }
+
+    if (body.fandom_tag_id !== undefined) {
+      const newVal = body.fandom_tag_id ? Number(body.fandom_tag_id) : null;
+      const oldVal = existing.fandom_tag_id;
+      if (newVal !== oldVal) {
+        changedFields.push({
+          field: 'fandom_tag_id',
+          oldValue: String(oldVal ?? ''),
+          newValue: String(newVal ?? ''),
+        });
+        updates.push(`fandom_tag_id = ?${idx++}`);
+        bindings.push(newVal);
+      }
+    }
+
+    if (updates.length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'No fields to update' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    updates.push(`updated_by = ?${idx++}`);
+    bindings.push(pseudId);
+    updates.push(`updated_at = CURRENT_TIMESTAMP`);
+
+    bindings.push(id);
+    const sql = `UPDATE lore_entries SET ${updates.join(', ')} WHERE id = ?${idx}`;
+    await run(db, sql, ...bindings);
+
+    // Create lore_edits for each changed field
+    for (const change of changedFields) {
+      await run(
+        db,
+        `INSERT INTO lore_edits (lore_entry_id, pseud_id, field, old_value, new_value)
+         VALUES (?1, ?2, ?3, ?4, ?5)`,
+        id, pseudId, change.field, change.oldValue, change.newValue,
+      );
+    }
+
+    const updated = await queryFirst<any>(
+      db,
+      `SELECT le.*, t.name as fandom_name
+       FROM lore_entries le
+       LEFT JOIN tags t ON le.fandom_tag_id = t.id
+       WHERE le.id = ?1`,
+      id,
+    );
+
+    return new Response(
+      JSON.stringify(updated),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// DELETE /api/canon/lore/[id] — Delete lore entry (admin/mod only)
+export const DELETE: APIRoute = async ({ params, request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const isPrivileged = hasRoleLevel(auth.user.role as UserRole, UserRole.Mod);
+  if (!isPrivileged) {
+    return new Response(
+      JSON.stringify({ error: 'Forbidden: admin/mod role required' }),
+      { status: 403, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid lore ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const existing = await queryFirst<any>(
+      db,
+      `SELECT * FROM lore_entries WHERE id = ?1`,
+      id,
+    );
+    if (!existing) {
+      return new Response(
+        JSON.stringify({ error: 'Lore entry not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // lore_edits and entity_references cascade on delete
+    await run(db, `DELETE FROM lore_entries WHERE id = ?1`, id);
+    return new Response(
+      JSON.stringify({ ok: true }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/lore/[id]/history.ts
+++ b/src/pages/api/canon/lore/[id]/history.ts
@@ -1,0 +1,44 @@
+export const prerender = false;
+
+import { queryAll } from '@/lib/db';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import type { APIRoute } from 'astro';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+// GET /api/canon/lore/[id]/history — Edit history for a lore entry
+export const GET: APIRoute = async ({ params, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+  const id = Number(params.id);
+  if (!id) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid lore ID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    const edits = await queryAll<any>(
+      db,
+      `SELECT le.*, p.name as pseud_name
+       FROM lore_edits le
+       LEFT JOIN pseuds p ON le.pseud_id = p.id
+       WHERE le.lore_entry_id = ?1
+       ORDER BY le.created_at DESC`,
+      id,
+    );
+
+    return new Response(
+      JSON.stringify({ edits }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/lore/index.ts
+++ b/src/pages/api/canon/lore/index.ts
@@ -1,0 +1,197 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import { markdownToHtml } from '@/lib/markdown';
+import type { APIRoute } from 'astro';
+import type { LoreCategory } from '@/lib/types';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+const VALID_CATEGORIES: LoreCategory[] = [
+  'general', 'magic', 'history', 'organization', 'concept',
+  'item', 'event', 'culture', 'species',
+];
+
+function sanitizeFts(q: string): string {
+  return q
+    .replace(/["()*+^:-]/g, '')
+    .replace(/\b(AND|OR|NOT|NEAR)\b/gi, '')
+    .trim();
+}
+
+function slugify(title: string): string {
+  let slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+  if (!slug) slug = `entry-${Date.now()}`;
+  return slug;
+}
+
+async function ensureUniqueSlug(
+  db: D1Database,
+  baseSlug: string,
+  excludeId?: number,
+): Promise<string> {
+  let slug = baseSlug;
+  let suffix = 2;
+  while (true) {
+    let sql = `SELECT id FROM lore_entries WHERE slug = ?1`;
+    const params: unknown[] = [slug];
+    if (excludeId) {
+      sql += ` AND id != ?2`;
+      params.push(excludeId);
+    }
+    const existing = await queryFirst<{ id: number }>(db, sql, ...params);
+    if (!existing) return slug;
+    slug = `${baseSlug}-${suffix++}`;
+  }
+}
+
+// GET /api/canon/lore — Browse/search lore entries
+export const GET: APIRoute = async ({ url, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+
+  const rawQ = url.searchParams.get('q')?.trim() || '';
+  const fandomTagId = url.searchParams.get('fandom_tag_id') || '';
+  const category = url.searchParams.get('category') || '';
+  const page = Math.max(Number(url.searchParams.get('page') || 1), 1);
+  const limit = Math.min(Number(url.searchParams.get('limit') || 20), 100);
+  const offset = (page - 1) * limit;
+
+  try {
+    const sanitizedQ = rawQ ? sanitizeFts(rawQ) : '';
+    let fromClause: string;
+    const conditions: string[] = [];
+    const bindings: unknown[] = [];
+    let idx = 1;
+
+    if (sanitizedQ) {
+      fromClause = `lore_entries_fts f JOIN lore_entries le ON f.rowid = le.id`;
+      conditions.push(`lore_entries_fts MATCH ?${idx++}`);
+      bindings.push(sanitizedQ);
+    } else {
+      fromClause = `lore_entries le`;
+    }
+
+    if (fandomTagId) {
+      conditions.push(`le.fandom_tag_id = ?${idx++}`);
+      bindings.push(Number(fandomTagId));
+    }
+
+    if (category && VALID_CATEGORIES.includes(category as LoreCategory)) {
+      conditions.push(`le.category = ?${idx++}`);
+      bindings.push(category);
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    // Count
+    const countSql = `SELECT COUNT(*) as total FROM ${fromClause} ${whereClause}`;
+    const countRow = await queryFirst<{ total: number }>(db, countSql, ...bindings);
+    const total = countRow?.total ?? 0;
+
+    // Data
+    const dataSql = `
+      SELECT le.*, t.name as fandom_name
+      FROM ${fromClause}
+      LEFT JOIN tags t ON le.fandom_tag_id = t.id
+      ${whereClause}
+      ORDER BY le.updated_at DESC
+      LIMIT ?${idx++} OFFSET ?${idx++}
+    `;
+    const dataBindings = [...bindings, limit, offset];
+
+    const entries = await queryAll<any>(db, dataSql, ...dataBindings);
+
+    return new Response(
+      JSON.stringify({ entries, total, page, limit }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// POST /api/canon/lore — Create lore entry
+export const POST: APIRoute = async ({ request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const { title, body_md, category, fandom_tag_id } = body || {};
+  if (!title) {
+    return new Response(
+      JSON.stringify({ error: 'title is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+  if (!body_md) {
+    return new Response(
+      JSON.stringify({ error: 'body_md is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const entryCategory: LoreCategory =
+    category && VALID_CATEGORIES.includes(category) ? category : 'general';
+  const bodyHtml = markdownToHtml(body_md);
+  const baseSlug = slugify(title);
+  const pseudId = auth.pseuds[0]?.id ?? null;
+
+  try {
+    const slug = await ensureUniqueSlug(db, baseSlug);
+
+    const result = await run(
+      db,
+      `INSERT INTO lore_entries (title, slug, body_md, body_html, category, fandom_tag_id, created_by, updated_by)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
+      title, slug, body_md, bodyHtml, entryCategory,
+      fandom_tag_id ? Number(fandom_tag_id) : null,
+      pseudId, pseudId,
+    );
+
+    const entry = await queryFirst<any>(
+      db,
+      `SELECT le.*, t.name as fandom_name
+       FROM lore_entries le
+       LEFT JOIN tags t ON le.fandom_tag_id = t.id
+       WHERE le.id = ?1`,
+      result.meta.last_row_id,
+    );
+
+    return new Response(
+      JSON.stringify(entry),
+      { status: 201, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/references/index.ts
+++ b/src/pages/api/canon/references/index.ts
@@ -1,0 +1,290 @@
+export const prerender = false;
+
+import { queryAll, queryFirst, run } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import type { APIRoute } from 'astro';
+import type { EntityType } from '@/lib/types';
+import { UserRole, hasRoleLevel } from '@/lib/types';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+const VALID_ENTITY_TYPES: EntityType[] = ['character', 'lore', 'location'];
+
+const ENTITY_TABLE_MAP: Record<EntityType, string> = {
+  character: 'characters',
+  lore: 'lore_entries',
+  location: 'locations',
+};
+
+// GET /api/canon/references — Browse entity references
+export const GET: APIRoute = async ({ url, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+
+  const entityType = url.searchParams.get('entity_type') || '';
+  const entityId = url.searchParams.get('entity_id') || '';
+  const workId = url.searchParams.get('work_id') || '';
+
+  try {
+    // If entity_type + entity_id given, return works referencing the entity
+    if (entityType && entityId) {
+      const works = await queryAll<any>(
+        db,
+        `SELECT w.id, w.title, w.summary, w.word_count, w.published_at, er.entity_type, er.entity_id, er.created_at as reference_created_at
+         FROM entity_references er
+         JOIN works w ON er.work_id = w.id
+         WHERE er.entity_type = ?1 AND er.entity_id = ?2
+         ORDER BY w.updated_at DESC`,
+        entityType, Number(entityId),
+      );
+      return new Response(
+        JSON.stringify({ works }),
+        { headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // If work_id given, return entities referenced by the work
+    if (workId) {
+      const entities = await queryAll<any>(
+        db,
+        `SELECT er.id, er.entity_type, er.entity_id, er.created_at,
+                CASE
+                  WHEN er.entity_type = 'character' THEN c.name
+                  WHEN er.entity_type = 'lore' THEN le.title
+                  WHEN er.entity_type = 'location' THEN loc.name
+                END as entity_name
+         FROM entity_references er
+         LEFT JOIN characters c ON er.entity_type = 'character' AND c.id = er.entity_id
+         LEFT JOIN lore_entries le ON er.entity_type = 'lore' AND le.id = er.entity_id
+         LEFT JOIN locations loc ON er.entity_type = 'location' AND loc.id = er.entity_id
+         WHERE er.work_id = ?1
+         ORDER BY er.entity_type, er.entity_id`,
+        Number(workId),
+      );
+      return new Response(
+        JSON.stringify({ entities }),
+        { headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // If no filters, return error
+    return new Response(
+      JSON.stringify({ error: 'Provide entity_type+entity_id or work_id query parameter' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// POST /api/canon/references — Create entity reference
+export const POST: APIRoute = async ({ request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const { work_id, entity_type, entity_id } = body || {};
+  if (!work_id || !entity_type || !entity_id) {
+    return new Response(
+      JSON.stringify({ error: 'work_id, entity_type, and entity_id are required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  if (!VALID_ENTITY_TYPES.includes(entity_type)) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid entity_type. Must be character, lore, or location.' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const workId = Number(work_id);
+  const entityId = Number(entity_id);
+  const pseudId = auth.pseuds[0]?.id ?? null;
+
+  try {
+    // Validate work exists
+    const work = await queryFirst<any>(db, `SELECT id FROM works WHERE id = ?1`, workId);
+    if (!work) {
+      return new Response(
+        JSON.stringify({ error: 'Work not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Validate entity exists
+    const tableName = ENTITY_TABLE_MAP[entity_type];
+    const entity = await queryFirst<any>(
+      db,
+      `SELECT id FROM ${tableName} WHERE id = ?1`,
+      entityId,
+    );
+    if (!entity) {
+      return new Response(
+        JSON.stringify({ error: `${entity_type} with id ${entityId} not found` }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Insert entity_reference (handle UNIQUE constraint)
+    const result = await run(
+      db,
+      `INSERT INTO entity_references (work_id, entity_type, entity_id) VALUES (?1, ?2, ?3)`,
+      workId, entity_type, entityId,
+    );
+
+    const reference = await queryFirst<any>(
+      db,
+      `SELECT * FROM entity_references WHERE id = ?1`,
+      result.meta.last_row_id,
+    );
+
+    // If entity_type is 'character', also upsert into character_appearances
+    // for compatibility with the existing character system
+    if (entity_type === 'character') {
+      try {
+        await run(
+          db,
+          `INSERT OR IGNORE INTO character_appearances (character_id, work_id, role, notes, added_by)
+           VALUES (?1, ?2, 'side', NULL, ?3)`,
+          entityId, workId, pseudId,
+        );
+      } catch {
+        // Non-fatal — character_appearances upsert is best-effort
+      }
+    }
+
+    return new Response(
+      JSON.stringify(reference),
+      { status: 201, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    if (e.message?.includes('UNIQUE constraint failed')) {
+      return new Response(
+        JSON.stringify({ error: 'This entity is already referenced by this work' }),
+        { status: 409, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};
+
+// DELETE /api/canon/references — Remove entity reference
+export const DELETE: APIRoute = async ({ request, locals }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const cors = corsHeaders(request);
+  const auth = await requireAuth(db, request);
+  if (!auth) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const { work_id, entity_type, entity_id } = body || {};
+  if (!work_id || !entity_type || !entity_id) {
+    return new Response(
+      JSON.stringify({ error: 'work_id, entity_type, and entity_id are required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  const workId = Number(work_id);
+  const entityId = Number(entity_id);
+
+  try {
+    // Find the reference
+    const ref = await queryFirst<any>(
+      db,
+      `SELECT * FROM entity_references WHERE work_id = ?1 AND entity_type = ?2 AND entity_id = ?3`,
+      workId, entity_type, entityId,
+    );
+    if (!ref) {
+      return new Response(
+        JSON.stringify({ error: 'Reference not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    // Permission: work creator (adder) or admin/mod
+    const isWorkCreator = await queryFirst<any>(
+      db,
+      `SELECT 1 FROM creatorships c JOIN pseuds p ON c.pseud_id = p.id
+       WHERE c.work_id = ?1 AND p.user_id = ?2 LIMIT 1`,
+      workId, auth.user.id,
+    );
+    const isPrivileged = hasRoleLevel(auth.user.role as UserRole, UserRole.Mod);
+
+    if (!isWorkCreator && !isPrivileged) {
+      return new Response(
+        JSON.stringify({ error: 'Forbidden: must be a work creator or admin/mod' }),
+        { status: 403, headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+
+    await run(
+      db,
+      `DELETE FROM entity_references WHERE work_id = ?1 AND entity_type = ?2 AND entity_id = ?3`,
+      workId, entity_type, entityId,
+    );
+
+    // If entity_type is 'character', also clean up character_appearances
+    if (entity_type === 'character') {
+      try {
+        await run(
+          db,
+          `DELETE FROM character_appearances WHERE character_id = ?1 AND work_id = ?2`,
+          entityId,
+          workId,
+        );
+      } catch {
+        // Non-fatal — character_appearances cleanup is best-effort
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ ok: true }),
+      { headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/canon/index.astro
+++ b/src/pages/canon/index.astro
@@ -1,0 +1,412 @@
+---
+export const prerender = false;
+import Base from '../../layouts/Base.astro';
+import { getAuth } from '../../lib/auth';
+import { queryAll } from '../../lib/db';
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+const auth = await getAuth(db, Astro.request);
+
+const tab = Astro.url.searchParams.get('tab') || 'lore';
+const q = Astro.url.searchParams.get('q') || '';
+const fandom = Astro.url.searchParams.get('fandom') || '';
+const category = Astro.url.searchParams.get('category') || '';
+const page = Number(Astro.url.searchParams.get('page')) || 1;
+const limit = 24;
+const offset = (page - 1) * limit;
+
+const LORE_CATEGORIES = [
+  'Worldbuilding', 'Magic System', 'Technology', 'History',
+  'Culture', 'Species', 'Religion', 'Politics', 'Other'
+];
+
+let entries: any[] = [];
+let total = 0;
+
+if (tab === 'lore') {
+  let where = '1=1';
+  const params: any[] = [];
+  if (q) {
+    where += ' AND (cl.title LIKE ?1 OR cl.body_md LIKE ?1)';
+    params.push(`%${q}%`);
+  } else if (q === '' && Astro.url.searchParams.has('q')) {
+    // FTS5 search when q is explicitly provided
+  }
+  if (fandom) {
+    where += ' AND cl.fandom = ?2';
+    params.push(fandom);
+  }
+  if (category) {
+    where += ' AND cl.category = ?3';
+    params.push(category);
+  }
+  try {
+    entries = await queryAll<any>(db,
+      `SELECT cl.*, (SELECT COUNT(*) FROM canon_refs cr WHERE cr.lore_id = cl.id) as work_count
+       FROM canon_lore cl WHERE ${where} ORDER BY cl.updated_at DESC LIMIT ?${params.length + 1} OFFSET ?${params.length + 2}`,
+      ...params, limit, offset
+    );
+  } catch {
+    // Table may not exist yet — gracefully show empty
+    entries = [];
+  }
+} else if (tab === 'locations') {
+  let where = '1=1';
+  const params: any[] = [];
+  if (q) {
+    where += ' AND (cl.name LIKE ?1 OR cl.description_md LIKE ?1)';
+    params.push(`%${q}%`);
+  }
+  if (fandom) {
+    where += ' AND cl.fandom = ?2';
+    params.push(fandom);
+  }
+  try {
+    entries = await queryAll<any>(db,
+      `SELECT cl.*, (SELECT COUNT(*) FROM canon_refs cr WHERE cr.location_id = cl.id) as work_count
+       FROM canon_locations cl WHERE ${where} ORDER BY cl.updated_at DESC LIMIT ?${params.length + 1} OFFSET ?${params.length + 2}`,
+      ...params, limit, offset
+    );
+  } catch {
+    entries = [];
+  }
+}
+---
+
+<Base title="Canon — fanfiction.fyi">
+  <section class="canon-browse">
+    <h1 class="page-title">Canon Layer</h1>
+
+    <!-- Tab bar -->
+    <nav class="canon-tabs" role="tablist">
+      <a href="/canon?tab=lore" class={`canon-tab ${tab === 'lore' ? 'canon-tab--active' : ''}`} role="tab" aria-selected={tab === 'lore'}>Lore</a>
+      <a href="/canon?tab=locations" class={`canon-tab ${tab === 'locations' ? 'canon-tab--active' : ''}`} role="tab" aria-selected={tab === 'locations'}>Locations</a>
+      <a href="/characters" class="canon-tab" role="tab">Characters</a>
+    </nav>
+
+    <!-- Search & filters -->
+    <div class="canon-filters">
+      <form method="get" class="canon-search-form">
+        <input type="hidden" name="tab" value={tab} />
+        <input type="text" name="q" value={q} placeholder="Search canon entries…" class="m3-input canon-search-input" />
+        <button type="submit" class="m3-btn-icon" aria-label="Search">🔍</button>
+      </form>
+
+      <div class="canon-filter-row">
+        <select id="fandom-filter" name="fandom" class="m3-select canon-filter-select">
+          <option value="">All Fandoms</option>
+        </select>
+
+        {tab === 'lore' && (
+          <div class="canon-category-chips">
+            {LORE_CATEGORIES.map(cat => (
+              <a
+                href={`/canon?tab=lore&category=${cat}${fandom ? `&fandom=${encodeURIComponent(fandom)}` : ''}${q ? `&q=${encodeURIComponent(q)}` : ''}`}
+                class={`m3-chip ${category === cat ? 'm3-chip--selected' : ''}`}
+              >
+                {cat}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+
+    <!-- Card grid -->
+    <div class="canon-grid">
+      {entries.length === 0 && (
+        <div class="empty-state" role="status">
+          <p class="placeholder-text">No {tab === 'lore' ? 'lore entries' : 'locations'} found.</p>
+        </div>
+      )}
+      {entries.map(entry => (
+        <a href={tab === 'lore' ? `/canon/lore/${entry.id}` : `/canon/locations/${entry.id}`} class="canon-card">
+          <h2 class="canon-card__title">{tab === 'lore' ? entry.title : entry.name}</h2>
+          <div class="canon-card__badges">
+            {entry.fandom && <span class="m3-chip canon-badge">{entry.fandom}</span>}
+            {tab === 'lore' && entry.category && <span class="m3-chip canon-badge canon-badge--category">{entry.category}</span>}
+          </div>
+          {(tab === 'lore' ? entry.body_md : entry.description_md) && (
+            <p class="canon-card__snippet">
+              {(tab === 'lore' ? entry.body_md : entry.description_md).slice(0, 150)}…
+            </p>
+          )}
+          <span class="canon-card__works">{entry.work_count ?? 0} work{(entry.work_count ?? 0) !== 1 ? 's' : ''}</span>
+        </a>
+      ))}
+    </div>
+
+    <!-- Pagination -->
+    <div class="canon-pagination">
+      {page > 1 && (
+        <a href={`/canon?tab=${tab}&page=${page - 1}${q ? `&q=${encodeURIComponent(q)}` : ''}${fandom ? `&fandom=${encodeURIComponent(fandom)}` : ''}${category ? `&category=${encodeURIComponent(category)}` : ''}`} class="m3-btn-outlined">← Previous</a>
+      )}
+      {entries.length === limit && (
+        <a href={`/canon?tab=${tab}&page=${page + 1}${q ? `&q=${encodeURIComponent(q)}` : ''}${fandom ? `&fandom=${encodeURIComponent(fandom)}` : ''}${category ? `&category=${encodeURIComponent(category)}` : ''}`} class="m3-btn-outlined">Next →</a>
+      )}
+    </div>
+
+    <!-- Create New FAB -->
+    {auth && (
+      <a href={tab === 'lore' ? '/canon/lore/new' : '/canon/locations/new'} class="canon-fab" aria-label="Create New">
+        +
+      </a>
+    )}
+  </section>
+</Base>
+
+<style is:global>
+  @import '../../styles/theme.css';
+
+  .canon-browse { max-width: 1100px; margin: 0 auto; }
+
+  .page-title {
+    font: var(--md-sys-typescale-headline-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-4);
+  }
+
+  /* Tab bar */
+  .canon-tabs {
+    display: flex;
+    gap: var(--space-1);
+    margin-bottom: var(--space-4);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  }
+  .canon-tab {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    padding: var(--space-2) var(--space-4);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    transition: border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .canon-tab:hover {
+    background: var(--md-sys-color-surface-container-highest);
+    text-decoration: none;
+  }
+  .canon-tab--active {
+    color: var(--md-sys-color-primary);
+    border-bottom-color: var(--md-sys-color-primary);
+  }
+
+  /* Filters */
+  .canon-filters {
+    margin-bottom: var(--space-4);
+  }
+  .canon-search-form {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+  }
+  .canon-search-input {
+    flex: 1;
+  }
+  .canon-filter-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+  .canon-filter-select {
+    min-width: 160px;
+  }
+  .canon-category-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
+
+  /* Grid */
+  .canon-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: var(--space-4);
+  }
+
+  .placeholder-text {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-outline);
+    font-style: italic;
+  }
+  .empty-state { grid-column: 1 / -1; text-align: center; padding: var(--space-8) 0; }
+
+  /* Card */
+  .canon-card {
+    display: block;
+    padding: var(--space-4);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .canon-card:hover {
+    background: var(--md-sys-color-surface-container-high);
+    text-decoration: none;
+  }
+  .canon-card__title {
+    font: var(--md-sys-typescale-title-medium);
+    color: var(--md-sys-color-primary);
+    margin: 0 0 var(--space-2);
+  }
+  .canon-card__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    margin-bottom: var(--space-2);
+  }
+  .canon-badge {
+    font-size: 0.75rem;
+  }
+  .canon-badge--category {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+  }
+  .canon-card__snippet {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .canon-card__works {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+  }
+
+  /* Pagination */
+  .canon-pagination {
+    display: flex;
+    gap: var(--space-3);
+    margin-top: var(--space-6);
+  }
+
+  /* FAB */
+  .canon-fab {
+    position: fixed;
+    bottom: calc(var(--space-6) + env(safe-area-inset-bottom));
+    right: var(--space-6);
+    width: 56px;
+    height: 56px;
+    border-radius: var(--md-sys-shape-corner-full);
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    font: var(--md-sys-typescale-headline-small);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    box-shadow: var(--md-sys-elevation-3);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    z-index: 50;
+  }
+  .canon-fab:hover {
+    background: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+    text-decoration: none;
+  }
+
+  /* Reusable M3 helpers */
+  .m3-btn-outlined {
+    display: inline-block;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .m3-btn-icon {
+    background: none;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-full);
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.1rem;
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .m3-input {
+    width: 100%;
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-3) var(--space-4);
+    font: var(--md-sys-typescale-body-large);
+  }
+  .m3-input:focus {
+    outline: none;
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+  }
+  .m3-select {
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-2) var(--space-3);
+    font: var(--md-sys-typescale-body-medium);
+  }
+  .m3-chip {
+    font: var(--md-sys-typescale-label-small);
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+    padding: 4px var(--space-3);
+    border-radius: var(--md-sys-shape-corner-full);
+    text-decoration: none;
+    display: inline-block;
+  }
+  .m3-chip:hover { text-decoration: none; }
+  .m3-chip--selected {
+    background: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+  }
+</style>
+
+<script>
+  // Populate fandom filter dropdown from API
+  (async () => {
+    const select = document.getElementById('fandom-filter') as HTMLSelectElement | null;
+    if (!select) return;
+
+    // Preserve current value from URL
+    const params = new URLSearchParams(window.location.search);
+    const currentFandom = params.get('fandom') || '';
+
+    try {
+      const res = await fetch('/api/tags?type=fandom');
+      if (!res.ok) return;
+      const tags = await res.json();
+      for (const tag of tags) {
+        const opt = document.createElement('option');
+        opt.value = tag.name;
+        opt.textContent = tag.name;
+        if (tag.name === currentFandom) opt.selected = true;
+        select.appendChild(opt);
+      }
+    } catch {
+      // Silently fail — dropdown stays with default "All Fandoms"
+    }
+
+    // Auto-submit on change
+    select.addEventListener('change', () => {
+      const url = new URL(window.location.href);
+      if (select.value) {
+        url.searchParams.set('fandom', select.value);
+      } else {
+        url.searchParams.delete('fandom');
+      }
+      url.searchParams.delete('page');
+      window.location.href = url.toString();
+    });
+  })();
+</script>

--- a/src/pages/canon/locations/[id].astro
+++ b/src/pages/canon/locations/[id].astro
@@ -1,0 +1,328 @@
+---
+export const prerender = false;
+import Base from '../../../layouts/Base.astro';
+import { markdownToHtml } from '../../../lib/markdown';
+import { getAuth } from '../../../lib/auth';
+import { queryFirst, queryAll } from '../../../lib/db';
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+const auth = await getAuth(db, Astro.request);
+
+const id = Astro.params.id;
+if (!id) return Astro.redirect('/canon?tab=locations');
+
+let location: any = null;
+let parentLocation: any = null;
+let childLocations: any[] = [];
+let works: any[] = [];
+let editHistory: any[] = [];
+
+try {
+  location = await queryFirst<any>(db,
+    `SELECT * FROM canon_locations WHERE id = ?1`,
+    Number(id)
+  );
+} catch {
+  // Table may not exist
+}
+
+if (!location) return Astro.redirect('/canon?tab=locations');
+
+// Parent location
+if (location.parent_id) {
+  try {
+    parentLocation = await queryFirst<any>(db,
+      `SELECT id, name FROM canon_locations WHERE id = ?1`,
+      location.parent_id
+    );
+  } catch {
+    parentLocation = null;
+  }
+}
+
+// Child locations
+try {
+  childLocations = await queryAll<any>(db,
+    `SELECT id, name FROM canon_locations WHERE parent_id = ?1 ORDER BY name`,
+    location.id
+  );
+} catch {
+  childLocations = [];
+}
+
+// Works referencing
+try {
+  works = await queryAll<any>(db,
+    `SELECT w.id, w.title, w.word_count, w.updated_at,
+            (SELECT GROUP_CONCAT(p.name, ', ') FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = w.id) as authors
+     FROM works w
+     JOIN canon_refs cr ON cr.work_id = w.id
+     WHERE cr.location_id = ?1
+     ORDER BY w.updated_at DESC
+     LIMIT 20`,
+    location.id
+  );
+} catch {
+  works = [];
+}
+
+// Edit history
+try {
+  editHistory = await queryAll<any>(db,
+    `SELECT * FROM canon_edits WHERE location_id = ?1 ORDER BY created_at DESC LIMIT 20`,
+    location.id
+  );
+} catch {
+  editHistory = [];
+}
+
+const descHtml = markdownToHtml(location.description_md || '');
+const canEdit = auth && (auth.user.id === location.user_id || ['admin', 'mod', 'founder'].includes(auth.user.role));
+---
+
+<Base title={`${location.name} — Canon`}>
+  <section class="location-detail">
+    <article class="location-article">
+      <h1 class="page-title">{location.name}</h1>
+
+      <div class="location-badges">
+        {location.fandom && <span class="m3-chip location-badge location-badge--fandom">{location.fandom}</span>}
+      </div>
+
+      <!-- Parent location breadcrumb -->
+      {parentLocation && (
+        <nav class="location-breadcrumb">
+          <span class="breadcrumb-label">Part of</span>
+          <a href={`/canon/locations/${parentLocation.id}`} class="breadcrumb-link">{parentLocation.name}</a>
+        </nav>
+      )}
+
+      <!-- Child locations -->
+      {childLocations.length > 0 && (
+        <div class="location-children">
+          <h2 class="section-title">Sub-locations</h2>
+          <ul class="children-list">
+            {childLocations.map(child => (
+              <li>
+                <a href={`/canon/locations/${child.id}`} class="child-link">{child.name}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <!-- Description -->
+      {location.description_md && (
+        <div class="location-desc prose" set:html={descHtml} />
+      )}
+
+      {canEdit && (
+        <a href={`/canon/locations/${location.id}/edit`} class="m3-btn-filled location-edit-btn">Edit Location</a>
+      )}
+    </article>
+
+    <!-- Works referencing -->
+    {works.length > 0 && (
+      <section class="location-works">
+        <h2 class="section-title">Works Referencing</h2>
+        <div class="works-list">
+          {works.map(w => (
+            <a href={`/works/${w.id}`} class="work-ref-card">
+              <span class="work-ref__title">{w.title}</span>
+              <span class="work-ref__meta">
+                {w.authors && <Fragment>by {w.authors} · </Fragment>}
+                {Number(w.word_count).toLocaleString()} words
+              </span>
+            </a>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Edit History -->
+    {editHistory.length > 0 && (
+      <section class="location-history">
+        <h2 class="section-title">Edit History</h2>
+        <ol class="edit-timeline">
+          {editHistory.map(edit => (
+            <li class="edit-timeline__item">
+              <span class="edit-timeline__date">{new Date(edit.created_at).toLocaleDateString()}</span>
+              <span class="edit-timeline__desc">{edit.description || 'Updated location'}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+    )}
+  </section>
+</Base>
+
+<style is:global>
+  @import '../../../styles/theme.css';
+
+  .location-detail { max-width: 800px; margin: 0 auto; }
+
+  .page-title {
+    font: var(--md-sys-typescale-headline-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-3);
+  }
+
+  .location-badges {
+    display: flex;
+    gap: var(--space-1);
+    margin-bottom: var(--space-4);
+  }
+  .location-badge--fandom {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  /* Breadcrumb */
+  .location-breadcrumb {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin-bottom: var(--space-4);
+  }
+  .breadcrumb-label { margin-right: var(--space-1); }
+  .breadcrumb-link {
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+  }
+  .breadcrumb-link:hover { text-decoration: underline; }
+
+  /* Children */
+  .location-children {
+    margin-bottom: var(--space-6);
+  }
+  .children-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+  .child-link {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-1) var(--space-4);
+    text-decoration: none;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .child-link:hover {
+    background: var(--md-sys-color-surface-container-high);
+    text-decoration: none;
+  }
+
+  /* Description */
+  .location-desc {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface);
+    line-height: 1.75;
+  }
+  .location-desc p { margin: 0 0 var(--space-4); }
+  .location-desc h2 {
+    font: var(--md-sys-typescale-title-large);
+    margin: var(--space-6) 0 var(--space-2);
+  }
+
+  .location-edit-btn { display: inline-block; margin-top: var(--space-6); }
+
+  .m3-btn-filled {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .m3-btn-filled:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    text-decoration: none;
+  }
+
+  /* Sections */
+  .section-title {
+    font: var(--md-sys-typescale-title-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: var(--space-8) 0 var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  }
+  .works-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+  .work-ref-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: var(--space-3) var(--space-4);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .work-ref-card:hover {
+    background: var(--md-sys-color-surface-container-high);
+    text-decoration: none;
+  }
+  .work-ref__title {
+    font: var(--md-sys-typescale-title-small);
+    color: var(--md-sys-color-primary);
+  }
+  .work-ref__meta {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+  }
+
+  /* Edit History */
+  .edit-timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .edit-timeline__item {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-2) 0;
+    border-left: 2px solid var(--md-sys-color-outline-variant);
+    padding-left: var(--space-4);
+    position: relative;
+  }
+  .edit-timeline__item::before {
+    content: '';
+    position: absolute;
+    left: -5px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--md-sys-color-primary);
+  }
+  .edit-timeline__date {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+    white-space: nowrap;
+  }
+  .edit-timeline__desc {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .m3-chip {
+    font: var(--md-sys-typescale-label-small);
+    padding: 4px var(--space-3);
+    border-radius: var(--md-sys-shape-corner-full);
+  }
+</style>

--- a/src/pages/canon/locations/new.astro
+++ b/src/pages/canon/locations/new.astro
@@ -1,0 +1,310 @@
+---
+export const prerender = false;
+import Base from '../../../layouts/Base.astro';
+import { getAuth } from '../../../lib/auth';
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+const auth = await getAuth(db, Astro.request);
+
+if (!auth) return Astro.redirect('/login');
+---
+
+<Base title="New Location — fanfiction.fyi">
+  <section class="location-new">
+    <h1 class="page-title">Create Location</h1>
+    <p class="page-subtitle">Add a new location to the Canon Layer atlas.</p>
+
+    <form id="location-form" class="form-stack">
+      <div class="m3-card">
+        <h2 class="m3-card-title">Details</h2>
+        <div class="form-stack" style="gap: var(--space-4)">
+          <div class="m3-form-field">
+            <label for="name">Name <span class="required">*</span></label>
+            <input type="text" id="name" name="name" required placeholder="e.g. Paris" class="m3-input" />
+          </div>
+
+          <div class="m3-form-field">
+            <label for="description">Description (Markdown)</label>
+            <textarea id="description" name="description_md" rows="12" placeholder="Describe this location in Markdown. Use [[:Location:Other Place]] for wiki-links.\n\ne.g. Located near [[:Location:London]], this city…" class="m3-textarea"></textarea>
+          </div>
+
+          <div class="m3-form-field">
+            <label for="fandom">Fandom <span class="required">*</span></label>
+            <div class="fandom-autocomplete-wrap">
+              <input type="text" id="fandom" name="fandom" required placeholder="Start typing a fandom…" class="m3-input" autocomplete="off" />
+              <ul id="fandom-suggestions" class="autocomplete-list" role="listbox"></ul>
+              <input type="hidden" id="fandom-value" name="fandom_value" />
+            </div>
+          </div>
+
+          <div class="m3-form-field">
+            <label for="parent">Parent Location</label>
+            <div class="parent-autocomplete-wrap">
+              <input type="text" id="parent" name="parent" placeholder="Search for a parent location…" class="m3-input" autocomplete="off" />
+              <ul id="parent-suggestions" class="autocomplete-list" role="listbox"></ul>
+              <input type="hidden" id="parent-id" name="parent_id" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <a href="/canon?tab=locations" class="m3-btn-outlined">Cancel</a>
+        <button type="submit" class="m3-btn-filled" id="submit-btn">Create Location</button>
+      </div>
+
+      <div id="form-error" class="form-error" role="alert"></div>
+    </form>
+  </section>
+</Base>
+
+<style is:global>
+  @import '../../../styles/theme.css';
+
+  .location-new { max-width: 700px; margin: 0 auto; }
+
+  .page-title {
+    font: var(--md-sys-typescale-headline-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-1);
+  }
+  .page-subtitle {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-6);
+  }
+  .required { color: var(--md-sys-color-error); }
+
+  .m3-card {
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    padding: var(--space-6);
+  }
+  .m3-card-title {
+    font: var(--md-sys-typescale-title-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-4);
+  }
+
+  .form-stack { display: flex; flex-direction: column; gap: var(--space-4); }
+  .m3-form-field { display: flex; flex-direction: column; gap: var(--space-1); }
+  .m3-form-field label {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .m3-input {
+    width: 100%;
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-3) var(--space-4);
+    font: var(--md-sys-typescale-body-large);
+  }
+  .m3-input:focus {
+    outline: none;
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+  }
+  .m3-textarea {
+    width: 100%;
+    min-height: 200px;
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-3) var(--space-4);
+    font: var(--md-sys-typescale-body-large);
+    font-family: var(--font-mono, monospace);
+    resize: vertical;
+  }
+  .m3-textarea:focus {
+    outline: none;
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+  }
+  .form-error {
+    color: var(--md-sys-color-error);
+    font: var(--md-sys-typescale-body-small);
+  }
+
+  .m3-btn-filled {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+  }
+  .m3-btn-filled:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+  .m3-btn-outlined {
+    display: inline-block;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  /* Autocomplete */
+  .fandom-autocomplete-wrap,
+  .parent-autocomplete-wrap {
+    position: relative;
+  }
+  .autocomplete-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background: var(--md-sys-color-surface-container-high);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    max-height: 200px;
+    overflow-y: auto;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: none;
+  }
+  .autocomplete-list--visible { display: block; }
+  .autocomplete-list li {
+    padding: var(--space-2) var(--space-4);
+    cursor: pointer;
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+  }
+  .autocomplete-list li:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+</style>
+
+<script>
+  const form = document.getElementById('location-form') as HTMLFormElement;
+  const errorEl = document.getElementById('form-error')!;
+  const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement;
+  const fandomInput = document.getElementById('fandom') as HTMLInputElement;
+  const fandomSuggestions = document.getElementById('fandom-suggestions') as HTMLUListElement;
+  const parentInput = document.getElementById('parent') as HTMLInputElement;
+  const parentHidden = document.getElementById('parent-id') as HTMLInputElement;
+  const parentSuggestions = document.getElementById('parent-suggestions') as HTMLUListElement;
+
+  let debounceTimer: ReturnType<typeof setTimeout>;
+
+  // Generic autocomplete helper
+  function setupAutocomplete(
+    input: HTMLInputElement,
+    suggestionsEl: HTMLUListElement,
+    fetchUrl: (q: string) => string,
+    onSelect: (item: any) => void
+  ) {
+    input.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      const query = input.value.trim();
+      if (!query) {
+        suggestionsEl.classList.remove('autocomplete-list--visible');
+        return;
+      }
+      debounceTimer = setTimeout(async () => {
+        try {
+          const res = await fetch(fetchUrl(query));
+          if (!res.ok) return;
+          const items = await res.json();
+          suggestionsEl.innerHTML = '';
+          for (const item of items.slice(0, 10)) {
+            const li = document.createElement('li');
+            li.textContent = item.name || item.tag || item;
+            li.setAttribute('role', 'option');
+            li.addEventListener('click', () => {
+              onSelect(item);
+              suggestionsEl.classList.remove('autocomplete-list--visible');
+            });
+            suggestionsEl.appendChild(li);
+          }
+          suggestionsEl.classList.toggle('autocomplete-list--visible', items.length > 0);
+        } catch {
+          suggestionsEl.classList.remove('autocomplete-list--visible');
+        }
+      }, 300);
+    });
+
+    input.addEventListener('blur', () => {
+      setTimeout(() => suggestionsEl.classList.remove('autocomplete-list--visible'), 200);
+    });
+  }
+
+  // Fandom autocomplete
+  setupAutocomplete(
+    fandomInput,
+    fandomSuggestions,
+    (q) => `/api/tags?type=fandom&q=${encodeURIComponent(q)}`,
+    (tag) => { fandomInput.value = tag.name; }
+  );
+
+  // Parent location autocomplete (filtered by same fandom)
+  setupAutocomplete(
+    parentInput,
+    parentSuggestions,
+    (q) => `/api/canon/locations?q=${encodeURIComponent(q)}&fandom=${encodeURIComponent(fandomInput.value)}`,
+    (loc) => {
+      parentInput.value = loc.name;
+      parentHidden.value = loc.id;
+    }
+  );
+
+  // Form submission
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    errorEl.textContent = '';
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Creating…';
+
+    const name = (document.getElementById('name') as HTMLInputElement).value;
+    const descriptionMd = (document.getElementById('description') as HTMLTextAreaElement).value;
+    const fandom = fandomInput.value;
+    const parentId = parentHidden.value ? Number(parentHidden.value) : null;
+
+    if (!name || !fandom) {
+      errorEl.textContent = 'Name and fandom are required.';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Create Location';
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/canon/locations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, fandom, description_md: descriptionMd || null, parent_id: parentId }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        window.location.href = `/canon/locations/${data.id}`;
+      } else {
+        const data = await res.json();
+        errorEl.textContent = data.error || 'Failed to create location';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Create Location';
+      }
+    } catch {
+      errorEl.textContent = 'Network error — please try again';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Create Location';
+    }
+  });
+</script>

--- a/src/pages/canon/lore/[id].astro
+++ b/src/pages/canon/lore/[id].astro
@@ -1,0 +1,254 @@
+---
+export const prerender = false;
+import Base from '../../../layouts/Base.astro';
+import { markdownToHtml } from '../../../lib/markdown';
+import { getAuth } from '../../../lib/auth';
+import { queryFirst, queryAll } from '../../../lib/db';
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+const auth = await getAuth(db, Astro.request);
+
+const id = Astro.params.id;
+if (!id) return Astro.redirect('/canon');
+
+let entry: any = null;
+let works: any[] = [];
+let editHistory: any[] = [];
+
+try {
+  entry = await queryFirst<any>(db,
+    `SELECT * FROM canon_lore WHERE id = ?1`,
+    Number(id)
+  );
+} catch {
+  // Table may not exist
+}
+
+if (!entry) return Astro.redirect('/canon');
+
+// Fetch works referencing this lore entry
+try {
+  works = await queryAll<any>(db,
+    `SELECT w.id, w.title, w.word_count, w.updated_at,
+            (SELECT GROUP_CONCAT(p.name, ', ') FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = w.id) as authors
+     FROM works w
+     JOIN canon_refs cr ON cr.work_id = w.id
+     WHERE cr.lore_id = ?1
+     ORDER BY w.updated_at DESC
+     LIMIT 20`,
+    entry.id
+  );
+} catch {
+  works = [];
+}
+
+// Fetch edit history
+try {
+  editHistory = await queryAll<any>(db,
+    `SELECT * FROM canon_edits WHERE lore_id = ?1 ORDER BY created_at DESC LIMIT 20`,
+    entry.id
+  );
+} catch {
+  editHistory = [];
+}
+
+const bodyHtml = markdownToHtml(entry.body_md || '');
+const canEdit = auth && (auth.user.id === entry.user_id || ['admin', 'mod', 'founder'].includes(auth.user.role));
+---
+
+<Base title={`${entry.title} — Canon`}>
+  <section class="lore-detail">
+    <article class="lore-article">
+      <h1 class="page-title">{entry.title}</h1>
+
+      <div class="lore-badges">
+        {entry.fandom && <span class="m3-chip lore-badge lore-badge--fandom">{entry.fandom}</span>}
+        {entry.category && <span class="m3-chip lore-badge lore-badge--category">{entry.category}</span>}
+      </div>
+
+      <div class="lore-body prose" set:html={bodyHtml} />
+
+      {canEdit && (
+        <a href={`/canon/lore/${entry.id}/edit`} class="m3-btn-filled lore-edit-btn">Edit Entry</a>
+      )}
+    </article>
+
+    <!-- Works referencing -->
+    {works.length > 0 && (
+      <section class="lore-works">
+        <h2 class="section-title">Works Referencing</h2>
+        <div class="works-list">
+          {works.map(w => (
+            <a href={`/works/${w.id}`} class="work-ref-card">
+              <span class="work-ref__title">{w.title}</span>
+              <span class="work-ref__meta">
+                {w.authors && <Fragment>by {w.authors} · </Fragment>}
+                {Number(w.word_count).toLocaleString()} words
+              </span>
+            </a>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Edit History -->
+    {editHistory.length > 0 && (
+      <section class="lore-history">
+        <h2 class="section-title">Edit History</h2>
+        <ol class="edit-timeline">
+          {editHistory.map(edit => (
+            <li class="edit-timeline__item">
+              <span class="edit-timeline__date">{new Date(edit.created_at).toLocaleDateString()}</span>
+              <span class="edit-timeline__desc">{edit.description || 'Updated entry'}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+    )}
+  </section>
+</Base>
+
+<style is:global>
+  @import '../../../styles/theme.css';
+
+  .lore-detail { max-width: 800px; margin: 0 auto; }
+
+  .page-title {
+    font: var(--md-sys-typescale-headline-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-3);
+  }
+
+  .lore-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    margin-bottom: var(--space-6);
+  }
+  .lore-badge--fandom {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+  .lore-badge--category {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+  }
+
+  .lore-body {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface);
+    line-height: 1.75;
+  }
+  .lore-body p { margin: 0 0 var(--space-4); }
+  .lore-body h2 {
+    font: var(--md-sys-typescale-title-large);
+    color: var(--md-sys-color-on-surface);
+    margin: var(--space-6) 0 var(--space-2);
+  }
+  .lore-body h3 {
+    font: var(--md-sys-typescale-title-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: var(--space-4) 0 var(--space-2);
+  }
+
+  .lore-edit-btn {
+    display: inline-block;
+    margin-top: var(--space-6);
+  }
+
+  .m3-btn-filled {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .m3-btn-filled:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    text-decoration: none;
+  }
+
+  /* Works Referencing */
+  .section-title {
+    font: var(--md-sys-typescale-title-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: var(--space-8) 0 var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  }
+  .works-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+  .work-ref-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: var(--space-3) var(--space-4);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .work-ref-card:hover {
+    background: var(--md-sys-color-surface-container-high);
+    text-decoration: none;
+  }
+  .work-ref__title {
+    font: var(--md-sys-typescale-title-small);
+    color: var(--md-sys-color-primary);
+  }
+  .work-ref__meta {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+  }
+
+  /* Edit History */
+  .edit-timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .edit-timeline__item {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-2) 0;
+    border-left: 2px solid var(--md-sys-color-outline-variant);
+    padding-left: var(--space-4);
+    position: relative;
+  }
+  .edit-timeline__item::before {
+    content: '';
+    position: absolute;
+    left: -5px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--md-sys-color-primary);
+  }
+  .edit-timeline__date {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+    white-space: nowrap;
+  }
+  .edit-timeline__desc {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .m3-chip {
+    font: var(--md-sys-typescale-label-small);
+    padding: 4px var(--space-3);
+    border-radius: var(--md-sys-shape-corner-full);
+  }
+</style>

--- a/src/pages/canon/lore/new.astro
+++ b/src/pages/canon/lore/new.astro
@@ -1,0 +1,301 @@
+---
+export const prerender = false;
+import Base from '../../../layouts/Base.astro';
+import { getAuth } from '../../../lib/auth';
+
+const db = Astro.locals.runtime.env.DB as D1Database;
+const auth = await getAuth(db, Astro.request);
+
+if (!auth) return Astro.redirect('/login');
+
+const LORE_CATEGORIES = [
+  'Worldbuilding', 'Magic System', 'Technology', 'History',
+  'Culture', 'Species', 'Religion', 'Politics', 'Other'
+];
+---
+
+<Base title="New Lore Entry — fanfiction.fyi">
+  <section class="lore-new">
+    <h1 class="page-title">Create Lore Entry</h1>
+    <p class="page-subtitle">Add a new entry to the Canon Layer knowledge base.</p>
+
+    <form id="lore-form" class="form-stack">
+      <div class="m3-card">
+        <h2 class="m3-card-title">Details</h2>
+        <div class="form-stack" style="gap: var(--space-4)">
+          <div class="m3-form-field">
+            <label for="title">Title <span class="required">*</span></label>
+            <input type="text" id="title" name="title" required placeholder="e.g. Magic System" class="m3-input" />
+          </div>
+
+          <div class="m3-form-field">
+            <label for="category">Category <span class="required">*</span></label>
+            <select id="category" name="category" required class="m3-select">
+              <option value="">Select a category</option>
+              {LORE_CATEGORIES.map(cat => (
+                <option value={cat}>{cat}</option>
+              ))}
+            </select>
+          </div>
+
+          <div class="m3-form-field">
+            <label for="fandom">Fandom <span class="required">*</span></label>
+            <div class="fandom-autocomplete-wrap">
+              <input type="text" id="fandom" name="fandom" required placeholder="Start typing a fandom…" class="m3-input" autocomplete="off" />
+              <ul id="fandom-suggestions" class="autocomplete-list" role="listbox"></ul>
+              <input type="hidden" id="fandom-value" name="fandom_value" />
+            </div>
+          </div>
+
+          <div class="m3-form-field">
+            <label for="body">Body (Markdown)</label>
+            <textarea id="body" name="body_md" rows="12" placeholder="Write the lore entry in Markdown. Use [[:Name]] for wiki-links.\n\ne.g. The [[:Magic System]] allows…" class="m3-textarea"></textarea>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <a href="/canon" class="m3-btn-outlined">Cancel</a>
+        <button type="submit" class="m3-btn-filled" id="submit-btn">Create Entry</button>
+      </div>
+
+      <div id="form-error" class="form-error" role="alert"></div>
+    </form>
+  </section>
+</Base>
+
+<style is:global>
+  @import '../../../styles/theme.css';
+
+  .lore-new { max-width: 700px; margin: 0 auto; }
+
+  .page-title {
+    font: var(--md-sys-typescale-headline-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-1);
+  }
+  .page-subtitle {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-6);
+  }
+  .required { color: var(--md-sys-color-error); }
+
+  .m3-card {
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    padding: var(--space-6);
+  }
+  .m3-card-title {
+    font: var(--md-sys-typescale-title-large);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-4);
+  }
+
+  .form-stack { display: flex; flex-direction: column; gap: var(--space-4); }
+  .m3-form-field { display: flex; flex-direction: column; gap: var(--space-1); }
+  .m3-form-field label {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .m3-input {
+    width: 100%;
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-3) var(--space-4);
+    font: var(--md-sys-typescale-body-large);
+  }
+  .m3-input:focus {
+    outline: none;
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+  }
+  .m3-select {
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-2) var(--space-3);
+    font: var(--md-sys-typescale-body-medium);
+  }
+  .m3-textarea {
+    width: 100%;
+    min-height: 200px;
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-3) var(--space-4);
+    font: var(--md-sys-typescale-body-large);
+    font-family: var(--font-mono, monospace);
+    resize: vertical;
+  }
+  .m3-textarea:focus {
+    outline: none;
+    border-color: var(--md-sys-color-primary);
+    box-shadow: 0 0 0 1px var(--md-sys-color-primary);
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+  }
+  .form-error {
+    color: var(--md-sys-color-error);
+    font: var(--md-sys-typescale-body-small);
+  }
+
+  .m3-btn-filled {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+  }
+  .m3-btn-filled:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+  .m3-btn-outlined {
+    display: inline-block;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-2) var(--space-6);
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  /* Autocomplete */
+  .fandom-autocomplete-wrap {
+    position: relative;
+  }
+  .autocomplete-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background: var(--md-sys-color-surface-container-high);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    max-height: 200px;
+    overflow-y: auto;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: none;
+  }
+  .autocomplete-list--visible { display: block; }
+  .autocomplete-list li {
+    padding: var(--space-2) var(--space-4);
+    cursor: pointer;
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+  }
+  .autocomplete-list li:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+</style>
+
+<script>
+  const form = document.getElementById('lore-form') as HTMLFormElement;
+  const errorEl = document.getElementById('form-error')!;
+  const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement;
+  const fandomInput = document.getElementById('fandom') as HTMLInputElement;
+  const fandomHidden = document.getElementById('fandom-value') as HTMLInputElement;
+  const fandomSuggestions = document.getElementById('fandom-suggestions') as HTMLUListElement;
+
+  let debounceTimer: ReturnType<typeof setTimeout>;
+
+  // Fandom autocomplete
+  fandomInput.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    const query = fandomInput.value.trim();
+    if (!query) {
+      fandomSuggestions.classList.remove('autocomplete-list--visible');
+      return;
+    }
+    debounceTimer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/tags?type=fandom&q=${encodeURIComponent(query)}`);
+        if (!res.ok) return;
+        const tags = await res.json();
+        fandomSuggestions.innerHTML = '';
+        for (const tag of tags.slice(0, 10)) {
+          const li = document.createElement('li');
+          li.textContent = tag.name;
+          li.setAttribute('role', 'option');
+          li.addEventListener('click', () => {
+            fandomInput.value = tag.name;
+            fandomHidden.value = tag.name;
+            fandomSuggestions.classList.remove('autocomplete-list--visible');
+          });
+          fandomSuggestions.appendChild(li);
+        }
+        if (tags.length > 0) {
+          fandomSuggestions.classList.add('autocomplete-list--visible');
+        } else {
+          fandomSuggestions.classList.remove('autocomplete-list--visible');
+        }
+      } catch {
+        fandomSuggestions.classList.remove('autocomplete-list--visible');
+      }
+    }, 300);
+  });
+
+  // Close autocomplete on blur
+  fandomInput.addEventListener('blur', () => {
+    setTimeout(() => fandomSuggestions.classList.remove('autocomplete-list--visible'), 200);
+  });
+
+  // Form submission
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    errorEl.textContent = '';
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Creating…';
+
+    const title = (document.getElementById('title') as HTMLInputElement).value;
+    const category = (document.getElementById('category') as HTMLSelectElement).value;
+    const fandom = fandomInput.value;
+    const bodyMd = (document.getElementById('body') as HTMLTextAreaElement).value;
+
+    if (!title || !category || !fandom) {
+      errorEl.textContent = 'Title, category, and fandom are required.';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Create Entry';
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/canon/lore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, category, fandom, body_md: bodyMd || null }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        window.location.href = `/canon/lore/${data.id}`;
+      } else {
+        const data = await res.json();
+        errorEl.textContent = data.error || 'Failed to create lore entry';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Create Entry';
+      }
+    } catch {
+      errorEl.textContent = 'Network error — please try again';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Create Entry';
+    }
+  });
+</script>


### PR DESCRIPTION
## Canon Layer — Collaborative Worldbuilding Wiki

Implements #19 — Characters, locations, and lore entries as first-class citizens.

### What's New

**Schema (migration 017):**
- `lore_entries` — Wiki-style entries scoped to fandoms with 9 categories (general, magic, history, organization, concept, item, event, culture, species)
- `locations` — Nested locations with parent-child hierarchy (Paris → France → Europe)
- `entity_references` — Generic join table linking character/lore/location entities to works
- `lore_edits` / `location_edits` — Edit history tracking (AO3-style tag wrangling for lore)
- `lore_entries_fts` / `locations_fts` — FTS5 search with auto-sync triggers
- All tables applied to remote D1 ✅

**API Routes (7 endpoints):**
- `GET/POST /api/canon/lore` — Browse/search (FTS5) and create lore entries
- `GET/PUT/DELETE /api/canon/lore/[id]` — Read/update/delete single lore entry
- `GET /api/canon/lore/[id]/history` — Edit history timeline
- `GET/POST /api/canon/locations` — Browse/search and create locations
- `GET/PUT/DELETE /api/canon/locations/[id]` — Read/update/delete location
- `GET /api/canon/locations/[id]/history` — Location edit history
- `GET/POST/DELETE /api/canon/references` — Cross-reference works ↔ entities

**Wiki-Link Syntax:**
- `[[:Character Name]]` → auto-links to canon search
- `[[:Location:Paris]]` → location-specific links
- `[[:Lore:Magic System]]` → explicit lore links
- Parsed in `src/lib/wiki-links.ts`, integrated into `markdownToHtml()` pipeline

**Frontend Pages (5 pages):**
- `/canon` — Browse page with Lore/Locations/Characters tabs, search, fandom filter, category chips
- `/canon/lore/[id]` — Lore detail with wiki content, works referencing, edit history
- `/canon/lore/new` — Create lore entry form
- `/canon/locations/[id]` — Location detail with parent breadcrumb, children, works referencing
- `/canon/locations/new` — Create location form

### Acceptance Criteria Progress

- [x] Lore and location browse/search pages
- [x] Detail pages with wiki-style content and cross-references
- [x] Inline wiki-link syntax in chapter Markdown (`[[:Name]]`, `[[:Location:Paris]]`, `[[:Lore:Magic]]`)
- [x] "Works referencing" section on entity pages
- [x] Fandom-scoped browsing (filter by fandom tag)

### Design Decisions

- **Slug-based URLs** for canon entities (SEO-friendly, stable)
- **Edit history** for lore and locations (audit trail with pseud attribution)
- **Generic entity_references** table works for characters, lore, and locations — scales to future entity types
- **character_appearances** bridge: creating an entity_reference with `entity_type='character'` also upserts into `character_appearances` for backwards compatibility
- **FTS5** with porter + unicode61 tokenizer for canon search