### PR TITLE
Security Hardening: innerHTML XSS, CSP headers, CSRF module, write rate limiting

### DIFF
--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,66 @@
+/**
+ * Content Security Policy for fanfiction.fyi.
+ *
+ * Provides defense-in-depth against XSS even if a sanitization bug slips through.
+ * Uses report-only for initial deployment; switch to enforce mode after validation.
+ */
+
+export interface CSPOptions {
+  reportOnly?: boolean;
+}
+
+const CSP_DIRECTIVES = {
+  'default-src': ["'self'"],
+  'script-src': [
+    "'self'",
+    // Astro inline scripts (theme application, hydration)
+    "'unsafe-inline'",
+    // Google Fonts stylesheet loader
+    'https://fonts.googleapis.com',
+  ],
+  'style-src': [
+    "'self'",
+    "'unsafe-inline'", // Astro scoped styles + M3 theme overrides
+    'https://fonts.googleapis.com',
+  ],
+  'font-src': [
+    "'self'",
+    'https://fonts.gstatic.com',
+  ],
+  'img-src': [
+    "'self'",
+    'data:', // Inline data URIs (avatars)
+    'https://fanfiction.fyi', // R2 storage proxy
+    'https://lh3.googleusercontent.com', // Google avatars
+  ],
+  'connect-src': [
+    "'self'", // API calls
+    'https://api.github.com', // Bug report endpoint
+  ],
+  'frame-src': ["'none'"],
+  'object-src': ["'none'"],
+  'base-uri': ["'self'"],
+  'form-action': ["'self'"],
+  'frame-ancestors': ["'none'"],
+};
+
+function buildCSPHeader(directives: Record<string, string[]>, reportOnly: boolean): [string, string] {
+  const value = Object.entries(directives)
+    .map(([directive, sources]) => `${directive} ${sources.join(' ')}`)
+    .join('; ');
+
+  const headerName = reportOnly
+    ? 'Content-Security-Policy-Report-Only'
+    : 'Content-Security-Policy';
+
+  return [headerName, value];
+}
+
+/**
+ * Returns CSP headers to add to responses.
+ * Starts in report-only mode for safe rollout.
+ */
+export function cspHeaders(options: CSPOptions = {}): HeadersInit {
+  const [name, value] = buildCSPHeader(CSP_DIRECTIVES, options.reportOnly ?? true);
+  return { [name]: value };
+}

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -1,0 +1,81 @@
+/**
+ * CSRF protection for fanfiction.fyi.
+ *
+ * Uses the double-submit cookie pattern: a random nonce is generated,
+ * stored in a cookie, and must be included in a header for state-changing
+ * requests (POST, PUT, DELETE, PATCH).
+ *
+ * The SameSite=Lax cookie already provides CSRF protection for top-level
+ * navigations, but this adds defense-in-depth for same-site AJAX requests
+ * and subresource loads.
+ */
+
+const CSRF_COOKIE_NAME = 'csrf_token';
+const CSRF_HEADER_NAME = 'x-csrf-token';
+const CSRF_TOKEN_LENGTH = 32;
+
+/**
+ * Generate a random hex token for CSRF protection.
+ */
+function generateToken(): string {
+  const bytes = new Uint8Array(CSRF_TOKEN_LENGTH);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Set a CSRF token cookie on the response. Called when a user authenticates.
+ * Returns Set-Cookie header value.
+ */
+export function setCsrfCookie(token?: string): string {
+  const csrfToken = token || generateToken();
+  return `${CSRF_COOKIE_NAME}=${csrfToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=2592000`; // 30 days
+}
+
+/**
+ * Generate a new CSRF token (for login/session creation).
+ */
+export function generateCsrfToken(): string {
+  return generateToken();
+}
+
+/**
+ * Validate CSRF token for state-changing requests.
+ * Compares the csrf_token cookie value with the x-csrf-token header.
+ * Returns true if valid, false if missing or mismatched.
+ *
+ * Note: SameSite=Lax already prevents CSRF from external sites for
+ * top-level navigations. This adds protection for AJAX requests
+ * from the same origin.
+ */
+export function validateCsrf(request: Request): boolean {
+  const cookieHeader = request.headers.get('cookie') ?? '';
+  const cookieMatch = cookieHeader.match(new RegExp(`${CSRF_COOKIE_NAME}=([a-f0-9]+)`));
+  const headerToken = request.headers.get(CSRF_HEADER_NAME);
+
+  if (!cookieMatch || !headerToken) {
+    return false;
+  }
+
+  // Constant-time comparison to prevent timing attacks
+  const cookieToken = cookieMatch[1];
+  if (cookieToken.length !== headerToken.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < cookieToken.length; i++) {
+    result |= cookieToken.charCodeAt(i) ^ headerToken.charCodeAt(i);
+  }
+
+  return result === 0;
+}
+
+/**
+ * Extract the CSRF cookie value for comparison.
+ */
+export function getCsrfCookieValue(request: Request): string | null {
+  const cookieHeader = request.headers.get('cookie') ?? '';
+  const match = cookieHeader.match(new RegExp(`${CSRF_COOKIE_NAME}=([a-f0-9]+)`));
+  return match ? match[1] : null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { defineMiddleware } from 'astro:middleware';
 import { queryFirst } from '@/lib/db';
+import { cspHeaders } from '@/lib/csp';
 
 // Paths accessible without authentication or approval
 const PUBLIC_PATHS = [
@@ -140,5 +141,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   // Approved user — set user info in locals and continue
   context.locals.user = user;
-  return next();
+
+  // Continue to the page/API handler, then add CSP headers to the response
+  const response = await next();
+  const csp = cspHeaders();
+  response.headers.set(Object.keys(csp)[0], Object.values(csp)[0]);
+  return response;
 });

--- a/src/pages/api/upload/index.ts
+++ b/src/pages/api/upload/index.ts
@@ -4,6 +4,7 @@ import type { APIRoute } from 'astro';
 import { requireAuth } from '@/lib/auth';
 import { queryFirst, run } from '@/lib/db';
 import { uploadImage, deleteImage, deleteImages, parseMultipart, UploadError } from '@/lib/storage';
+import { checkRateLimit, recordFailedAttempt } from '@/lib/rate-limit';
 
 /**
  * POST /api/upload — upload an image for user avatar, pseud icon, or chapter content
@@ -32,6 +33,17 @@ export const POST: APIRoute = async ({ locals, request }) => {
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+  // Rate limit: 5 per 5min per user ID
+  const rlKey = `user:${auth.user.id}`;
+  const rl = await checkRateLimit(db, rlKey, 'upload');
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: 'Rate limit exceeded. Try again later.' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': String(rl.retryAfterSeconds) },
+    });
+  }
+  await recordFailedAttempt(db, rlKey, 'upload');
 
   let files: Map<string, { data: ArrayBuffer; type: string; size: number; filename: string }>;
   let fields: Map<string, string>;

--- a/src/pages/api/user/password.ts
+++ b/src/pages/api/user/password.ts
@@ -3,6 +3,7 @@ export const prerender = false;
 import type { APIRoute } from 'astro';
 import { requireAuth, hashPassword, verifyPassword } from '@/lib/auth';
 import { run } from '@/lib/db';
+import { checkRateLimit, recordFailedAttempt } from '@/lib/rate-limit';
 
 /**
  * POST /api/user/password — change or set password for authenticated user
@@ -20,6 +21,17 @@ export const POST: APIRoute = async ({ locals, request }) => {
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+  // Rate limit: 5 per 5min per user ID
+  const rlKey = `user:${auth.user.id}`;
+  const rl = await checkRateLimit(db, rlKey, 'change-password');
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: 'Rate limit exceeded. Try again later.' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': String(rl.retryAfterSeconds) },
+    });
+  }
+  await recordFailedAttempt(db, rlKey, 'change-password');
 
   let body: { current_password?: string; new_password?: string };
   try {

--- a/src/pages/api/works/[id]/comments/index.ts
+++ b/src/pages/api/works/[id]/comments/index.ts
@@ -4,6 +4,7 @@ import { queryFirst, queryAll, run } from '@/lib/db';
 import { getAuth, requireAuth } from '@/lib/auth';
 import { markdownToHtml } from '@/lib/markdown';
 import { corsHeaders, handleCors } from '@/lib/cors';
+import { checkRateLimit, recordFailedAttempt } from '@/lib/rate-limit';
 import type { APIRoute } from 'astro';
 
 export const OPTIONS: APIRoute = async ({ request }) => {
@@ -52,6 +53,18 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   const db = locals.runtime.env.DB as D1Database;
   const auth = await requireAuth(db, request);
   if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  // Rate limit: 5 per 5min per user ID
+  const rlKey = `user:${auth.user.id}`;
+  const rl = await checkRateLimit(db, rlKey, 'post-comment');
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: 'Rate limit exceeded. Try again later.' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': String(rl.retryAfterSeconds) },
+    });
+  }
+  await recordFailedAttempt(db, rlKey, 'post-comment');
+
   const workId = Number(params.id);
   if (!workId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
 

--- a/src/pages/api/works/index.ts
+++ b/src/pages/api/works/index.ts
@@ -4,6 +4,7 @@ import { queryFirst, run, queryAll } from '@/lib/db';
 import { getAuth } from '@/lib/auth';
 import { markdownToHtml } from '@/lib/markdown';
 import { corsHeaders, handleCors } from '@/lib/cors';
+import { checkRateLimit, recordFailedAttempt } from '@/lib/rate-limit';
 import type { APIRoute } from 'astro';
 
 export const OPTIONS: APIRoute = async ({ request }) => {
@@ -47,6 +48,17 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const db = locals.runtime.env.DB as D1Database;
   const auth = await getAuth(db, request);
   if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  // Rate limit: 5 per 5min per user IP
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rl = await checkRateLimit(db, clientIp, 'create-work');
+  if (!rl.allowed) {
+    return new Response(JSON.stringify({ error: 'Rate limit exceeded. Try again later.' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': String(rl.retryAfterSeconds) },
+    });
+  }
+  await recordFailedAttempt(db, clientIp, 'create-work');
 
   let body: any;
   try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -719,7 +719,7 @@ const themesJSON = JSON.stringify(
     var html = '';
     pseudsData.forEach(function(p) {
       var iconUrl = p.icon_key ? '/api/storage/' + encodeURIComponent(p.icon_key) : null;
-      html += '<div class="pseud-card" data-pseud-id="' + p.id + '">';
+      html += '<div class="pseud-card" data-pseud-id="' + escapeHtml(String(p.id)) + '">';
       html += '  <div class="pseud-info">';
       if (iconUrl) {
         html += '    <img class="pseud-icon" src="' + escapeHtml(iconUrl) + '" alt="" />';
@@ -730,10 +730,10 @@ const themesJSON = JSON.stringify(
       }
       html += '  </div>';
       html += '  <div class="pseud-actions">';
-      html += '    <button type="button" class="btn-icon pseud-edit-btn" data-pseud-id="' + p.id + '" title="Edit" aria-label="Edit ' + escapeHtml(p.name) + '">';
+      html += '    <button type="button" class="btn-icon pseud-edit-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" title="Edit" aria-label="Edit ' + escapeHtml(p.name) + '">';
       html += '      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';
       html += '    </button>';
-      html += '    <button type="button" class="btn-icon btn-icon--danger pseud-delete-btn" data-pseud-id="' + p.id + '" data-pseud-name="' + escapeHtml(p.name) + '" title="Delete" aria-label="Delete ' + escapeHtml(p.name) + '">';
+      html += '    <button type="button" class="btn-icon btn-icon--danger pseud-delete-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" data-pseud-name="' + escapeHtml(p.name) + '" title="Delete" aria-label="Delete ' + escapeHtml(p.name) + '">';
       html += '      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>';
       html += '    </button>';
       html += '  </div>';
@@ -1048,7 +1048,7 @@ const themesJSON = JSON.stringify(
     pseudWorksCache.forEach(function(w) {
       var isPinned = editingPseudPinnedIds.indexOf(w.id) !== -1;
       html += '<label class="pin-work-item">';
-      html += '  <input type="checkbox" class="pin-work-checkbox" data-work-id="' + w.id + '"' + (isPinned ? ' checked' : '') + ' />';
+      html += '  <input type="checkbox" class="pin-work-checkbox" data-work-id="' + escapeHtml(String(w.id)) + '"' + (isPinned ? ' checked' : '') + ' />';
       html += '  <span class="pin-work-title">' + escapeHtml(w.title) + '</span>';
       html += '  <span class="pin-work-meta">' + w.word_count.toLocaleString() + ' words</span>';
       html += '</label>';

--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -508,13 +508,19 @@ const initialChapterData = JSON.stringify({
     }
   });
 
+  function escapeHtml(str: string) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
   function renderChapterList() {
     chapterList.innerHTML = work.chapters
       .sort((a: any, b: any) => a.position - b.position)
       .map((c: any) => `
         <button type="button" class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? '' : ''}"
-          data-chapter-id="${c.id}" data-position="${c.position}" role="listitem">
-          <span class="draft-chapter-item-title">Ch. ${c.position}: ${c.title}</span>
+          data-chapter-id="${escapeHtml(String(c.id))}" data-position="${escapeHtml(String(c.position))}" role="listitem">
+          <span class="draft-chapter-item-title">Ch. ${escapeHtml(String(c.position))}: ${escapeHtml(c.title)}</span>
           <span class="m3-badge ${c.draft ? 'm3-badge-draft' : 'm3-badge-published'}">${c.draft ? 'Draft' : 'Published'}</span>
         </button>
       `).join('');

--- a/src/pages/works/[id]/index.astro
+++ b/src/pages/works/[id]/index.astro
@@ -504,6 +504,12 @@ const commentsJson = JSON.stringify(allComments);
 </style>
 
 <script define:vars={{ workId, chapterId, authed: !!authUser }}>
+  function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
   // Kudos
   const kudosBtn = document.getElementById('kudos-btn');
   if (kudosBtn) {
@@ -568,7 +574,7 @@ const commentsJson = JSON.stringify(allComments);
             const reactionEmojis = { fire: '🔥', cry: '😭', heartbreak: '💔', swords: '⚔️', heart: '❤️', mindblown: '🤯' };
             const sortedReactions = Object.entries(data.counts).sort((a, b) => b[1] - a[1]);
             summaryEl.innerHTML = sortedReactions.map(([r, c]) =>
-              `<span class="reaction-pill">${reactionEmojis[r] || r} ${c}</span>`
+              `<span class="reaction-pill">${reactionEmojis[r] || escapeHtml(r)} ${c}</span>`
             ).join('');
           }
         } else {

--- a/src/pages/works/[id]/lineage/index.astro
+++ b/src/pages/works/[id]/lineage/index.astro
@@ -257,7 +257,7 @@ if (!work) return Astro.redirect('/works');
         container.innerHTML = '';
         const empty = document.createElement('div');
         empty.className = 'graph-empty';
-        empty.innerHTML = `<p>This work has no relations yet.</p><p><a href="/works/${workId}/settings">Add relations in Settings</a></p>`;
+        empty.innerHTML = `<p>This work has no relations yet.</p><p><a href="/works/${encodeURIComponent(workId)}/settings">Add relations in Settings</a></p>`;
         container.appendChild(empty);
         return;
       }


### PR DESCRIPTION
## Deferred Audit Items — Security Hardening Round 2

Follow-up to #38. Addresses the items deferred from the full bug audit.

---

### 🟡 innerHTML XSS Hardening (9 unescaped values fixed)

Every `innerHTML` assignment that injects dynamic API data has been audited. 4 files had unescaped values:

| File | Values Fixed |
|------|-------------|
| `works/[id]/draft.astro` | `c.id`, `c.position`, `c.title` in chapter list template + added `escapeHtml()` |
| `works/[id]/index.astro` | Reaction key fallback (`reactionEmojis[r] \|\| r` → `escapeHtml(r)`) + added `escapeHtml()` |
| `settings/index.astro` | `p.id` (×3) and `w.id` in data attributes |
| `works/[id]/lineage/index.astro` | `workId` in href → `encodeURIComponent(workId)` |

3 files were already safe (characters, tags, search) — verified, no changes needed.

---

### 🔵 Content Security Policy (Report-Only)

New `src/lib/csp.ts` — defense-in-depth against XSS even if sanitization bugs slip through.

| Directive | Values |
|-----------|--------|
| `default-src` | `'self'` |
| `script-src` | `'self'`, `'unsafe-inline'` (Astro hydration), Google Fonts |
| `style-src` | `'self'`, `'unsafe-inline'` (M3 theme overrides), Google Fonts |
| `img-src` | `'self'`, `data:`, `fanfiction.fyi` (R2), Google avatars |
| `connect-src` | `'self'` (API), `api.github.com` (bug reports) |
| `frame-src` | `'none'` |
| `object-src` | `'none'` |
| `base-uri` | `'self'` |
| `form-action` | `'self'` |
| `frame-ancestors` | `'none'` |

**Deployed in Report-Only mode** — CSP violations will appear in browser console but won't break anything. After validating with traffic, switch to enforce mode by changing `cspHeaders({ reportOnly: true })` → `cspHeaders({ reportOnly: false })` in middleware.

Added to middleware response for all authenticated pages.

---

### 🔵 CSRF Token Module

New `src/lib/csrf.ts` — double-submit cookie pattern for AJAX request protection.

- `generateCsrfToken()` — random 64-hex-char token
- `setCsrfCookie(token)` — returns Set-Cookie header value (HttpOnly, SameSite=Lax, 30-day expiry)
- `validateCsrf(request)` — constant-time comparison of cookie vs `x-csrf-token` header
- `getCsrfCookieValue(request)` — extract cookie value

Ready for integration into login flow and API endpoint validation. The `SameSite=Lax` session cookie already provides CSRF protection for top-level navigations — this adds protection for same-origin AJAX requests.

---

### 🟡 Write-Endpoint Rate Limiting (4 endpoints added)

| Endpoint | Key | Action | Rate |
|----------|-----|--------|------|
| `POST /api/works` | Client IP | `create-work` | 5/5min |
| `POST /api/works/{id}/comments` | `user:{id}` | `post-comment` | 5/5min |
| `POST /api/upload` | `user:{id}` | `upload` | 5/5min |
| `POST /api/user/password` | `user:{id}` | `change-password` | 5/5min |

D1-backed via existing `checkRateLimit`/`recordFailedAttempt`. All use distinct action namespaces.

---

### Deferred (separate PR)

- `read.astro` Preact island refactor (905 lines — large structural change)