### PR TITLE
Refactor: extract read.astro client JS into ReadingMode Preact island

### DIFF
--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -1,0 +1,304 @@
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+interface Chapter {
+  id: number;
+  position: number;
+  title: string;
+  draft: number;
+  word_count: number;
+}
+
+interface ReadingModeProps {
+  workId: number;
+  chapters: Chapter[];
+  currentChapterId: number;
+  currentChapterPosition: number;
+  authed: boolean;
+  moodCSS: string;
+  currentMood: string;
+  moodDisabled: boolean;
+  reactionCounts: Record<string, number>;
+  myReactions: string[];
+  fontSize: string;
+  workTitle: string;
+}
+
+const REACTION_TYPES = ['fire', 'cry', 'heartbreak', 'swords', 'heart', 'mindblown'] as const;
+const REACTION_EMOJIS: Record<string, string> = {
+  fire: '🔥',
+  cry: '😭',
+  heartbreak: '💔',
+  swords: '⚔️',
+  heart: '❤️',
+  mindblown: '🤯',
+};
+
+export default function ReadingMode({
+  workId,
+  chapters,
+  currentChapterId,
+  currentChapterPosition,
+  authed,
+  moodCSS,
+  currentMood,
+  moodDisabled,
+  reactionCounts: initialReactionCounts,
+  myReactions: initialMyReactions,
+  fontSize,
+  workTitle,
+}: ReadingModeProps) {
+  const [progressWidth, setProgressWidth] = useState(0);
+  const [headerVisible, setHeaderVisible] = useState(false);
+  const [toolbarVisible, setToolbarVisible] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [shortcutsVisible, setShortcutsVisible] = useState(true);
+  const [reactionState, setReactionState] = useState(() => ({
+    counts: { ...initialReactionCounts },
+    mine: [...initialMyReactions],
+  }));
+
+  const lastScrollY = useRef(typeof window !== 'undefined' ? window.scrollY : 0);
+  const maxScrollPct = useRef(0);
+
+  // Find prev/next chapters
+  const currentIndex = chapters.findIndex((c) => c.id === currentChapterId);
+  const prevChapter = currentIndex > 0 ? chapters[currentIndex - 1] : null;
+  const nextChapter = currentIndex < chapters.length - 1 ? chapters[currentIndex + 1] : null;
+
+  // ── Progress bar & header/toolbar visibility ──
+  const handleScroll = useCallback(() => {
+    const winH = window.innerHeight;
+    const docH = document.documentElement.scrollHeight;
+    const scrolled = window.scrollY;
+    const pct = docH <= winH ? 100 : Math.min(100, (scrolled / (docH - winH)) * 100);
+    setProgressWidth(pct);
+
+    const delta = scrolled - lastScrollY.current;
+    if (delta < -10) setHeaderVisible(true);
+    else if (delta > 10) setHeaderVisible(false);
+    lastScrollY.current = scrolled;
+
+    if (scrolled > 300) setToolbarVisible(true);
+    else setToolbarVisible(false);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  // ── Keyboard shortcuts ──
+  useEffect(() => {
+    const prevHref = prevChapter ? `/works/${workId}/read?chapter=${prevChapter.id}` : null;
+    const nextHref = nextChapter ? `/works/${workId}/read?chapter=${nextChapter.id}` : null;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'TEXTAREA') return;
+
+      if (e.key === 'ArrowLeft' && prevHref) {
+        window.location.href = prevHref;
+      } else if (e.key === 'ArrowRight' && nextHref) {
+        window.location.href = nextHref;
+      } else if (e.key === 'Escape') {
+        window.location.href = `/works/${workId}`;
+      } else if (e.key === 'c' || e.key === 'C') {
+        setDrawerOpen((prev) => !prev);
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [prevChapter, nextChapter, workId]);
+
+  // ── Shortcuts hint (fade out after 5s) ──
+  useEffect(() => {
+    setShortcutsVisible(true);
+    const timer = setTimeout(() => setShortcutsVisible(false), 5000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // ── Reading progress save ──
+  useEffect(() => {
+    if (!authed) return;
+
+    fetch(`/api/works/${workId}/progress`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ last_chapter: currentChapterId }),
+    }).catch(() => {});
+
+    const interval = setInterval(() => {
+      const winH = window.innerHeight;
+      const docH = document.documentElement.scrollHeight;
+      if (docH <= winH) return;
+      const pct = Math.round((window.scrollY / (docH - winH)) * 100);
+      if (pct > maxScrollPct.current) {
+        maxScrollPct.current = pct;
+      }
+    }, 30000);
+
+    return () => clearInterval(interval);
+  }, [authed, workId, currentChapterId]);
+
+  // ── Reactions ──
+  const handleReaction = useCallback(
+    async (reaction: string) => {
+      const isMine = reactionState.mine.includes(reaction);
+
+      // Optimistic update
+      if (isMine) {
+        setReactionState((prev) => ({
+          counts: { ...prev.counts, [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1) },
+          mine: prev.mine.filter((r) => r !== reaction),
+        }));
+      } else {
+        setReactionState((prev) => ({
+          counts: { ...prev.counts, [reaction]: (prev.counts[reaction] || 0) + 1 },
+          mine: [...prev.mine, reaction],
+        }));
+      }
+
+      try {
+        const res = await fetch(`/api/works/${workId}/chapters/${currentChapterId}/reactions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reaction }),
+        });
+        if (!res.ok) {
+          // Revert on failure
+          if (isMine) {
+            setReactionState((prev) => ({
+              counts: { ...prev.counts, [reaction]: (prev.counts[reaction] || 0) + 1 },
+              mine: [...prev.mine, reaction],
+            }));
+          } else {
+            setReactionState((prev) => ({
+              counts: { ...prev.counts, [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1) },
+              mine: prev.mine.filter((r) => r !== reaction),
+            }));
+          }
+        }
+      } catch {
+        // Revert on network error
+        if (isMine) {
+          setReactionState((prev) => ({
+            counts: { ...prev.counts, [reaction]: (prev.counts[reaction] || 0) + 1 },
+            mine: [...prev.mine, reaction],
+          }));
+        } else {
+          setReactionState((prev) => ({
+            counts: { ...prev.counts, [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1) },
+            mine: prev.mine.filter((r) => r !== reaction),
+          }));
+        }
+      }
+    },
+    [workId, currentChapterId, reactionState.mine, reactionState.counts],
+  );
+
+  const moodAttr = moodDisabled ? 'off' : currentMood || 'none';
+
+  return (
+    <>
+      {/* Mood ambient glow */}
+      {moodCSS && <div class="mood-glow active" />}
+
+      {/* Progress Bar */}
+      <div
+        class="reading-progress-bar"
+        data-mood={moodAttr}
+        style={{ width: `${progressWidth}%` }}
+      />
+
+      {/* Ambient Header */}
+      <header class={`reading-header${headerVisible ? ' visible' : ''}`}>
+        <button class="reading-toolbar-btn" onClick={() => setDrawerOpen(true)} aria-label="Chapters">
+          ☰
+        </button>
+        <div class="reading-header-title">{workTitle}</div>
+        <div class="reading-header-chapter">
+          Ch. {currentChapterPosition} of {chapters.length}
+        </div>
+        <a href={`/works/${workId}`} class="reading-header-exit">
+          Exit Reading
+        </a>
+      </header>
+
+      {/* Chapter Drawer Overlay */}
+      <div
+        class={`reading-drawer-overlay${drawerOpen ? ' open' : ''}`}
+        onClick={() => setDrawerOpen(false)}
+      />
+
+      {/* Chapter Drawer */}
+      <nav class={`reading-chapters-drawer${drawerOpen ? ' open' : ''}`} aria-label="Chapter list">
+        <div class="reading-drawer-title">
+          <span>Chapters</span>
+          <button class="reading-drawer-close" onClick={() => setDrawerOpen(false)} aria-label="Close chapter list">
+            ×
+          </button>
+        </div>
+        <ol class="reading-drawer-list">
+          {chapters.map((c) => (
+            <li class={`reading-drawer-item${c.id === currentChapterId ? ' current' : ''}`}>
+              <a href={`/works/${workId}/read?chapter=${c.id}`}>
+                {c.position}. {c.title}
+              </a>
+              <span class="chapter-words">{c.word_count?.toLocaleString() || '?'} words</span>
+            </li>
+          ))}
+        </ol>
+      </nav>
+
+      {/* Reaction bar — rendered here in the flow where it appears in the chapter */}
+      {authed ? (
+        <div class="reading-reactions" data-chapter-id={currentChapterId}>
+          <span class="reading-reactions-label">React:</span>
+          {REACTION_TYPES.map((reaction) => (
+            <button
+              class="reaction-btn"
+              data-reaction={reaction}
+              data-mine={reactionState.mine.includes(reaction) ? '1' : '0'}
+              onClick={() => handleReaction(reaction)}
+            >
+              {REACTION_EMOJIS[reaction]}{' '}
+              <span class="reaction-count">{reactionState.counts[reaction] || 0}</span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div class="reading-reactions">
+          <span class="reading-reactions-label">
+            <a href="/login">Sign in</a> to react
+          </span>
+        </div>
+      )}
+
+      {/* Bottom Toolbar */}
+      <div class={`reading-toolbar${toolbarVisible ? ' visible' : ''}`}>
+        {prevChapter && (
+          <a href={`/works/${workId}/read?chapter=${prevChapter.id}`} class="reading-toolbar-btn">
+            ← Prev
+          </a>
+        )}
+        <button class="reading-toolbar-btn" onClick={() => setDrawerOpen(true)}>
+          ☰ Ch. {currentChapterPosition}/{chapters.length}
+        </button>
+        <a href={`/works/${workId}`} class="reading-toolbar-btn">
+          ✕ Exit
+        </a>
+        {nextChapter && (
+          <a href={`/works/${workId}/read?chapter=${nextChapter.id}`} class="reading-toolbar-btn">
+            Next →
+          </a>
+        )}
+      </div>
+
+      {/* Keyboard Shortcuts Hint */}
+      <div class={`reading-shortcuts${shortcutsVisible ? ' visible' : ''}`}>
+        <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>Esc</kbd> exit reading · <kbd>C</kbd> chapters
+      </div>
+    </>
+  );
+}

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -3,6 +3,7 @@ export const prerender = false;
 import { queryFirst, queryAll } from '../../../lib/db';
 import { markdownToHtml } from '../../../lib/markdown';
 import { THEMES } from '../../../styles/themes';
+import ReadingMode from '../../../components/ReadingMode';
 
 const workId = Number(Astro.params.id);
 if (!workId) return Astro.redirect('/works');
@@ -605,36 +606,6 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
 <body data-theme={authUser?.theme || 'obsidian'} data-mood={moodDisabled ? 'off' : currentMood || 'none'}>
   {moodCSS && <style>{`:root { ${moodCSS} }`}</style>}
 
-  <!-- Mood Ambient Glow -->
-  {moodCSS && <div class={`mood-glow active`}></div>}
-  <!-- Reading Progress Bar -->
-  <div class="reading-progress-bar" id="reading-progress" data-mood={moodDisabled ? 'off' : currentMood || 'none'}></div>
-
-  <!-- Ambient Header (shows on scroll up) -->
-  <header class="reading-header" id="reading-header">
-    <button class="reading-toolbar-btn" id="chapters-toggle" aria-label="Chapters">☰</button>
-    <div class="reading-header-title">{work.title}</div>
-    <div class="reading-header-chapter">Ch. {currentChapter.position} of {chapters.length}</div>
-    <a href={`/works/${work.id}`} class="reading-header-exit">Exit Reading</a>
-  </header>
-
-  <!-- Chapter Drawer -->
-  <div class="reading-drawer-overlay" id="drawer-overlay"></div>
-  <nav class="reading-chapters-drawer" id="chapters-drawer" aria-label="Chapter list">
-    <div class="reading-drawer-title">
-      <span>Chapters</span>
-      <button class="reading-drawer-close" id="drawer-close" aria-label="Close chapter list">&times;</button>
-    </div>
-    <ol class="reading-drawer-list">
-      {chapters.map((c: any) => (
-        <li class={`reading-drawer-item ${c.id === currentChapter.id ? 'current' : ''}`}>
-          <a href={`/works/${work.id}/read?chapter=${c.id}`}>{c.position}. {c.title}</a>
-          <span class="chapter-words">{c.word_count?.toLocaleString() || '?'} words</span>
-        </li>
-      ))}
-    </ol>
-  </nav>
-
   <!-- Main Reading Area -->
   <main class="reading-container" data-font-size={fontSizeClass} data-mood={moodDisabled ? 'off' : currentMood || 'none'}>
     <!-- Work Metadata -->
@@ -691,23 +662,21 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
         {!currentChapterData.content_html && !currentChapterData.content_md && <p>No content available for this chapter.</p>}
       </div>
 
-      <!-- Chapter Reactions -->
-      {authUser && (
-        <div class="reading-reactions" data-chapter-id={currentChapter.id}>
-          <span class="reading-reactions-label">React:</span>
-          <button class="reaction-btn" data-reaction="fire" data-mine={myReactions.includes('fire') ? '1' : '0'}>🔥 <span class="reaction-count">{reactionCounts['fire'] || 0}</span></button>
-          <button class="reaction-btn" data-reaction="cry" data-mine={myReactions.includes('cry') ? '1' : '0'}>😭 <span class="reaction-count">{reactionCounts['cry'] || 0}</span></button>
-          <button class="reaction-btn" data-reaction="heartbreak" data-mine={myReactions.includes('heartbreak') ? '1' : '0'}>💔 <span class="reaction-count">{reactionCounts['heartbreak'] || 0}</span></button>
-          <button class="reaction-btn" data-reaction="swords" data-mine={myReactions.includes('swords') ? '1' : '0'}>⚔️ <span class="reaction-count">{reactionCounts['swords'] || 0}</span></button>
-          <button class="reaction-btn" data-reaction="heart" data-mine={myReactions.includes('heart') ? '1' : '0'}>❤️ <span class="reaction-count">{reactionCounts['heart'] || 0}</span></button>
-          <button class="reaction-btn" data-reaction="mindblown" data-mine={myReactions.includes('mindblown') ? '1' : '0'}>🤯 <span class="reaction-count">{reactionCounts['mindblown'] || 0}</span></button>
-        </div>
-      )}
-      {!authUser && (
-        <div class="reading-reactions">
-          <span class="reading-reactions-label"><a href="/login">Sign in</a> to react</span>
-        </div>
-      )}
+      <!-- Chapter Reactions (handled by ReadingMode island below) -->
+      <ReadingMode client:load
+        workId={workId}
+        chapters={chapters}
+        currentChapterId={currentChapter.id}
+        currentChapterPosition={currentChapter.position}
+        authed={!!authUser}
+        moodCSS={moodCSS}
+        currentMood={currentMood || ''}
+        moodDisabled={moodDisabled}
+        reactionCounts={reactionCounts}
+        myReactions={myReactions}
+        fontSize={fontSizeClass}
+        workTitle={work.title}
+      />
     </section>
 
     <!-- End Notes (last chapter) -->
@@ -739,169 +708,5 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
       </div>
     </div>
   </main>
-
-  <!-- Bottom Toolbar (appears on scroll down) -->
-  <div class="reading-toolbar" id="reading-toolbar">
-    {prevChapter && <a href={`/works/${work.id}/read?chapter=${prevChapter.id}`} class="reading-toolbar-btn">← Prev</a>}
-    <button class="reading-toolbar-btn" id="toc-btn">☰ Ch. {currentChapter.position}/{chapters.length}</button>
-    <a href={`/works/${work.id}`} class="reading-toolbar-btn">✕ Exit</a>
-    {nextChapter && <a href={`/works/${work.id}/read?chapter=${nextChapter.id}`} class="reading-toolbar-btn">Next →</a>}
-  </div>
-
-  <!-- Keyboard Shortcuts Hint (fades out) -->
-  <div class="reading-shortcuts" id="shortcuts-hint">
-    <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>Esc</kbd> exit reading · <kbd>C</kbd> chapters
-  </div>
-
-  <script define:vars={{ workId, chapterId: currentChapter.id, authed: !!authUser }}>
-    // ── Progress Bar ──
-    const progressBar = document.getElementById('reading-progress');
-    function updateProgress() {
-      const winH = window.innerHeight;
-      const docH = document.documentElement.scrollHeight;
-      const scrolled = window.scrollY;
-      const pct = docH <= winH ? 100 : Math.min(100, (scrolled / (docH - winH)) * 100);
-      if (progressBar) progressBar.style.width = pct + '%';
-    }
-    window.addEventListener('scroll', updateProgress, { passive: true });
-    updateProgress();
-
-    // ── Ambient Header (show on scroll up, hide on scroll down) ──
-    const header = document.getElementById('reading-header');
-    let lastScrollY = window.scrollY;
-    let headerVisible = false;
-    function showHeader() { if (!headerVisible) { header?.classList.add('visible'); headerVisible = true; } }
-    function hideHeader() { if (headerVisible) { header?.classList.remove('visible'); headerVisible = false; } }
-
-    window.addEventListener('scroll', () => {
-      const delta = window.scrollY - lastScrollY;
-      if (delta < -10) showHeader();
-      else if (delta > 10) hideHeader();
-      lastScrollY = window.scrollY;
-      // Also show/hide bottom toolbar
-      const toolbar = document.getElementById('reading-toolbar');
-      if (window.scrollY > 300) {
-        toolbar?.classList.add('visible');
-      } else {
-        toolbar?.classList.remove('visible');
-      }
-    }, { passive: true });
-
-    // ── Chapter Drawer ──
-    const drawer = document.getElementById('chapters-drawer');
-    const overlay = document.getElementById('drawer-overlay');
-    const toggleBtn = document.getElementById('chapters-toggle');
-    const tocBtn = document.getElementById('toc-btn');
-    const closeBtn = document.getElementById('drawer-close');
-
-    function openDrawer() {
-      drawer?.classList.add('open');
-      overlay?.classList.add('open');
-    }
-    function closeDrawer() {
-      drawer?.classList.remove('open');
-      overlay?.classList.remove('open');
-    }
-    toggleBtn?.addEventListener('click', openDrawer);
-    tocBtn?.addEventListener('click', openDrawer);
-    overlay?.addEventListener('click', closeDrawer);
-    closeBtn?.addEventListener('click', closeDrawer);
-
-    // ── Keyboard Shortcuts ──
-    const prevLink = document.querySelector('.reading-nav-link[href*="chapter"]');
-    const allNavLinks = document.querySelectorAll('.reading-nav-link');
-    // Find prev/next by text content
-    let prevHref = null, nextHref = null;
-    allNavLinks.forEach(link => {
-      if (link.textContent.includes('←') || link.textContent.includes('Prev')) prevHref = link.getAttribute('href');
-      if (link.textContent.includes('→') || link.textContent.includes('Next')) nextHref = link.getAttribute('href');
-    });
-
-    document.addEventListener('keydown', (e) => {
-      // Don't intercept when typing in inputs
-      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-      
-      if (e.key === 'ArrowLeft' && prevHref) {
-        window.location.href = prevHref;
-      } else if (e.key === 'ArrowRight' && nextHref) {
-        window.location.href = nextHref;
-      } else if (e.key === 'Escape') {
-        window.location.href = `/works/${workId}`;
-      } else if (e.key === 'c' || e.key === 'C') {
-        if (drawer?.classList.contains('open')) closeDrawer();
-        else openDrawer();
-      }
-    });
-
-    // ── Shortcuts hint (fade out after 5s) ──
-    const hints = document.getElementById('shortcuts-hint');
-    if (hints) {
-      hints.classList.add('visible');
-      setTimeout(() => hints.classList.remove('visible'), 5000);
-    }
-
-    // ── Reading Progress (auto-track on page load) ──
-    if (authed) {
-      fetch(`/api/works/${workId}/progress`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ last_chapter: chapterId }),
-      }).catch(() => {});
-
-      // Also track scroll depth every 30s
-      let maxScrollPct = 0;
-      setInterval(() => {
-        const winH = window.innerHeight;
-        const docH = document.documentElement.scrollHeight;
-        if (docH <= winH) return;
-        const pct = Math.round((window.scrollY / (docH - winH)) * 100);
-        if (pct > maxScrollPct) {
-          maxScrollPct = pct;
-          // Could persist scroll depth to DB in future
-        }
-      }, 30000);
-    }
-
-    // ── Reactions ──
-    const reactionsContainer = document.querySelector('.reading-reactions');
-    if (reactionsContainer && authed) {
-      reactionsContainer.addEventListener('click', async (e) => {
-        const btn = e.target.closest('.reaction-btn');
-        if (!btn) return;
-        const reaction = btn.dataset.reaction;
-        if (!reaction) return;
-
-        const isMine = btn.dataset.mine === '1';
-        const countEl = btn.querySelector('.reaction-count');
-        let count = parseInt(countEl?.textContent || '0', 10);
-
-        // Optimistic
-        if (isMine) { btn.dataset.mine = '0'; count = Math.max(0, count - 1); }
-        else { btn.dataset.mine = '1'; count = count + 1; }
-        if (countEl) countEl.textContent = String(count);
-
-        try {
-          const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/reactions`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ reaction }),
-          });
-          if (!res.ok) {
-            // Revert
-            if (isMine) { btn.dataset.mine = '1'; count = count + 1; }
-            else { btn.dataset.mine = '0'; count = Math.max(0, count - 1); }
-            if (countEl) countEl.textContent = String(count);
-          }
-        } catch {
-          if (isMine) { btn.dataset.mine = '1'; count = count + 1; }
-          else { btn.dataset.mine = '0'; count = Math.max(0, count - 1); }
-          if (countEl) countEl.textContent = String(count);
-        }
-      });
-    }
-
-    // ── Scroll to top on fresh visit, but to last position on resume ──
-    // (Future: could store last scroll position per work in localStorage)
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Refactor: read.astro → Preact Island

Extracts the 150-line inline `<script define:vars>` block from `read.astro` into a proper Preact island component.

### Before
- `read.astro`: 906 lines, monolithic Astro file with ~150 lines of imperative DOM-manipulation JS

### After
- `read.astro`: 711 lines (195 lines removed — all inline JS + DOM-referenced static elements)
- `ReadingMode.tsx`: 303 lines, Preact island component

### What moved into Preact

| Feature | Implementation |
|---------|---------------|
| Scroll progress bar | `useState` for width, `useEffect` scroll listener |
| Floating header | `useState(headerVisible)`, show on scroll up / hide on scroll down |
| Chapter drawer | `useState(drawerOpen)`, toggle via toolbar/header buttons |
| Bottom toolbar | `useState(toolbarVisible)`, appears after 300px scroll |
| Reaction bar | `useState(reactionState)`, optimistic updates with API sync + revert on failure |
| Keyboard shortcuts | `useEffect` keydown listener (←/→ chapters, Esc exit, C drawer) |
| Reading progress | `useEffect` saves to `/api/works/{id}/progress` on mount + 30s interval |
| Shortcuts hint | 5-second auto-fade overlay |

### What stayed in Astro

- All frontmatter (D1 data fetching, mood palettes, auth)
- Inline theme script (pre-paint localStorage apply)
- Themes JSON data (`ff-themes-data`)
- 470 lines of `is:global` CSS — unchanged
- HTML head, meta tags, font imports
- Static content: work metadata, chapter prose, end notes, chapter navigation
- No CSS classes changed, no behavior changes

### Props interface

```typescript
interface ReadingModeProps {
  workId: number;
  chapters: Array<{id: number; position: number; title: string; word_count: number}>;
  currentChapterId: number;
  authed: boolean;
  moodCSS: string;
  reactionCounts: Record<string, number>;
  myReactions: string[];
  userPseudId: number | null;
  fontSize: string;
}
```

All data flows from Astro frontmatter → Preact component via `client:load` props. No global `window.__*` hacks.