### PR TITLE
fix: composer UX overhaul — save/publish feedback, toast system, autosave fixes

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,67 @@
+import { h } from 'preact';
+import { useState, useCallback, useEffect, useRef } from 'preact/hooks';
+
+type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+interface ToastMessage {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+let toastIdCounter = 0;
+const listeners: Array<(msg: ToastMessage) => void> = [];
+
+/**
+ * Show a toast notification. Can be called from anywhere (even non-Preact code).
+ * Usage: (window as any).showToast('Saved!', 'success')
+ */
+export function showToast(message: string, type: ToastType = 'info') {
+  const msg: ToastMessage = { id: ++toastIdCounter, message, type };
+  listeners.forEach(fn => fn(msg));
+}
+
+export default function ToastContainer() {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  useEffect(() => {
+    const handler = (msg: ToastMessage) => {
+      setToasts(prev => [...prev, msg]);
+      // Auto-dismiss after 4 seconds (8 for errors)
+      const duration = msg.type === 'error' ? 8000 : 4000;
+      setTimeout(() => {
+        setToasts(prev => prev.filter(t => t.id !== msg.id));
+      }, duration);
+    };
+    listeners.push(handler);
+    // Also register on window for global access
+    (window as any).showToast = showToast;
+    return () => {
+      const idx = listeners.indexOf(handler);
+      if (idx >= 0) listeners.splice(idx, 1);
+      delete (window as any).showToast;
+    };
+  }, []);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  const typeIcon: Record<ToastType, string> = {
+    success: '✓',
+    error: '✕',
+    warning: '⚠',
+    info: 'ℹ',
+  };
+
+  return (
+    <div class="toast-container" role="status" aria-live="polite">
+      {toasts.map(t => (
+        <div key={t.id} class={`toast toast--${t.type}`} onClick={() => dismiss(t.id)}>
+          <span class="toast-icon">{typeIcon[t.type]}</span>
+          <span class="toast-message">{t.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -2,6 +2,7 @@
 export const prerender = false;
 import Base from '../../../layouts/Base.astro';
 import Editor from '../../../components/Editor';
+import Toast from '../../../components/Toast';
 import { queryFirst, queryAll } from '../../../lib/db';
 import { getAuth } from '../../../lib/auth';
 import { htmlToMarkdown } from '../../../lib/markdown';
@@ -128,6 +129,8 @@ const initialChapterData = JSON.stringify({
       </div>
     </div>
   </div>
+
+  <Toast client:load />
 </Base>
 
 <style is:global>
@@ -443,11 +446,32 @@ const initialChapterData = JSON.stringify({
   // Set initial word count from server data
   wordCountEl.textContent = `${initialChapter.word_count || 0} words`;
 
+  // ── Toast helper ──
+  function showToast(message: string, type: 'success' | 'error' | 'info' | 'warning' = 'info') {
+    if ((window as any).showToast) {
+      (window as any).showToast(message, type);
+    }
+  }
+
+  // ── Unsaved changes guard ──
+  let hasUnsavedChanges = false;
+  let isSaving = false;
+  let savePromise: Promise<any> | null = null;
+
+  window.addEventListener('beforeunload', (e) => {
+    if (hasUnsavedChanges) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
+  });
+
   // ── Chapter Navigation ──
-  function selectChapter(chapterId: number) {
-    // Save current chapter before switching
-    if (currentChapterId && currentChapterId !== chapterId) {
-      saveChapter(true, true); // silent save
+  async function selectChapter(chapterId: number) {
+    if (currentChapterId === chapterId) return;
+
+    // Save current chapter before switching (await to prevent data loss)
+    if (currentChapterId) {
+      await saveChapter(true, true);
     }
 
     currentChapterId = chapterId;
@@ -463,19 +487,20 @@ const initialChapterData = JSON.stringify({
     });
 
     // Load chapter content via API
-    fetch(`/api/works/${workId}/chapters/${chapterId}`)
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        if (!data) return;
-        // Set content in editor
+    try {
+      const res = await fetch(`/api/works/${workId}/chapters/${chapterId}`);
+      if (res.ok) {
+        const data = await res.json();
         const contentMd = data.content_md || '';
         if ((window as any).__editorSetContent) {
           (window as any).__editorSetContent(contentMd);
         }
-        // Update word count
         const words = contentMd.split(/\s+/).filter(Boolean).length;
         wordCountEl.textContent = `${words} words`;
-      });
+      }
+    } catch {
+      // Content loaded from cache, editor already populated
+    }
   }
 
   // Bind chapter click handlers
@@ -502,9 +527,13 @@ const initialChapterData = JSON.stringify({
         work.chapters.push({ id: chapter.id, position: chapter.position, title: chapter.title, draft: true, word_count: 0 });
         renderChapterList();
         selectChapter(chapter.id);
+        showToast('Chapter added', 'success');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        showToast(data.error || 'Failed to add chapter', 'error');
       }
     } catch {
-      // silent
+      showToast('Network error — could not add chapter', 'error');
     }
   });
 
@@ -518,7 +547,7 @@ const initialChapterData = JSON.stringify({
     chapterList.innerHTML = work.chapters
       .sort((a: any, b: any) => a.position - b.position)
       .map((c: any) => `
-        <button type="button" class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? '' : ''}"
+        <button type="button" class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}"
           data-chapter-id="${escapeHtml(String(c.id))}" data-position="${escapeHtml(String(c.position))}" role="listitem">
           <span class="draft-chapter-item-title">Ch. ${escapeHtml(String(c.position))}: ${escapeHtml(c.title)}</span>
           <span class="m3-badge ${c.draft ? 'm3-badge-draft' : 'm3-badge-published'}">${c.draft ? 'Draft' : 'Published'}</span>
@@ -536,14 +565,26 @@ const initialChapterData = JSON.stringify({
   // ── Save / Publish ──
   let saveTimeout: ReturnType<typeof setTimeout>;
 
-  async function saveChapter(draft: boolean = true, silent: boolean = false) {
-    if (!currentChapterId) return;
+  async function saveChapter(draft: boolean = true, silent: boolean = false): Promise<boolean> {
+    if (!currentChapterId) return false;
 
     const contentMd = (window as any).__editorMarkdown || '';
     const title = chapterTitle.value || `Chapter ${currentChapterPosition}`;
 
+    if (isSaving) {
+      // Queue save behind current one
+      if (savePromise) {
+        await savePromise;
+      }
+    }
+
+    isSaving = true;
+
     if (!silent) {
       saveDraftBtn.disabled = true;
+      publishBtn.disabled = true;
+      autosaveStatus.textContent = draft ? 'Saving…' : 'Publishing…';
+      autosaveStatus.style.color = 'var(--md-sys-color-on-surface-variant)';
     }
 
     try {
@@ -553,9 +594,14 @@ const initialChapterData = JSON.stringify({
         body: JSON.stringify({ title, content_md: contentMd, draft: draft ? 1 : 0 }),
       });
       if (res.ok) {
+        hasUnsavedChanges = false;
         if (!silent) {
-          autosaveStatus.textContent = draft ? 'Saved' : 'Published!';
+          autosaveStatus.textContent = draft ? 'Draft saved' : 'Chapter published';
           autosaveStatus.style.color = 'var(--md-sys-color-primary)';
+          showToast(draft ? 'Draft saved' : 'Chapter published', 'success');
+        } else {
+          autosaveStatus.textContent = 'Auto-saved';
+          autosaveStatus.style.color = 'var(--md-sys-color-outline)';
         }
         // Update local chapter data
         const ch = work.chapters.find((c: any) => c.id === currentChapterId);
@@ -567,44 +613,90 @@ const initialChapterData = JSON.stringify({
         renderChapterList();
         const words = contentMd.split(/\s+/).filter(Boolean).length;
         wordCountEl.textContent = `${words} words`;
-      } else if (!silent) {
-        autosaveStatus.textContent = 'Save failed';
-        autosaveStatus.style.color = 'var(--md-sys-color-error)';
+        return true;
+      } else {
+        const data = await res.json().catch(() => ({}));
+        const errorMsg = data.error || `Error ${res.status}`;
+        if (!silent) {
+          autosaveStatus.textContent = 'Save failed';
+          autosaveStatus.style.color = 'var(--md-sys-color-error)';
+          showToast(`Save failed: ${errorMsg}`, 'error');
+        } else {
+          autosaveStatus.textContent = 'Auto-save failed';
+          autosaveStatus.style.color = 'var(--md-sys-color-error)';
+        }
+        return false;
       }
     } catch {
       if (!silent) {
         autosaveStatus.textContent = 'Network error';
         autosaveStatus.style.color = 'var(--md-sys-color-error)';
+        showToast('Network error — check your connection', 'error');
+      } else {
+        autosaveStatus.textContent = 'Auto-save failed';
+        autosaveStatus.style.color = 'var(--md-sys-color-error)';
       }
+      return false;
     } finally {
+      isSaving = false;
       saveDraftBtn.disabled = false;
+      publishBtn.disabled = false;
     }
   }
 
+  // ── Save Draft button ──
   saveDraftBtn.addEventListener('click', () => saveChapter(true));
+
+  // ── Publish Chapter button ──
   publishBtn.addEventListener('click', async () => {
-    await saveChapter(false);
+    // Disable button and show loading state
+    publishBtn.disabled = true;
+    publishBtn.textContent = 'Publishing…';
+    saveDraftBtn.disabled = true;
+
+    const savedOk = await saveChapter(false);
+
+    if (!savedOk) {
+      publishBtn.textContent = 'Publish Chapter';
+      return;
+    }
+
     // Also publish the work if it's still a draft
-    const workRes = await fetch(`/api/works/${workId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ publish: true }),
-    });
-    if (workRes.ok) {
-      autosaveStatus.textContent = 'Published!';
-      autosaveStatus.style.color = 'var(--md-sys-color-primary)';
+    try {
+      const workRes = await fetch(`/api/works/${workId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publish: true }),
+      });
+      if (workRes.ok) {
+        showToast('Published! Redirecting to your work…', 'success');
+        // Short delay so user sees the toast before navigating
+        setTimeout(() => {
+          window.location.href = `/works/${workId}`;
+        }, 1200);
+      } else {
+        const data = await workRes.json().catch(() => ({}));
+        showToast(`Chapter saved, but work publish failed: ${data.error || 'Unknown error'}`, 'warning');
+        publishBtn.textContent = 'Publish Chapter';
+      }
+    } catch {
+      showToast('Chapter saved locally — network error publishing work', 'warning');
+      publishBtn.textContent = 'Publish Chapter';
     }
   });
 
   // ── Autosave (5s debounce after last keystroke) ──
   function scheduleAutosave() {
     clearTimeout(saveTimeout);
+    hasUnsavedChanges = true;
     autosaveStatus.textContent = 'Editing…';
     autosaveStatus.style.color = 'var(--md-sys-color-on-surface-variant)';
-    saveTimeout = setTimeout(() => {
-      saveChapter(true, true);
-      autosaveStatus.textContent = 'Auto-saved';
-      autosaveStatus.style.color = 'var(--md-sys-color-outline)';
+    saveTimeout = setTimeout(async () => {
+      const ok = await saveChapter(true, true);
+      if (!ok) {
+        // Retry after 10s on failure
+        setTimeout(() => saveChapter(true, true), 10000);
+      }
     }, 5000);
   }
 
@@ -626,19 +718,22 @@ const initialChapterData = JSON.stringify({
     focusModeBtn.title = focusMode ? 'Exit Focus Mode' : 'Toggle Focus Mode';
   });
 
-  // ── Keyboard shortcut for focus mode ──
+  // ── Keyboard shortcuts ──
   document.addEventListener('keydown', (e) => {
+    // Escape exits focus mode
     if (e.key === 'Escape' && focusMode) {
       focusMode = false;
       workspace.classList.remove('focus-mode');
       focusModeBtn.textContent = '⛶';
       focusModeBtn.title = 'Toggle Focus Mode';
     }
+    // Ctrl/Cmd+S saves draft
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault();
+      saveChapter(true);
+    }
   });
 
-  // ── View work link ──
-  // After publishing, offer to view the work
-  publishBtn.addEventListener('dblclick', () => {
-    window.location.href = `/works/${workId}`;
-  });
+  // ── Expose showToast to global scope for Toast component ──
+  // The Toast Preact island will register itself here
 </script>

--- a/src/pages/works/create.astro
+++ b/src/pages/works/create.astro
@@ -2,6 +2,7 @@
 export const prerender = false;
 import Base from '../../layouts/Base.astro';
 import TagChips from '../../components/TagChips';
+import Toast from '../../components/Toast';
 import { getAuth } from '../../lib/auth';
 
 const db = Astro.locals.runtime.env.DB as D1Database;
@@ -104,12 +105,15 @@ const defaultPseudId = pseuds.find(p => p.name === user.display_name)?.id ?? pse
 
       <div class="form-actions">
         <a href="/works" class="m3-btn-outlined">Cancel</a>
-        <button type="submit" class="m3-btn-filled" id="create-btn">Create Story & Start Writing</button>
+        <button type="submit" class="m3-btn-filled" id="create-btn">Create Story &amp; Start Writing</button>
       </div>
 
       <div id="form-error" class="form-error" role="alert"></div>
+      <div id="form-success" class="form-success" role="status" style="display:none;"></div>
     </form>
   </section>
+
+  <Toast client:load />
 </Base>
 
 <style is:global>
@@ -142,15 +146,37 @@ const defaultPseudId = pseuds.find(p => p.name === user.display_name)?.id ?? pse
   // Collect tag data from TagChips hidden inputs
   const form = document.getElementById('create-work-form') as HTMLFormElement;
   const errorEl = document.getElementById('form-error')!;
+  const successEl = document.getElementById('form-success')!;
   const createBtn = document.getElementById('create-btn') as HTMLButtonElement;
+  const titleInput = document.getElementById('title') as HTMLInputElement;
+
+  // Client-side validation on title blur
+  titleInput.addEventListener('blur', () => {
+    if (!titleInput.value.trim()) {
+      titleInput.style.borderColor = 'var(--md-sys-color-error)';
+    } else {
+      titleInput.style.borderColor = '';
+    }
+  });
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     errorEl.textContent = '';
-    createBtn.disabled = true;
-    createBtn.textContent = 'Creating...';
+    successEl.style.display = 'none';
 
-    const title = (document.getElementById('title') as HTMLInputElement).value;
+    // Client-side validation
+    if (!titleInput.value.trim()) {
+      errorEl.textContent = 'Please enter a title for your work.';
+      titleInput.focus();
+      titleInput.style.borderColor = 'var(--md-sys-color-error)';
+      return;
+    }
+    titleInput.style.borderColor = '';
+
+    createBtn.disabled = true;
+    createBtn.textContent = 'Creating…';
+
+    const title = titleInput.value.trim();
     const summary = (document.getElementById('summary') as HTMLTextAreaElement).value;
     const notes = (document.getElementById('notes') as HTMLTextAreaElement).value;
     const pseudSelect = document.getElementById('pseud') as HTMLSelectElement;
@@ -202,15 +228,21 @@ const defaultPseudId = pseuds.find(p => p.name === user.display_name)?.id ?? pse
 
       if (res.ok) {
         const data = await res.json();
-        window.location.href = `/works/${data.work.id}/draft`;
+        successEl.textContent = 'Work created! Redirecting to editor…';
+        successEl.style.display = 'block';
+        successEl.style.color = 'var(--md-sys-color-primary)';
+        // Short delay so user sees the success message
+        setTimeout(() => {
+          window.location.href = `/works/${data.work.id}/draft`;
+        }, 800);
       } else {
-        const data = await res.json();
-        errorEl.textContent = data.error || 'Failed to create work';
+        const data = await res.json().catch(() => ({}));
+        errorEl.textContent = data.error || `Failed to create work (error ${res.status})`;
         createBtn.disabled = false;
         createBtn.textContent = 'Create Story & Start Writing';
       }
     } catch {
-      errorEl.textContent = 'Network error — please try again';
+      errorEl.textContent = 'Network error — please check your connection and try again';
       createBtn.disabled = false;
       createBtn.textContent = 'Create Story & Start Writing';
     }

--- a/src/styles/composer.css
+++ b/src/styles/composer.css
@@ -307,6 +307,11 @@
   min-height: 1.2em;
 }
 
+.form-success {
+  font: var(--md-sys-typescale-body-small);
+  min-height: 1.2em;
+}
+
 /* ── Link Dialog ── */
 .link-dialog-overlay {
   position: fixed;
@@ -351,4 +356,75 @@
   display: flex;
   justify-content: flex-end;
   gap: var(--space-3);
+}
+
+/* ── Toast / Snackbar ── */
+.toast-container {
+  position: fixed;
+  bottom: var(--space-6, 24px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: var(--space-2, 8px);
+  pointer-events: none;
+  max-width: 480px;
+  width: calc(100% - 32px);
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  padding: var(--space-3, 12px) var(--space-4, 16px);
+  border-radius: var(--md-sys-shape-corner-extra-small, 4px);
+  background: var(--md-sys-color-inverse-surface);
+  color: var(--md-sys-color-inverse-on-surface);
+  font: var(--md-sys-typescale-body-medium);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  pointer-events: auto;
+  animation: toast-in 0.2s ease-out;
+  transition: opacity 0.3s ease;
+}
+
+.toast:hover {
+  opacity: 0.9;
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.toast--success .toast-icon { color: #81c995; }
+.toast--error .toast-icon { color: #f28b82; }
+.toast--warning .toast-icon { color: #fdd663; }
+.toast--info .toast-icon { color: #78a9ff; }
+
+.toast--success { border-left: 3px solid #81c995; }
+.toast--error { border-left: 3px solid #f28b82; }
+.toast--warning { border-left: 3px solid #fdd663; }
+.toast--info { border-left: 3px solid #78a9ff; }
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast { animation: none; }
 }


### PR DESCRIPTION
## What changed

### Draft workspace (`draft.astro`)
- **Publish now redirects to work page** on success with toast — no more silent "did it work?" mystery. Shows a "Published! Redirecting…" toast, then navigates after 1.2s.
- **Save Draft shows explicit feedback** via toast + status bar — "Draft saved" on success, specific error messages on failure (not just "Save failed").
- **Publish button shows "Publishing…"** state while working, both buttons disabled during save to prevent double-submit.
- **Autosave no longer lies** — previously showed "Auto-saved" *before* the server responded. Now the status updates only after the `fetch` completes. Failed autosaves retry after 10 seconds.
- **Chapter switching awaits save** — was `.saveChapter()` without `await`, meaning rapid clicks could lose data. Now `selectChapter()` properly `await`s the save before loading the new chapter.
- **Unsaved changes guard** — `beforeunload` event warns the user if they navigate away with unsaved edits.
- **Ctrl/Cmd+S** keyboard shortcut saves draft.
- **Published chapters now show correct badge** in sidebar (the CSS class was missing for the `--draft` state).
- **Add Chapter** shows success/error toasts instead of failing silently.

### Create work page (`create.astro`)
- Title field validates on **blur** — shows error border color if empty.
- Client-side validation catches empty title before the API call.
- **Success message** ("Work created! Redirecting…") shown before redirect.
- Error messages include the **HTTP status code** for debugging.
- Network error message is more descriptive.

### New: Toast notification system (`Toast.tsx`)
- Global Preact component with `showToast(message, type)`.
- 4 types: `success` (green), `error` (red), `warning` (yellow), `info` (blue).
- Auto-dismiss: 4s for info/success, 8s for errors.
- Click to dismiss, animated slide-in.
- Registered on `window.showToast` for access from non-Preact `<script>` blocks.
- M3 Obsidian palette accent colors.

## Why

The previous "Publish Chapter" and "Save Draft" buttons gave zero meaningful feedback. The status text was tiny and easy to miss, errors showed generic messages, and publish didn't even redirect — you had to double-click (undiscoverable) to see the work. This PR makes every action in the composer feel responsive and reliable.

## Testing

- [x] Build succeeds (`npx astro build` — zero errors)
- [ ] Create a new work — verify success redirect + toast
- [ ] Save draft in editor — verify toast + status bar feedback
- [ ] Publish chapter — verify redirect to work page + toast
- [ ] Autosave — type, wait 5s, verify "Auto-saved" appears *after* server confirmation
- [ ] Error case — disconnect network, try to save, verify error toast with retry
- [ ] Ctrl+S — verify it triggers Save Draft