### PR TITLE
fix: address Copilot/Codex review findings from PR #41

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,5 +1,4 @@
-import { h } from 'preact';
-import { useState, useCallback, useEffect, useRef } from 'preact/hooks';
+import { useState, useCallback, useEffect } from 'preact/hooks';
 
 type ToastType = 'success' | 'error' | 'info' | 'warning';
 

--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -457,7 +457,6 @@ const initialChapterData = JSON.stringify({
   let hasUnsavedChanges = false;
   let isSaving = false;
   let savePromise: Promise<any> | null = null;
-  let lastSavedContent = '';
 
   window.addEventListener('beforeunload', (e) => {
     if (hasUnsavedChanges) {
@@ -508,8 +507,9 @@ const initialChapterData = JSON.stringify({
       if (chapterSwitchToken !== thisToken) return;
       if (res.ok) {
         const data = await res.json();
+        // Check again after parsing JSON — another switch may have started
+        if (chapterSwitchToken !== thisToken) return;
         const contentMd = data.content_md || '';
-        lastSavedContent = contentMd;
         if ((window as any).__editorSetContent) {
           (window as any).__editorSetContent(contentMd);
         }
@@ -586,15 +586,16 @@ const initialChapterData = JSON.stringify({
   async function saveChapter(draft: boolean = true, silent: boolean = false): Promise<boolean> {
     if (!currentChapterId) return false;
 
-    const contentMd = (window as any).__editorMarkdown || '';
-    const title = chapterTitle.value || `Chapter ${currentChapterPosition}`;
-
     // If a save is already in flight, queue behind it
     if (isSaving) {
       if (savePromise) {
         await savePromise;
       }
     }
+
+    // Read content after any queued save has finished so we don't send stale data
+    const contentMd = (window as any).__editorMarkdown || '';
+    const title = chapterTitle.value || `Chapter ${currentChapterPosition}`;
 
     // Snapshot content at save time — only clear dirty flag if no new edits happened
     const contentAtSaveStart = contentMd;
@@ -626,7 +627,6 @@ const initialChapterData = JSON.stringify({
         if (contentNow === contentAtSaveStart) {
           hasUnsavedChanges = false;
         }
-        lastSavedContent = contentAtSaveStart;
         if (!silent) {
           autosaveStatus.textContent = draft ? 'Draft saved' : 'Chapter published';
           autosaveStatus.style.color = 'var(--md-sys-color-primary)';

--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -457,6 +457,7 @@ const initialChapterData = JSON.stringify({
   let hasUnsavedChanges = false;
   let isSaving = false;
   let savePromise: Promise<any> | null = null;
+  let lastSavedContent = '';
 
   window.addEventListener('beforeunload', (e) => {
     if (hasUnsavedChanges) {
@@ -466,13 +467,26 @@ const initialChapterData = JSON.stringify({
   });
 
   // ── Chapter Navigation ──
+  // Serialization token to prevent out-of-order chapter switches from rapid clicks
+  let chapterSwitchToken = 0;
+
   async function selectChapter(chapterId: number) {
     if (currentChapterId === chapterId) return;
 
+    const thisToken = ++chapterSwitchToken;
+
     // Save current chapter before switching (await to prevent data loss)
     if (currentChapterId) {
-      await saveChapter(true, true);
+      const savedOk = await saveChapter(true, true);
+      if (!savedOk) {
+        // Abort switch — don't lose unsaved edits
+        showToast('Could not save current chapter — please try again', 'error');
+        return;
+      }
     }
+
+    // If another switch was triggered while we were saving, abort this one
+    if (chapterSwitchToken !== thisToken) return;
 
     currentChapterId = chapterId;
     const chapter = work.chapters.find((c: any) => c.id === chapterId);
@@ -480,6 +494,7 @@ const initialChapterData = JSON.stringify({
 
     currentChapterPosition = chapter.position;
     chapterTitle.value = chapter.title;
+    hasUnsavedChanges = false;
 
     // Update active state in sidebar
     document.querySelectorAll('.draft-chapter-item').forEach(el => {
@@ -489,9 +504,12 @@ const initialChapterData = JSON.stringify({
     // Load chapter content via API
     try {
       const res = await fetch(`/api/works/${workId}/chapters/${chapterId}`);
+      // Check again after await — another switch may have happened
+      if (chapterSwitchToken !== thisToken) return;
       if (res.ok) {
         const data = await res.json();
         const contentMd = data.content_md || '';
+        lastSavedContent = contentMd;
         if ((window as any).__editorSetContent) {
           (window as any).__editorSetContent(contentMd);
         }
@@ -571,14 +589,19 @@ const initialChapterData = JSON.stringify({
     const contentMd = (window as any).__editorMarkdown || '';
     const title = chapterTitle.value || `Chapter ${currentChapterPosition}`;
 
+    // If a save is already in flight, queue behind it
     if (isSaving) {
-      // Queue save behind current one
       if (savePromise) {
         await savePromise;
       }
     }
 
+    // Snapshot content at save time — only clear dirty flag if no new edits happened
+    const contentAtSaveStart = contentMd;
+
     isSaving = true;
+    const previousSaveDraftDisabled = saveDraftBtn.disabled;
+    const previousPublishDisabled = publishBtn.disabled;
 
     if (!silent) {
       saveDraftBtn.disabled = true;
@@ -587,6 +610,10 @@ const initialChapterData = JSON.stringify({
       autosaveStatus.style.color = 'var(--md-sys-color-on-surface-variant)';
     }
 
+    // Assign savePromise so queued callers can await this operation
+    let resolveSave: () => void;
+    savePromise = new Promise<void>(resolve => { resolveSave = resolve; });
+
     try {
       const res = await fetch(`/api/works/${workId}/chapters/${currentChapterId}`, {
         method: 'PUT',
@@ -594,7 +621,12 @@ const initialChapterData = JSON.stringify({
         body: JSON.stringify({ title, content_md: contentMd, draft: draft ? 1 : 0 }),
       });
       if (res.ok) {
-        hasUnsavedChanges = false;
+        // Only clear dirty flag if no new edits happened while we were saving
+        const contentNow = (window as any).__editorMarkdown || '';
+        if (contentNow === contentAtSaveStart) {
+          hasUnsavedChanges = false;
+        }
+        lastSavedContent = contentAtSaveStart;
         if (!silent) {
           autosaveStatus.textContent = draft ? 'Draft saved' : 'Chapter published';
           autosaveStatus.style.color = 'var(--md-sys-color-primary)';
@@ -639,8 +671,14 @@ const initialChapterData = JSON.stringify({
       return false;
     } finally {
       isSaving = false;
-      saveDraftBtn.disabled = false;
-      publishBtn.disabled = false;
+      savePromise = null;
+      resolveSave!();
+      // Only restore buttons if this wasn't a silent save and publish flow
+      // isn't controlling them. In silent mode, preserve whatever state they were in.
+      if (!silent) {
+        saveDraftBtn.disabled = previousSaveDraftDisabled;
+        publishBtn.disabled = previousPublishDisabled;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Addresses all 5 review findings from Copilot and Codex on PR #41 (which was merged with outstanding review items).

### Fixes

| # | Finding | Source | Fix |
|---|---------|--------|-----|
| 1 | **P1: `hasUnsavedChanges` race** — flag cleared by stale save response even if user kept typing | Codex | `saveChapter` snapshots content at save start; only clears dirty flag if editor content hasn't changed since. Prevents `beforeunload` guard from silently passing. |
| 2 | **P2: Chapter switch out-of-order** — rapid async `selectChapter` calls complete in wrong order | Codex | `chapterSwitchToken` serialization — each call increments the token and aborts if a newer switch has started. |
| 3 | **`savePromise` never assigned** — queuing code checks `savePromise` but nothing sets it, so saves still run in parallel | Copilot | `savePromise` now assigned to a `new Promise()` wrapping the save, resolved in `finally`. Concurrent callers properly await. |
| 4 | **`finally` always re-enables buttons** — breaks publish loading state and autosave should not touch buttons | Copilot | `finally` now only restores button state for non-silent saves, and restores to the *previous* disabled state rather than hardcoding `false`. |
| 5 | **`selectChapter` ignores save failure** — switches chapters even if save fails, losing unsaved edits | Copilot | Now checks the boolean return; aborts switch and shows error toast on failure. |
| 6 | **Unused imports in Toast.tsx** — `h` and `useRef` imported but never used | Copilot | Removed. |

### Testing
- Build succeeds (`npx astro build` — zero errors)
- No behavioral changes to successful paths — only fixes edge cases that previously had data-loss or race-condition bugs