### PR TITLE
feat: D1-backed publish logger for debugging publish failures

### DIFF
--- a/src/lib/publish-logger.ts
+++ b/src/lib/publish-logger.ts
@@ -1,0 +1,138 @@
+/**
+ * Publish Logger — D1-backed persistent logging for the publish flow.
+ * 
+ * Records every publish attempt (chapter save + work publish) with:
+ * - Step identifier (chapter_save | work_publish)
+ * - Status (attempt → success | fail)
+ * - HTTP status code, error message, user/work/chapter IDs
+ * - Request/response summaries (truncated for D1 safety)
+ * 
+ * Usage in API handlers:
+ *   import { logPublishAttempt, logPublishResult } from '@/lib/publish-logger';
+ *   const logId = await logPublishAttempt(db, { workId, chapterId, step, userId, requestSummary });
+ *   // ... do the work ...
+ *   await logPublishResult(db, logId, { status: 'success', httpStatus: 200 });
+ *   // or on error:
+ *   await logPublishResult(db, logId, { status: 'fail', httpStatus: 500, error: err.message });
+ */
+
+export interface PublishLogEntry {
+  id?: number;
+  work_id: number;
+  chapter_id?: number | null;
+  step: 'chapter_save' | 'work_publish' | 'chapter_publish_post';
+  status: 'attempt' | 'success' | 'fail';
+  http_status?: number | null;
+  error?: string | null;
+  user_id?: number | null;
+  request_summary?: string | null;
+  response_summary?: string | null;
+  created_at?: string;
+}
+
+/**
+ * Log a publish attempt (before the operation executes).
+ * Returns the log entry ID for later update with logPublishResult().
+ */
+export async function logPublishAttempt(
+  db: D1Database,
+  entry: {
+    workId: number;
+    chapterId?: number | null;
+    step: PublishLogEntry['step'];
+    userId?: number | null;
+    requestSummary?: string;
+  }
+): Promise<number> {
+  try {
+    const result = await db.prepare(
+      `INSERT INTO publish_log (work_id, chapter_id, step, status, user_id, request_summary, created_at)
+       VALUES (?1, ?2, ?3, 'attempt', ?4, ?5, CURRENT_TIMESTAMP)`
+    )
+      .bind(
+        entry.workId,
+        entry.chapterId ?? null,
+        entry.step,
+        entry.userId ?? null,
+        truncate(entry.requestSummary, 500)
+      )
+      .run();
+
+    return result.meta.last_row_id ?? 0;
+  } catch {
+    // Logger must never break the publish flow — swallow errors
+    console.error('[publish-logger] Failed to log attempt');
+    return 0;
+  }
+}
+
+/**
+ * Update a log entry with the result (success or failure).
+ */
+export async function logPublishResult(
+  db: D1Database,
+  logId: number,
+  result: {
+    status: 'success' | 'fail';
+    httpStatus?: number;
+    error?: string;
+    responseSummary?: string;
+  }
+): Promise<void> {
+  if (!logId) return; // Entry was never created
+  try {
+    await db.prepare(
+      `UPDATE publish_log SET status = ?1, http_status = ?2, error = ?3, response_summary = ?4
+       WHERE id = ?5`
+    )
+      .bind(
+        result.status,
+        result.httpStatus ?? null,
+        truncate(result.error, 500) ?? null,
+        truncate(result.responseSummary, 500) ?? null,
+        logId
+      )
+      .run();
+  } catch {
+    console.error('[publish-logger] Failed to log result');
+  }
+}
+
+/**
+ * Convenience: log attempt + execute + log result in one wrapper.
+ * Use this to wrap any async publish operation.
+ */
+export async function withPublishLog<T>(
+  db: D1Database,
+  entry: {
+    workId: number;
+    chapterId?: number | null;
+    step: PublishLogEntry['step'];
+    userId?: number | null;
+    requestSummary?: string;
+  },
+  fn: () => Promise<{ status: number; body: T; error?: string }>
+): Promise<{ status: number; body: T; error?: string }> {
+  const logId = await logPublishAttempt(db, entry);
+  try {
+    const result = await fn();
+    await logPublishResult(db, logId, {
+      status: 'success',
+      httpStatus: result.status,
+      responseSummary: JSON.stringify(result.body).slice(0, 500),
+    });
+    return result;
+  } catch (err: any) {
+    await logPublishResult(db, logId, {
+      status: 'fail',
+      httpStatus: 500,
+      error: err?.message || String(err),
+    });
+    throw err;
+  }
+}
+
+function truncate(str: string | undefined | null, max: number): string | undefined {
+  if (!str) return undefined;
+  return str.length > max ? str.slice(0, max) + '…' : str;
+}

--- a/src/pages/api/admin/publish-log.ts
+++ b/src/pages/api/admin/publish-log.ts
@@ -1,0 +1,26 @@
+export const prerender = false;
+import { queryAll } from '@/lib/db';
+import { requireRole } from '@/lib/auth';
+import type { APIRoute } from 'astro';
+import { UserRole } from '@/lib/types';
+
+export const GET: APIRoute = async ({ request, locals, url }) => {
+  const db = locals.runtime.env.DB as D1Database;
+  const auth = await requireRole(db, request, UserRole.Admin);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  if ('forbidden' in auth) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  
+  const workId = url.searchParams.get('work_id');
+  const limit = Math.min(Number(url.searchParams.get('limit') || 50), 200);
+  
+  let query = `SELECT * FROM publish_log`;
+  const params: any[] = [];
+  if (workId) {
+    query += ` WHERE work_id = ?1`;
+    params.push(Number(workId));
+  }
+  query += ` ORDER BY created_at DESC LIMIT ${limit}`;
+  
+  const logs = await queryAll<any>(db, query, ...params);
+  return new Response(JSON.stringify({ logs }), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/works/[id]/chapters/[chapterId]/index.ts
+++ b/src/pages/api/works/[id]/chapters/[chapterId]/index.ts
@@ -3,6 +3,7 @@ export const prerender = false;
 import { queryFirst, queryAll, run } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
 import { markdownToHtml } from '@/lib/markdown';
+import { logPublishAttempt, logPublishResult } from '@/lib/publish-logger';
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = async ({ params, locals }) => {
@@ -25,6 +26,9 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   const chapterId = Number(params.chapterId);
   if (!workId || !chapterId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
 
+  // Publish log: record attempt
+  const isPublishOp = (() => { try { const b = JSON.parse(request.headers.get('x-body-preview') || '{}'); return b.draft === 0; } catch { return false; } })();
+
   const creatorship = await queryFirst<any>(db, `SELECT * FROM creatorships WHERE work_id = ?1 AND pseud_id IN (SELECT id FROM pseuds WHERE user_id = ?2)`, workId, auth.user.id);
   if (!creatorship) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
 
@@ -34,6 +38,16 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   let body: any;
   try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
 
+  // Publish log: record attempt with actual body data
+  const logId = await logPublishAttempt(db, {
+    workId,
+    chapterId,
+    step: 'chapter_save',
+    userId: auth.user.id,
+    requestSummary: JSON.stringify({ title: body.title, draft: body.draft, hasContent: !!body.content_md, contentLen: body.content_md?.length }),
+  });
+
+  try {
   await run(db, `INSERT INTO chapter_versions (chapter_id, version, content_md, content_html, note, created_at) SELECT id, (SELECT COALESCE(MAX(version), 0) + 1 FROM chapter_versions WHERE chapter_id = ?1), content_md, content_html, 'Auto-save before update', datetime('now') FROM chapters WHERE id = ?1`, chapterId);
 
   const fields: string[] = [];
@@ -77,5 +91,10 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   await run(db, `UPDATE works SET word_count = (SELECT COALESCE(SUM(word_count), 0) FROM chapters WHERE work_id = ?1 AND draft = 0) WHERE id = ?1`, workId);
 
   const updated = await queryFirst<any>(db, `SELECT * FROM chapters WHERE id = ?1`, chapterId);
+  await logPublishResult(db, logId, { status: 'success', httpStatus: 200, responseSummary: JSON.stringify({id: updated?.id, draft: updated?.draft, word_count: updated?.word_count}).slice(0,200) });
   return new Response(JSON.stringify(updated), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    await logPublishResult(db, logId, { status: 'fail', httpStatus: 500, error: err?.message });
+    throw err;
+  }
 };

--- a/src/pages/api/works/[id]/chapters/[chapterId]/publish.ts
+++ b/src/pages/api/works/[id]/chapters/[chapterId]/publish.ts
@@ -2,6 +2,7 @@ export const prerender = false;
 
 import { queryFirst, run } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
+import { logPublishAttempt, logPublishResult } from '@/lib/publish-logger';
 import type { APIRoute } from 'astro';
 
 export const POST: APIRoute = async ({ params, request, locals }) => {
@@ -15,10 +16,19 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   const creatorship = await queryFirst<any>(db, `SELECT * FROM creatorships WHERE work_id = ?1 AND pseud_id IN (SELECT id FROM pseuds WHERE user_id = ?2)`, workId, auth.user.id);
   if (!creatorship) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
 
-  await run(db, `UPDATE chapters SET draft = 0, updated_at = datetime('now') WHERE id = ?1 AND work_id = ?2`, chapterId, workId);
-  await run(db, `UPDATE works SET published_at = COALESCE(published_at, datetime('now')), updated_at = datetime('now') WHERE id = ?1`, workId);
-  await run(db, `UPDATE works SET word_count = (SELECT COALESCE(SUM(word_count), 0) FROM chapters WHERE work_id = ?1 AND draft = 0) WHERE id = ?1`, workId);
+  const logId = await logPublishAttempt(db, { workId, chapterId, step: 'chapter_publish_post', userId: auth.user.id, requestSummary: 'POST /publish' });
 
-  const chapter = await queryFirst<any>(db, `SELECT * FROM chapters WHERE id = ?1`, chapterId);
-  return new Response(JSON.stringify(chapter), { headers: { 'Content-Type': 'application/json' } });
+  try {
+    await run(db, `UPDATE chapters SET draft = 0, updated_at = datetime('now') WHERE id = ?1 AND work_id = ?2`, chapterId, workId);
+    await run(db, `UPDATE works SET published_at = COALESCE(published_at, datetime('now')), updated_at = datetime('now') WHERE id = ?1`, workId);
+    await run(db, `UPDATE works SET word_count = (SELECT COALESCE(SUM(word_count), 0) FROM chapters WHERE work_id = ?1 AND draft = 0) WHERE id = ?1`, workId);
+
+    await logPublishResult(db, logId, { status: 'success', httpStatus: 200 });
+
+    const chapter = await queryFirst<any>(db, `SELECT * FROM chapters WHERE id = ?1`, chapterId);
+    return new Response(JSON.stringify(chapter), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    await logPublishResult(db, logId, { status: 'fail', httpStatus: 500, error: err?.message });
+    throw err;
+  }
 };

--- a/src/pages/api/works/[id]/index.ts
+++ b/src/pages/api/works/[id]/index.ts
@@ -2,6 +2,7 @@ export const prerender = false;
 
 import { queryFirst, queryAll, run } from '@/lib/db';
 import { getAuth, requireAuth } from '@/lib/auth';
+import { logPublishAttempt, logPublishResult } from '@/lib/publish-logger';
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = async ({ params, locals, request }) => {
@@ -48,6 +49,13 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 
   let body: any;
   try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
+
+  let workLogId: number = 0;
+  if (body.publish) {
+    workLogId = await logPublishAttempt(db, { workId, step: 'work_publish', userId: auth.user.id, requestSummary: JSON.stringify({ publish: true }) });
+  }
+
+  try {
 
   // Handle tag updates: resolve tag_names + tag_ids, then clear and re-add
   const resolvedTagIds: number[] = [...(Array.isArray(body.tag_ids) ? body.tag_ids.filter((id: any) => typeof id === 'number' && id > 0) : [])];
@@ -124,10 +132,15 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   if (body.publish) {
     await run(db, `UPDATE chapters SET draft = 0, updated_at = datetime('now') WHERE work_id = ?1 AND draft = 1`, workId);
     await run(db, `UPDATE works SET word_count = (SELECT COALESCE(SUM(word_count), 0) FROM chapters WHERE work_id = ?1 AND draft = 0) WHERE id = ?1`, workId);
+    await logPublishResult(db, workLogId, { status: 'success', httpStatus: 200, responseSummary: JSON.stringify({ published_at: work?.published_at }).slice(0,200) });
   }
 
   const work = await queryFirst<any>(db, `SELECT * FROM works WHERE id = ?1`, workId);
   return new Response(JSON.stringify(work), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    if (workLogId) await logPublishResult(db, workLogId, { status: 'fail', httpStatus: 500, error: err?.message });
+    throw err;
+  }
 };
 
 export const DELETE: APIRoute = async ({ params, request, locals }) => {


### PR DESCRIPTION
## Summary

Adds a D1-backed persistent logging system to record every publish attempt and result, making it possible to debug publish flow failures after the fact.

## What changed

### New module: `src/lib/publish-logger.ts`
- `logPublishAttempt(db, { workId, chapterId?, step, userId, requestSummary? })` — inserts a row with status `"attempt"` and returns the log entry ID
- `logPublishResult(db, logId, { status, httpStatus?, error?, responseSummary? })` — updates the row with success/failure details
- `withPublishLog(db, entry, fn)` — convenience wrapper that logs attempt → runs `fn` → logs result (or logs error on throw)
- All functions swallow their own errors so the logger can never break the publish flow

### Instrumented endpoints
1. **Chapter PUT** (`/api/works/:id/chapters/:chapterId`) — logs `step: "chapter_save"` on every save; logs success with `{id, draft, word_count}` summary, or failure with error message
2. **Work PUT** (`/api/works/:id`) — logs `step: "work_publish"` when `body.publish === true`; logs success with `published_at`, or failure
3. **Chapter POST /publish** (`/api/works/:id/chapters/:chapterId/publish`) — logs `step: "chapter_publish_post"`; logs success or failure

All three handlers are wrapped in try/catch that logs `status: "fail"` before re-throwing.

### New admin endpoint
- **GET `/api/admin/publish-log`** — requires Admin role
  - Query params: `work_id` (filter by work), `limit` (max 200, default 50)
  - Returns `{ logs: [...] }` ordered by `created_at DESC`

### Database
- `publish_log` table (already applied on remote D1): `id, created_at, work_id, chapter_id, step, status, http_status, error, user_id, request_summary, response_summary`

## How to use

Query the admin endpoint to inspect publish attempts:
```
GET /api/admin/publish-log?work_id=42&limit=100
```

Each log entry shows the step, attempt → success/fail transition, HTTP status, error messages, and truncated request/response summaries.