### PR TITLE
fix: remove TypeScript syntax from define:vars script block

### DIFF
--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -506,30 +506,31 @@ const initialChapterData = JSON.stringify({
   let currentChapterId = initialChapter.id;
   let currentChapterPosition = 1;
 
-  const chapterList = document.getElementById('chapter-list')!;
-  const chapterTitle = document.getElementById('chapter-title') as HTMLInputElement;
-  const wordCountEl = document.getElementById('word-count')!;
-  const autosaveStatus = document.getElementById('autosave-status')!;
-  const saveDraftBtn = document.getElementById('save-draft-btn') as HTMLButtonElement;
-  const publishBtn = document.getElementById('publish-btn') as HTMLButtonElement;
-  const addChapterBtn = document.getElementById('add-chapter-btn')!;
-  const focusModeBtn = document.getElementById('focus-mode-btn')!;
-  const workspace = document.getElementById('draft-workspace')!;
+  const chapterList = document.getElementById('chapter-list');
+  const chapterTitle = document.getElementById('chapter-title');
+  const wordCountEl = document.getElementById('word-count');
+  const autosaveStatus = document.getElementById('autosave-status');
+  const saveDraftBtn = document.getElementById('save-draft-btn');
+  const publishBtn = document.getElementById('publish-btn');
+  const addChapterBtn = document.getElementById('add-chapter-btn');
+  const focusModeBtn = document.getElementById('focus-mode-btn');
+  const workspace = document.getElementById('draft-workspace');
 
   // Set initial word count from server data
   wordCountEl.textContent = `${initialChapter.word_count || 0} words`;
 
   // ── Toast helper ──
-  function showToast(message: string, type: 'success' | 'error' | 'info' | 'warning' = 'info') {
-    if ((window as any).showToast) {
-      (window as any).showToast(message, type);
+  function showToast(message, type) {
+    if (type === undefined) type = 'info';
+    if (window.showToast) {
+      window.showToast(message, type);
     }
   }
 
   // ── DEBUG: Client-side publish flow tracer ──
   // Sends every publish-related state change to /api/admin/client-log
   // so we can see exactly what happens in the browser even if toasts fail.
-  async function clientLog(action: string, detail: string) {
+  function clientLog(action, detail) {
     try {
       navigator.sendBeacon('/api/client-log',
         JSON.stringify({ action, detail, url: location.href, ts: Date.now() }));
@@ -539,7 +540,7 @@ const initialChapterData = JSON.stringify({
   // ── Unsaved changes guard ──
   let hasUnsavedChanges = false;
   let isSaving = false;
-  let savePromise: Promise<any> | null = null;
+  let savePromise = null;
 
   window.addEventListener('beforeunload', (e) => {
     if (hasUnsavedChanges) {
@@ -552,7 +553,7 @@ const initialChapterData = JSON.stringify({
   // Serialization token to prevent out-of-order chapter switches from rapid clicks
   let chapterSwitchToken = 0;
 
-  async function selectChapter(chapterId: number) {
+  async function selectChapter(chapterId) {
     if (currentChapterId === chapterId) return;
 
     const thisToken = ++chapterSwitchToken;
@@ -571,7 +572,7 @@ const initialChapterData = JSON.stringify({
     if (chapterSwitchToken !== thisToken) return;
 
     currentChapterId = chapterId;
-    const chapter = work.chapters.find((c: any) => c.id === chapterId);
+    const chapter = work.chapters.find((c) => c.id === chapterId);
     if (!chapter) return;
 
     currentChapterPosition = chapter.position;
@@ -580,7 +581,7 @@ const initialChapterData = JSON.stringify({
 
     // Update active state in sidebar
     document.querySelectorAll('.draft-chapter-item').forEach(el => {
-      el.classList.toggle('draft-chapter-item--active', Number((el as HTMLElement).dataset.chapterId) === chapterId);
+      el.classList.toggle('draft-chapter-item--active', Number(el.dataset.chapterId) === chapterId);
     });
 
     // Load chapter content via API
@@ -593,8 +594,8 @@ const initialChapterData = JSON.stringify({
         // Check again after parsing JSON — another switch may have started
         if (chapterSwitchToken !== thisToken) return;
         const contentMd = data.content_md || '';
-        if ((window as any).__editorSetContent) {
-          (window as any).__editorSetContent(contentMd);
+        if (window.__editorSetContent) {
+          window.__editorSetContent(contentMd);
         }
         const words = contentMd.split(/\s+/).filter(Boolean).length;
         wordCountEl.textContent = `${words} words`;
@@ -607,7 +608,7 @@ const initialChapterData = JSON.stringify({
   // Bind chapter click handlers
   document.querySelectorAll('.draft-chapter-item').forEach(btn => {
     btn.addEventListener('click', () => {
-      const id = Number((btn as HTMLElement).dataset.chapterId);
+      const id = Number(btn.dataset.chapterId);
       selectChapter(id);
     });
   });
@@ -616,7 +617,7 @@ const initialChapterData = JSON.stringify({
   addChapterBtn.addEventListener('click', async () => {
     try {
       const nextPos = work.chapters.length > 0
-        ? Math.max(...work.chapters.map((c: any) => c.position)) + 1
+        ? Math.max(...work.chapters.map((c) => c.position)) + 1
         : 1;
       const res = await fetch(`/api/works/${workId}/chapters`, {
         method: 'POST',
@@ -638,7 +639,7 @@ const initialChapterData = JSON.stringify({
     }
   });
 
-  function escapeHtml(str: string) {
+  function escapeHtml(str) {
     const div = document.createElement('div');
     div.textContent = str;
     return div.innerHTML;
@@ -646,8 +647,8 @@ const initialChapterData = JSON.stringify({
 
   function renderChapterList() {
     chapterList.innerHTML = work.chapters
-      .sort((a: any, b: any) => a.position - b.position)
-      .map((c: any) => `
+      .sort((a, b) => a.position - b.position)
+      .map((c) => `
         <button type="button" class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}"
           data-chapter-id="${escapeHtml(String(c.id))}" data-position="${escapeHtml(String(c.position))}" role="listitem">
           <span class="draft-chapter-item-title">Ch. ${escapeHtml(String(c.position))}: ${escapeHtml(c.title)}</span>
@@ -657,16 +658,18 @@ const initialChapterData = JSON.stringify({
     // Re-bind click handlers
     document.querySelectorAll('.draft-chapter-item').forEach(btn => {
       btn.addEventListener('click', () => {
-        const id = Number((btn as HTMLElement).dataset.chapterId);
+        const id = Number(btn.dataset.chapterId);
         selectChapter(id);
       });
     });
   }
 
   // ── Save / Publish ──
-  let saveTimeout: ReturnType<typeof setTimeout>;
+  let saveTimeout;
 
-  async function saveChapter(draft: boolean = true, silent: boolean = false): Promise<boolean> {
+  async function saveChapter(draft, silent) {
+    if (draft === undefined) draft = true;
+    if (silent === undefined) silent = false;
     clientLog('saveChapter_start', `draft=${draft} silent=${silent} currentChapterId=${currentChapterId} isSaving=${isSaving}`);
     if (!currentChapterId) return false;
 
@@ -679,9 +682,9 @@ const initialChapterData = JSON.stringify({
     }
 
     // Read content after any queued save has finished so we don't send stale data
-    const contentMd = (window as any).__editorMarkdown || '';
+    const contentMd = window.__editorMarkdown || '';
     const title = chapterTitle.value || `Chapter ${currentChapterPosition}`;
-    clientLog('saveChapter_content', `title="${title}" mdLen=${contentMd.length} editorMarkdown=${typeof (window as any).__editorMarkdown}`);
+    clientLog('saveChapter_content', `title="${title}" mdLen=${contentMd.length} editorMarkdown=${typeof window.__editorMarkdown}`);
 
     // Snapshot content at save time — only clear dirty flag if no new edits happened
     const contentAtSaveStart = contentMd;
@@ -698,8 +701,8 @@ const initialChapterData = JSON.stringify({
     }
 
     // Assign savePromise so queued callers can await this operation
-    let resolveSave: () => void;
-    savePromise = new Promise<void>(resolve => { resolveSave = resolve; });
+    let resolveSave;
+    savePromise = new Promise((resolve) => { resolveSave = resolve; });
 
     try {
       clientLog('saveChapter_fetch', `PUT /api/works/${workId}/chapters/${currentChapterId} draft=${draft ? 1 : 0}`);
@@ -711,7 +714,7 @@ const initialChapterData = JSON.stringify({
       clientLog('saveChapter_response', `status=${res.status} ok=${res.ok}`);
       if (res.ok) {
         // Only clear dirty flag if no new edits happened while we were saving
-        const contentNow = (window as any).__editorMarkdown || '';
+        const contentNow = window.__editorMarkdown || '';
         if (contentNow === contentAtSaveStart) {
           hasUnsavedChanges = false;
         }
@@ -724,7 +727,7 @@ const initialChapterData = JSON.stringify({
           autosaveStatus.style.color = 'var(--md-sys-color-outline)';
         }
         // Update local chapter data
-        const ch = work.chapters.find((c: any) => c.id === currentChapterId);
+        const ch = work.chapters.find((c) => c.id === currentChapterId);
         if (ch) {
           ch.title = title;
           ch.draft = draft;
@@ -761,7 +764,7 @@ const initialChapterData = JSON.stringify({
     } finally {
       isSaving = false;
       savePromise = null;
-      resolveSave!();
+      resolveSave();
       // Only restore buttons if this wasn't a silent save and publish flow
       // isn't controlling them. In silent mode, preserve whatever state they were in.
       if (!silent) {
@@ -841,8 +844,8 @@ const initialChapterData = JSON.stringify({
   }
 
   // Hook into editor content changes via the global callback
-  const originalOnContentChange = (window as any).__editorOnContentChange;
-  (window as any).__editorOnContentChange = (md: string) => {
+  const originalOnContentChange = window.__editorOnContentChange;
+  window.__editorOnContentChange = (md) => {
     const words = md.split(/\s+/).filter(Boolean).length;
     wordCountEl.textContent = `${words} words`;
     scheduleAutosave();


### PR DESCRIPTION
## Root Cause
The `<script define:vars>` block in Astro is **not transpiled** — it is injected as-is into the browser HTML. TypeScript syntax like `!`, `as Type`, `: string`, and `Promise<boolean>` causes `SyntaxError: Unexpected token` in the browser, which **kills the entire script block** before any event listeners are registered.

This is why "Publish Chapter" did nothing when clicked — `publishBtn.addEventListener` never executed.

## Changes
Removed all TypeScript-only syntax from the `define:vars` block in `draft.astro`:
- `document.getElementById(x)!` → `document.getElementById(x)`
- `as HTMLInputElement/HTMLElement/ButtonElement` → removed
- `(window as any).__x` → `window.__x`
- Function parameter types → defaults with `if (x === undefined)`
- `resolveSave!()` → `resolveSave()`
- `let savePromise: Promise<any> | null` → `let savePromise = null`
- Arrow type annotations `(c: any)` → `(c)`
- `new Promise<void>()` → `new Promise()`

## Verification
- Build succeeds (`npx astro build` ✅)
- Diagnostic overlay confirmed: button exists, disabled=false, clicks captured — but no action because define:vars script crashed on SyntaxError