### PR TITLE
fix: return proper JSON error from work PUT handler

### DIFF
--- a/src/pages/api/works/[id]/index.ts
+++ b/src/pages/api/works/[id]/index.ts
@@ -116,6 +116,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   if (body.complete !== undefined) { fields.push('complete = ?'); values.push(body.complete ? 1 : 0); }
   if (body.language !== undefined) { fields.push('language = ?'); values.push(body.language); }
   if (body.publish) {
+    console.log('[WORK_PUT] Publishing work:', workId, 'body keys:', Object.keys(body).join(','));
     // Set published_at only if it's currently null (first publish)
     fields.push("published_at = COALESCE(published_at, CURRENT_TIMESTAMP)");
   }
@@ -137,9 +138,10 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 
   const work = await queryFirst<any>(db, `SELECT * FROM works WHERE id = ?1`, workId);
   return new Response(JSON.stringify(work), { headers: { 'Content-Type': 'application/json' } });
-  } catch (err: any) {
-    if (workLogId) await logPublishResult(db, workLogId, { status: 'fail', httpStatus: 500, error: err?.message });
-    throw err;
+  } catch (err) {
+    console.error('[WORK_PUT] Error updating work:', workId, err);
+    if (workLogId) await logPublishResult(db, workLogId, { status: 'fail', httpStatus: 500, error: String(err?.message || err) });
+    return new Response(JSON.stringify({ error: err?.message || 'Internal server error' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
   }
 };
 


### PR DESCRIPTION
## Problem
The work PUT handler (`PUT /api/works/:id`) was catching errors and then re-throwing with `throw err`. This caused Astro to return a non-JSON 500 response, which the client could not parse — resulting in the unhelpful "Unknown error" toast.

## Fix
Changed the catch block to:
1. `console.error` the full error for server-side debugging
2. Return a proper JSON 500 response with `err?.message || "Internal server error"`
3. Added a `console.log` at the start of the `body.publish` block to trace the publish flow

This is the second fix in the publish flow — the first fix (PR #49) resolved the SyntaxError that prevented the script from running at all. This fix ensures that when the work-publish API call fails, the actual error message reaches the client.

## Test
After merge: click "Publish Chapter" again. If it still fails, the toast will now show the **actual** error message instead of "Unknown error" — which will tell us exactly what D1 query is failing.