### PR TITLE
fix: inverted exclusiveFilter in sanitize-html — all chapter content silently stripped

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -38,19 +38,16 @@ export function markdownToHtml(md: string): string {
           : attribs,
       }),
     },
-    // Validate img src — allow /api/storage/ paths and absolute https URLs
+    // Filter: only allow img tags with safe src URLs (allow-list approach)
+    // exclusiveFilter returns true to REMOVE the element
     exclusiveFilter: (frame) => {
-      // For img tags, ensure src is a safe URL
       if (frame.tag === 'img') {
         const src = frame.attribs.src || '';
-        // Allow /api/storage/ relative paths (our R2 proxy)
-        if (src.startsWith('/api/storage/')) return true;
-        // Allow absolute https URLs
-        if (src.startsWith('https://')) return true;
-        // Reject everything else (data: URIs, javascript:, etc.)
-        return false;
+        // Remove imgs that do NOT have safe URLs (allow only /api/storage/ and https://)
+        const isSafe = src.startsWith('/api/storage/') || src.startsWith('https://');
+        return !isSafe; // true = remove unsafe imgs, false = keep safe imgs
       }
-      return true;
+      return false; // false = keep all non-img elements
     },
   });
 }


### PR DESCRIPTION
## Bug

Every chapter published to fanfiction.fyi had its `content_html` stored as `"\n"` — effectively empty. The work view page showed "Content not available." for any published chapter.

### Root Cause
The `exclusiveFilter` in `markdownToHtml()` had its **boolean logic inverted**. In `sanitize-html` v2.x:
- `exclusiveFilter` returns `true` → **REMOVE** the element
- `exclusiveFilter` returns `false` → **KEEP** the element

The code did the opposite:
```ts
// WRONG — removes valid imgs, keeps invalid ones
if (src.startsWith("/api/storage/")) return true;   // removes valid imgs!
return false;  // keeps invalid imgs!

// WRONG — strips ALL non-img tags
return true;  // removes every <p>, <em>, <strong>, etc.
```

Result: `markdownToHtml("Any text here")` → `"\n"` — every HTML element stripped.

### Fix
Invert the logic:
```ts
const isSafe = src.startsWith("/api/storage/") || src.startsWith("https://");
return !isSafe; // true = remove unsafe imgs, false = keep safe imgs
// ...
return false; // false = keep all non-img elements
```

### D1 Data Fix
Chapter 7 had `content_html = "\n"`. Patched to regenerated value `<p>Now this is podracing!...</p>` from existing `content_md`.

### Test
```
Before: markdownToHtml("Hello world") → "\n" (Len: 1)
After:  markdownToHtml("Hello world") → "<p>Hello world</p>\n" (Len: 20)
```