### PR TITLE
feat: Alias Management UX Upgrade — Cards, Visual Identity, Default Pseud, Stats

### DIFF
--- a/schema/019_pseud_enhancements.sql
+++ b/schema/019_pseud_enhancements.sql
@@ -7,6 +7,14 @@ ALTER TABLE pseuds ADD COLUMN theme_color TEXT DEFAULT NULL;
 -- Default pseud flag (only one per user)
 ALTER TABLE pseuds ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0;
 
+-- Backfill: mark the earliest pseud per user as default so every existing
+-- account has exactly one default pseud before the unique index is created.
+UPDATE pseuds
+SET is_default = 1
+WHERE id IN (
+  SELECT MIN(id) FROM pseuds GROUP BY user_id
+);
+
 -- Partial unique index: at most one default pseud per user
 -- SQLite doesn't support CREATE UNIQUE INDEX ... WHERE directly in all contexts,
 -- but D1 (SQLite 3.37+) supports partial indexes.

--- a/schema/019_pseud_enhancements.sql
+++ b/schema/019_pseud_enhancements.sql
@@ -1,0 +1,13 @@
+-- Pseud enhancements — visual identity, default pseud, stats
+-- Issue #53: Alias Management UX Upgrade
+
+-- Theme color for each pseud (hex color string, e.g. '#4A90D9')
+ALTER TABLE pseuds ADD COLUMN theme_color TEXT DEFAULT NULL;
+
+-- Default pseud flag (only one per user)
+ALTER TABLE pseuds ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0;
+
+-- Partial unique index: at most one default pseud per user
+-- SQLite doesn't support CREATE UNIQUE INDEX ... WHERE directly in all contexts,
+-- but D1 (SQLite 3.37+) supports partial indexes.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pseuds_user_default ON pseuds(user_id) WHERE is_default = 1;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,7 +47,14 @@ export interface Pseud {
   name: string;
   description?: string | null;
   icon_key?: string | null;
+  theme_color?: string | null;
+  is_default: number; // 0 or 1 (SQLite doesn't have booleans)
+  banner_key?: string | null;
+  pinned_work_ids?: string | null; // JSON array string
   created_at: string;
+  // Joined fields (from GET /api/pseuds)
+  work_count?: number;
+  series_count?: number;
 }
 
 export interface Work {

--- a/src/pages/api/pseuds/[id].ts
+++ b/src/pages/api/pseuds/[id].ts
@@ -19,7 +19,7 @@ export const GET: APIRoute = async ({ request, locals, params }) => {
   return new Response(JSON.stringify(pseud), { headers: { 'Content-Type': 'application/json' } });
 };
 
-/** PUT /api/pseuds/[id] — update pseud name/description (owner only) */
+/** PUT /api/pseuds/[id] — update pseud (owner only) */
 export const PUT: APIRoute = async ({ request, locals, params }) => {
   const db = locals.runtime.env.DB as D1Database;
   const auth = await requireAuth(db, request);
@@ -37,7 +37,7 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
-  const { name, description, icon_key, pinned_work_ids, banner_key } = body || {};
+  const { name, description, icon_key, pinned_work_ids, banner_key, theme_color, is_default } = body || {};
   const newName = (typeof name === 'string' ? name.trim() : existing.name);
   const newDesc = (description !== undefined ? (typeof description === 'string' ? description : null) : existing.description);
   const newIconKey = (icon_key !== undefined ? (typeof icon_key === 'string' ? icon_key : null) : existing.icon_key);
@@ -68,6 +68,15 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
   // Banner key validation
   const newBannerKey = (banner_key !== undefined ? (typeof banner_key === 'string' ? banner_key : null) : existing.banner_key);
 
+  // Theme color validation (hex color)
+  let newThemeColor = existing.theme_color;
+  if (theme_color !== undefined) {
+    if (theme_color !== null && !/^#[0-9a-fA-F]{3,8}$/.test(String(theme_color))) {
+      return new Response(JSON.stringify({ error: 'Invalid theme color format' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    newThemeColor = theme_color === null ? null : String(theme_color);
+  }
+
   // Name validation
   if (!newName || newName.length === 0) {
     return new Response(JSON.stringify({ error: 'Name is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
@@ -84,7 +93,15 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     }
   }
 
-  await run(db, `UPDATE pseuds SET name = ?1, description = ?2, icon_key = ?3, pinned_work_ids = ?4, banner_key = ?5 WHERE id = ?6 AND user_id = ?7`, newName, newDesc, newIconKey, newPinnedWorkIds, newBannerKey, pseudId, auth.user.id);
+  // Handle is_default: only one pseud per user can be default
+  if (is_default === 1) {
+    await run(db, `UPDATE pseuds SET is_default = 0 WHERE user_id = ?1`, auth.user.id);
+  }
+
+  await run(db,
+    `UPDATE pseuds SET name = ?1, description = ?2, icon_key = ?3, pinned_work_ids = ?4, banner_key = ?5, theme_color = ?6, is_default = ?7 WHERE id = ?8 AND user_id = ?9`,
+    newName, newDesc, newIconKey, newPinnedWorkIds, newBannerKey, newThemeColor, (is_default === 1 ? 1 : existing.is_default), pseudId, auth.user.id
+  );
 
   const updated = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1`, pseudId);
   return new Response(JSON.stringify(updated), { headers: { 'Content-Type': 'application/json' } });
@@ -119,6 +136,14 @@ export const DELETE: APIRoute = async ({ request, locals, params }) => {
       JSON.stringify({ error: 'You must have at least one pseud. Create a new one before deleting this one.' }),
       { status: 409, headers: { 'Content-Type': 'application/json' } }
     );
+  }
+
+  // If deleting the default pseud, promote the first remaining one
+  if (existing.is_default === 1) {
+    const remaining = allPseuds.filter((p: any) => p.id !== pseudId);
+    if (remaining.length > 0) {
+      await run(db, `UPDATE pseuds SET is_default = 1 WHERE id = ?1`, remaining[0].id);
+    }
   }
 
   // Delete related records first (comments, kudos, bookmarks, readings)

--- a/src/pages/api/pseuds/[id].ts
+++ b/src/pages/api/pseuds/[id].ts
@@ -71,7 +71,7 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
   // Theme color validation (hex color)
   let newThemeColor = existing.theme_color;
   if (theme_color !== undefined) {
-    if (theme_color !== null && !/^#[0-9a-fA-F]{3,8}$/.test(String(theme_color))) {
+    if (theme_color !== null && !/^(?:#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8})$/.test(String(theme_color))) {
       return new Response(JSON.stringify({ error: 'Invalid theme color format' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
     }
     newThemeColor = theme_color === null ? null : String(theme_color);
@@ -93,14 +93,27 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     }
   }
 
-  // Handle is_default: only one pseud per user can be default
-  if (is_default === 1) {
-    await run(db, `UPDATE pseuds SET is_default = 0 WHERE user_id = ?1`, auth.user.id);
-  }
-
+  // Handle is_default atomically: if promoting this pseud to default, clear all others in the same statement
   await run(db,
-    `UPDATE pseuds SET name = ?1, description = ?2, icon_key = ?3, pinned_work_ids = ?4, banner_key = ?5, theme_color = ?6, is_default = ?7 WHERE id = ?8 AND user_id = ?9`,
-    newName, newDesc, newIconKey, newPinnedWorkIds, newBannerKey, newThemeColor, (is_default === 1 ? 1 : existing.is_default), pseudId, auth.user.id
+    `UPDATE pseuds SET
+       name         = CASE WHEN id = ?8 THEN ?1 ELSE name END,
+       description  = CASE WHEN id = ?8 THEN ?2 ELSE description END,
+       icon_key     = CASE WHEN id = ?8 THEN ?3 ELSE icon_key END,
+       pinned_work_ids = CASE WHEN id = ?8 THEN ?4 ELSE pinned_work_ids END,
+       banner_key   = CASE WHEN id = ?8 THEN ?5 ELSE banner_key END,
+       theme_color  = CASE WHEN id = ?8 THEN ?6 ELSE theme_color END,
+       is_default   = CASE
+                        WHEN ?7 = 1 AND id = ?8 THEN 1
+                        WHEN ?7 = 1             THEN 0
+                        WHEN id = ?8            THEN ?10
+                        ELSE is_default
+                      END
+     WHERE user_id = ?9 AND (?7 = 1 OR id = ?8)`,
+    newName, newDesc, newIconKey, newPinnedWorkIds, newBannerKey, newThemeColor,
+    is_default === 1 ? 1 : 0,
+    pseudId,
+    auth.user.id,
+    existing.is_default
   );
 
   const updated = await queryFirst<any>(db, `SELECT * FROM pseuds WHERE id = ?1`, pseudId);
@@ -138,8 +151,9 @@ export const DELETE: APIRoute = async ({ request, locals, params }) => {
     );
   }
 
-  // If deleting the default pseud, promote the first remaining one
+  // If deleting the default pseud, first clear its flag then promote the next one
   if (existing.is_default === 1) {
+    await run(db, `UPDATE pseuds SET is_default = 0 WHERE id = ?1`, pseudId);
     const remaining = allPseuds.filter((p: any) => p.id !== pseudId);
     if (remaining.length > 0) {
       await run(db, `UPDATE pseuds SET is_default = 1 WHERE id = ?1`, remaining[0].id);

--- a/src/pages/api/pseuds/index.ts
+++ b/src/pages/api/pseuds/index.ts
@@ -9,12 +9,15 @@ export const GET: APIRoute = async ({ request, locals }) => {
   const auth = await requireAuth(db, request);
   if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   const pseuds = await queryAll<any>(db, `
-    SELECT p.*, COUNT(c.id) as work_count
+    SELECT p.*,
+      COUNT(DISTINCT c.id) as work_count,
+      COUNT(DISTINCT sw.series_id) as series_count
     FROM pseuds p
     LEFT JOIN creatorships c ON c.pseud_id = p.id
+    LEFT JOIN serial_works sw ON sw.work_id = c.work_id
     WHERE p.user_id = ?1
     GROUP BY p.id
-    ORDER BY p.id
+    ORDER BY p.is_default DESC, p.id
   `, auth.user.id);
   return new Response(JSON.stringify(pseuds), { headers: { 'Content-Type': 'application/json' } });
 };
@@ -47,8 +50,22 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   const desc = (description !== undefined && description !== null) ? String(description) : null;
   const iconKey = (body.icon_key !== undefined && body.icon_key !== null) ? String(body.icon_key) : null;
-  const result = await run(db, `INSERT INTO pseuds (user_id, name, description, icon_key, created_at) VALUES (?1, ?2, ?3, ?4, datetime('now'))`, auth.user.id, trimmedName, desc, iconKey);
-  const pseud = await queryAll<any>(db, `SELECT *, 0 as work_count FROM pseuds WHERE id = ?1`, result.meta.last_row_id);
+  const themeColor = (body.theme_color !== undefined && body.theme_color !== null) ? String(body.theme_color) : null;
+
+  // Validate theme_color format (hex color)
+  if (themeColor && !/^#[0-9a-fA-F]{3,8}$/.test(themeColor)) {
+    return new Response(JSON.stringify({ error: 'Invalid theme color format' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // If this is the user's first pseud, make it default
+  const pseudCount = await queryAll<any>(db, `SELECT COUNT(*) as cnt FROM pseuds WHERE user_id = ?1`, auth.user.id);
+  const isDefault = (pseudCount[0].cnt === 0) ? 1 : 0;
+
+  const result = await run(db,
+    `INSERT INTO pseuds (user_id, name, description, icon_key, theme_color, is_default, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))`,
+    auth.user.id, trimmedName, desc, iconKey, themeColor, isDefault
+  );
+  const pseud = await queryAll<any>(db, `SELECT *, 0 as work_count, 0 as series_count FROM pseuds WHERE id = ?1`, result.meta.last_row_id);
 
   return new Response(JSON.stringify(pseud[0]), { status: 201, headers: { 'Content-Type': 'application/json' } });
 };

--- a/src/pages/api/pseuds/index.ts
+++ b/src/pages/api/pseuds/index.ts
@@ -10,7 +10,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
   if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   const pseuds = await queryAll<any>(db, `
     SELECT p.*,
-      COUNT(DISTINCT c.id) as work_count,
+      COUNT(DISTINCT c.work_id) as work_count,
       COUNT(DISTINCT sw.series_id) as series_count
     FROM pseuds p
     LEFT JOIN creatorships c ON c.pseud_id = p.id
@@ -53,7 +53,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const themeColor = (body.theme_color !== undefined && body.theme_color !== null) ? String(body.theme_color) : null;
 
   // Validate theme_color format (hex color)
-  if (themeColor && !/^#[0-9a-fA-F]{3,8}$/.test(themeColor)) {
+  if (themeColor && !/^(?:#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8})$/.test(themeColor)) {
     return new Response(JSON.stringify({ error: 'Invalid theme color format' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -760,7 +760,7 @@ const themesJSON = JSON.stringify(
     var html = '';
     THEME_COLORS.forEach(function(color) {
       var isSelected = (color === selectedColor);
-      html += '<button type="button" class="color-swatch' + (isSelected ? ' color-swatch--selected' : '') + '" data-color="' + escapeHtml(color) + '" style="background:' + escapeHtml(color) + '" title="' + escapeHtml(color) + '">';
+      html += '<button type="button" class="color-swatch' + (isSelected ? ' color-swatch--selected' : '') + '" data-color="' + escapeHtml(color) + '" style="background:' + escapeHtml(color) + '" title="' + escapeHtml(color) + '" aria-label="Theme color ' + escapeHtml(color) + '" aria-pressed="' + (isSelected ? 'true' : 'false') + '">';
       if (isSelected) html += '<svg class="color-swatch-check" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
       html += '</button>';
     });
@@ -818,8 +818,8 @@ const themesJSON = JSON.stringify(
       html += '    </div>';
       html += '  </div>';
       html += '  <div class="pseud-card-right">';
-      html += '    <button type="button" class="pseud-menu-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" aria-label="Menu for ' + escapeHtml(p.name) + '">⋮</button>';
-      html += '    <div class="pseud-dropdown" data-pseud-id="' + escapeHtml(String(p.id)) + '">';
+      html += '    <button type="button" class="pseud-menu-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" aria-label="Menu for ' + escapeHtml(p.name) + '" aria-haspopup="true" aria-expanded="false" aria-controls="pseud-dropdown-' + escapeHtml(String(p.id)) + '">⋮</button>';
+      html += '    <div class="pseud-dropdown" id="pseud-dropdown-' + escapeHtml(String(p.id)) + '" data-pseud-id="' + escapeHtml(String(p.id)) + '">';
       html += '      <button type="button" class="pseud-dropdown-item pseud-edit-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '">Edit</button>';
       if (p.is_default != 1) {
         html += '    <button type="button" class="pseud-dropdown-item pseud-default-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '">Set as Default</button>';
@@ -840,8 +840,22 @@ const themesJSON = JSON.stringify(
         pseudsList.querySelectorAll('.pseud-dropdown').forEach(function(dd) {
           if (dd.dataset.pseudId !== pseudId) dd.classList.remove('pseud-dropdown--open');
         });
+        pseudsList.querySelectorAll('.pseud-menu-btn').forEach(function(b) {
+          if (b.dataset.pseudId !== pseudId) b.setAttribute('aria-expanded', 'false');
+        });
         var dropdown = pseudsList.querySelector('.pseud-dropdown[data-pseud-id="' + pseudId + '"]');
-        if (dropdown) dropdown.classList.toggle('pseud-dropdown--open');
+        if (dropdown) {
+          var isOpen = dropdown.classList.toggle('pseud-dropdown--open');
+          btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        }
+      });
+      btn.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+          var pseudId = btn.dataset.pseudId;
+          var dropdown = pseudsList.querySelector('.pseud-dropdown[data-pseud-id="' + pseudId + '"]');
+          if (dropdown) dropdown.classList.remove('pseud-dropdown--open');
+          btn.setAttribute('aria-expanded', 'false');
+        }
       });
     });
 
@@ -994,22 +1008,36 @@ const themesJSON = JSON.stringify(
     })
     .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
     .then(function(result) {
-      saveAddPseudBtn.disabled = false;
       if (result.ok) {
-        // If a file was selected, upload it now
+        // If a file was selected, upload it now and await result before refreshing
         var iconFile = addPseudIconFileInput.files[0];
         if (iconFile && result.data && result.data.id) {
           var formData = new FormData();
           formData.append('file', iconFile);
           formData.append('type', 'pseud');
           formData.append('id', String(result.data.id));
-          fetch('/api/upload', { method: 'POST', body: formData })
-            .catch(function() {});
+          return fetch('/api/upload', { method: 'POST', body: formData })
+            .then(function(uploadRes) {
+              if (!uploadRes.ok) {
+                showToast('Alias created, but icon upload failed.', 'error');
+              }
+            })
+            .catch(function() {
+              showToast('Alias created, but icon upload failed.', 'error');
+            })
+            .then(function() {
+              saveAddPseudBtn.disabled = false;
+              addPseudModal.style.display = 'none';
+              showToast('Alias created!');
+              loadPseuds();
+            });
         }
+        saveAddPseudBtn.disabled = false;
         addPseudModal.style.display = 'none';
         showToast('Alias created!');
-        setTimeout(loadPseuds, 500);
+        loadPseuds();
       } else {
+        saveAddPseudBtn.disabled = false;
         setFeedback(addPseudFeedback, result.data.error || 'Failed to add alias.', true);
       }
     })
@@ -1030,7 +1058,7 @@ const themesJSON = JSON.stringify(
     .then(function(result) {
       if (result.ok) {
         showToast('Default alias updated!');
-        setTimeout(loadPseuds, 500);
+        loadPseuds();
       } else {
         showToast(result.data.error || 'Failed to set default.', 'error');
       }
@@ -2176,7 +2204,11 @@ const themesJSON = JSON.stringify(
     align-items: center;
     justify-content: center;
     transition: border-color 150ms, transform 150ms;
-    outline: none;
+  }
+
+  .color-swatch:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: 2px;
   }
 
   .color-swatch:hover {

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -134,27 +134,15 @@ const themesJSON = JSON.stringify(
     <!--  SECTION 2: Aliases (Pseuds)                       -->
     <!-- ═══════════════════════════════════════════════════ -->
     <section class="settings-card" id="aliases-section">
-      <h2 class="card-title">Aliases</h2>
-      <p class="card-subtitle">Pseuds are pen names you write under. You can have multiple — one for each fandom or persona.</p>
-
+      <div class="aliases-header-row">
+        <div>
+          <h2 class="card-title" style="margin-bottom:0">Aliases</h2>
+          <p class="card-subtitle" style="margin-top:var(--space-1, 4px)">Pseuds are pen names you write under. You can have multiple — one for each fandom or persona.</p>
+        </div>
+        <button type="button" class="btn-filled" id="open-add-pseud-modal-btn">Add Alias</button>
+      </div>
       <div id="pseuds-list" class="pseuds-list">
         <!-- Populated by JS -->
-      </div>
-
-      <div class="pseud-add-form" id="pseud-add-form">
-        <h3 class="subsection-title" style="margin-top:0; border-top:none; padding-top:0;">Add Alias</h3>
-        <div class="form-group">
-          <label for="new-pseud-name" class="form-label">Name</label>
-          <input type="text" id="new-pseud-name" class="form-input" placeholder="e.g. DarkElfWriter" maxlength="100" />
-        </div>
-        <div class="form-group">
-          <label for="new-pseud-desc" class="form-label">Description <span class="form-hint" style="display:inline">(optional)</span></label>
-          <input type="text" id="new-pseud-desc" class="form-input" placeholder="A short blurb about this pseud" maxlength="200" />
-        </div>
-        <div class="form-actions">
-          <button type="button" class="btn-filled" id="add-pseud-btn">Add Alias</button>
-          <span class="inline-feedback" id="add-pseud-feedback"></span>
-        </div>
       </div>
     </section>
 
@@ -284,6 +272,12 @@ const themesJSON = JSON.stringify(
       <input type="text" id="edit-pseud-desc" class="form-input" maxlength="200" />
     </div>
     <div class="form-group">
+      <label class="form-label">Theme Color</label>
+      <div class="color-picker-swatches" id="edit-color-swatches">
+        <!-- populated by JS -->
+      </div>
+    </div>
+    <div class="form-group">
       <label class="form-label">Banner Image</label>
       <div class="pseud-banner-upload">
         <div class="pseud-banner-preview" id="edit-pseud-banner-preview">
@@ -308,6 +302,48 @@ const themesJSON = JSON.stringify(
       <button type="button" class="btn-filled" id="save-pseud-btn">Save</button>
       <button type="button" class="btn-outlined" id="cancel-pseud-btn">Cancel</button>
       <span class="inline-feedback" id="edit-pseud-feedback"></span>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════ -->
+<!--  Add Pseud Modal (hidden by default)                   -->
+<!-- ═══════════════════════════════════════════════════════ -->
+<div class="modal-overlay" id="pseud-add-modal" style="display:none" role="dialog" aria-modal="true" aria-label="Add alias">
+  <div class="modal-card">
+    <h3 class="modal-title">Add Alias</h3>
+    <div class="form-group">
+      <label class="form-label">Icon</label>
+      <div class="pseud-icon-upload">
+        <div class="pseud-icon-preview" id="add-pseud-icon-preview">
+          <img id="add-pseud-icon-img" src="" alt="Pseud icon" style="display:none" />
+          <span id="add-pseud-icon-fallback" class="avatar-fallback">?</span>
+        </div>
+        <div class="pseud-icon-actions">
+          <label for="add-pseud-icon-file" class="btn-outlined pseud-icon-btn">Upload</label>
+          <input type="file" id="add-pseud-icon-file" accept="image/gif,image/png,image/jpeg,image/webp" style="display:none" />
+          <button type="button" class="btn-text btn-text--danger" id="add-pseud-icon-remove" style="display:none">Remove</button>
+        </div>
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="add-pseud-name-input" class="form-label">Name</label>
+      <input type="text" id="add-pseud-name-input" class="form-input" placeholder="e.g. DarkElfWriter" maxlength="100" />
+    </div>
+    <div class="form-group">
+      <label for="add-pseud-desc-input" class="form-label">Description <span class="form-hint" style="display:inline">(optional)</span></label>
+      <input type="text" id="add-pseud-desc-input" class="form-input" placeholder="A short blurb about this pseud" maxlength="200" />
+    </div>
+    <div class="form-group">
+      <label class="form-label">Theme Color</label>
+      <div class="color-picker-swatches" id="add-color-swatches">
+        <!-- populated by JS -->
+      </div>
+    </div>
+    <div class="form-actions">
+      <button type="button" class="btn-filled" id="save-add-pseud-btn">Save</button>
+      <button type="button" class="btn-outlined" id="cancel-add-pseud-btn">Cancel</button>
+      <span class="inline-feedback" id="add-pseud-feedback"></span>
     </div>
   </div>
 </div>
@@ -711,35 +747,103 @@ const themesJSON = JSON.stringify(
   var pseudsList = document.getElementById('pseuds-list');
   var pseudsData = [];
 
+  var THEME_COLORS = ['#7B8FA8', '#4A90D9', '#D946EF', '#F59E0B', '#10B981', '#EF4444', '#8B5CF6', '#EC4899', '#06B6D4', '#78716C'];
+  var DEFAULT_THEME_COLOR = THEME_COLORS[0];
+
+  var addPseudSelectedColor = DEFAULT_THEME_COLOR;
+  var editPseudSelectedColor = DEFAULT_THEME_COLOR;
+
+  // ─── Color picker rendering ─────────────────────────────
+  function renderColorSwatches(containerId, selectedColor) {
+    var container = document.getElementById(containerId);
+    if (!container) return;
+    var html = '';
+    THEME_COLORS.forEach(function(color) {
+      var isSelected = (color === selectedColor);
+      html += '<button type="button" class="color-swatch' + (isSelected ? ' color-swatch--selected' : '') + '" data-color="' + escapeHtml(color) + '" style="background:' + escapeHtml(color) + '" title="' + escapeHtml(color) + '">';
+      if (isSelected) html += '<svg class="color-swatch-check" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+      html += '</button>';
+    });
+    container.innerHTML = html;
+    container.querySelectorAll('.color-swatch').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var color = btn.dataset.color;
+        if (containerId === 'add-color-swatches') {
+          addPseudSelectedColor = color;
+        } else {
+          editPseudSelectedColor = color;
+        }
+        renderColorSwatches(containerId, color);
+      });
+    });
+  }
+
+  // Initialize color swatches
+  renderColorSwatches('add-color-swatches', addPseudSelectedColor);
+
   function renderPseuds() {
     if (!pseudsData || pseudsData.length === 0) {
-      pseudsList.innerHTML = '<div class="pseuds-empty" role="status">No aliases yet. Add one below.</div>';
+      pseudsList.innerHTML = '<div class="pseuds-empty" role="status">No aliases yet. Click "Add Alias" to create one.</div>';
       return;
     }
     var html = '';
     pseudsData.forEach(function(p) {
       var iconUrl = p.icon_key ? '/api/storage/' + encodeURIComponent(p.icon_key) : null;
-      html += '<div class="pseud-card" data-pseud-id="' + escapeHtml(String(p.id)) + '">';
-      html += '  <div class="pseud-info">';
+      var themeColor = p.theme_color || THEME_COLORS[0];
+      var desc = p.description ? p.description : '';
+      var truncatedDesc = desc.length > 80 ? desc.substring(0, 80) + '…' : desc;
+      var workCount = (typeof p.work_count !== 'undefined') ? p.work_count : 0;
+      var seriesCount = (typeof p.series_count !== 'undefined') ? p.series_count : 0;
+
+      html += '<div class="pseud-card" data-pseud-id="' + escapeHtml(String(p.id)) + '" style="border-left:4px solid ' + escapeHtml(themeColor) + '">';
+      html += '  <div class="pseud-card-left">';
+      html += '    <div class="pseud-avatar">';
       if (iconUrl) {
-        html += '    <img class="pseud-icon" src="' + escapeHtml(iconUrl) + '" alt="" />';
+        html += '      <img class="pseud-avatar-img" src="' + escapeHtml(iconUrl) + '" alt="" />';
+      } else {
+        html += '      <span class="pseud-avatar-initial" style="color:' + escapeHtml(themeColor) + '">' + escapeHtml(p.name.charAt(0).toUpperCase()) + '</span>';
       }
-      html += '    <span class="pseud-name">' + escapeHtml(p.name) + '</span>';
-      if (p.description) {
-        html += '    <span class="pseud-desc">' + escapeHtml(p.description) + '</span>';
+      html += '    </div>';
+      html += '    <div class="pseud-card-info">';
+      html += '      <div class="pseud-name-row">';
+      html += '        <span class="pseud-name">' + escapeHtml(p.name) + '</span>';
+      if (p.is_default == 1) {
+        html += '      <span class="pseud-badge pseud-badge--primary">Primary</span>';
       }
+      html += '      </div>';
+      if (truncatedDesc) {
+        html += '    <span class="pseud-desc">' + escapeHtml(truncatedDesc) + '</span>';
+      }
+      html += '      <span class="pseud-stats">' + escapeHtml(String(workCount)) + ' Works · ' + escapeHtml(String(seriesCount)) + ' Series</span>';
+      html += '    </div>';
       html += '  </div>';
-      html += '  <div class="pseud-actions">';
-      html += '    <button type="button" class="btn-icon pseud-edit-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" title="Edit" aria-label="Edit ' + escapeHtml(p.name) + '">';
-      html += '      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>';
-      html += '    </button>';
-      html += '    <button type="button" class="btn-icon btn-icon--danger pseud-delete-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" data-pseud-name="' + escapeHtml(p.name) + '" title="Delete" aria-label="Delete ' + escapeHtml(p.name) + '">';
-      html += '      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>';
-      html += '    </button>';
+      html += '  <div class="pseud-card-right">';
+      html += '    <button type="button" class="pseud-menu-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" aria-label="Menu for ' + escapeHtml(p.name) + '">⋮</button>';
+      html += '    <div class="pseud-dropdown" data-pseud-id="' + escapeHtml(String(p.id)) + '">';
+      html += '      <button type="button" class="pseud-dropdown-item pseud-edit-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '">Edit</button>';
+      if (p.is_default != 1) {
+        html += '    <button type="button" class="pseud-dropdown-item pseud-default-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '">Set as Default</button>';
+      }
+      html += '      <button type="button" class="pseud-dropdown-item pseud-dropdown-item--danger pseud-delete-btn" data-pseud-id="' + escapeHtml(String(p.id)) + '" data-pseud-name="' + escapeHtml(p.name) + '">Delete</button>';
+      html += '    </div>';
       html += '  </div>';
       html += '</div>';
     });
     pseudsList.innerHTML = html;
+
+    // Bind three-dot menu buttons
+    pseudsList.querySelectorAll('.pseud-menu-btn').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var pseudId = btn.dataset.pseudId;
+        // Close all other dropdowns first
+        pseudsList.querySelectorAll('.pseud-dropdown').forEach(function(dd) {
+          if (dd.dataset.pseudId !== pseudId) dd.classList.remove('pseud-dropdown--open');
+        });
+        var dropdown = pseudsList.querySelector('.pseud-dropdown[data-pseud-id="' + pseudId + '"]');
+        if (dropdown) dropdown.classList.toggle('pseud-dropdown--open');
+      });
+    });
 
     // Bind edit buttons
     pseudsList.querySelectorAll('.pseud-edit-btn').forEach(function(btn) {
@@ -747,7 +851,17 @@ const themesJSON = JSON.stringify(
         var pseudId = parseInt(btn.dataset.pseudId, 10);
         var pseud = pseudsData.find(function(p) { return p.id === pseudId; });
         if (!pseud) return;
+        closeAllDropdowns();
         openEditModal(pseud);
+      });
+    });
+
+    // Bind default buttons
+    pseudsList.querySelectorAll('.pseud-default-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var pseudId = parseInt(btn.dataset.pseudId, 10);
+        closeAllDropdowns();
+        setDefaultPseud(pseudId);
       });
     });
 
@@ -756,10 +870,22 @@ const themesJSON = JSON.stringify(
       btn.addEventListener('click', function() {
         var pseudId = parseInt(btn.dataset.pseudId, 10);
         var pseudName = btn.dataset.pseudName;
+        closeAllDropdowns();
         deletePseud(pseudId, pseudName);
       });
     });
   }
+
+  function closeAllDropdowns() {
+    pseudsList.querySelectorAll('.pseud-dropdown--open').forEach(function(dd) {
+      dd.classList.remove('pseud-dropdown--open');
+    });
+  }
+
+  // Close dropdowns when clicking outside
+  document.addEventListener('click', function() {
+    closeAllDropdowns();
+  });
 
   function loadPseuds() {
     fetch('/api/pseuds')
@@ -773,45 +899,146 @@ const themesJSON = JSON.stringify(
       });
   }
 
-  // ─── Add new pseud ────────────────────────────────────
-  var addPseudBtn = document.getElementById('add-pseud-btn');
+  // ─── Add Pseud Modal ──────────────────────────────────
+  var addPseudModal = document.getElementById('pseud-add-modal');
+  var openAddPseudModalBtn = document.getElementById('open-add-pseud-modal-btn');
+  var saveAddPseudBtn = document.getElementById('save-add-pseud-btn');
+  var cancelAddPseudBtn = document.getElementById('cancel-add-pseud-btn');
   var addPseudFeedback = document.getElementById('add-pseud-feedback');
+  var addingPseudIconKey = null;
 
-  addPseudBtn.addEventListener('click', function() {
-    var name = document.getElementById('new-pseud-name').value.trim();
-    var desc = document.getElementById('new-pseud-desc').value.trim();
+  openAddPseudModalBtn.addEventListener('click', function() {
+    // Reset form
+    document.getElementById('add-pseud-name-input').value = '';
+    document.getElementById('add-pseud-desc-input').value = '';
+    addingPseudIconKey = null;
+    addPseudSelectedColor = DEFAULT_THEME_COLOR;
+    var addIconImg = document.getElementById('add-pseud-icon-img');
+    var addIconFallback = document.getElementById('add-pseud-icon-fallback');
+    var addIconRemoveBtn = document.getElementById('add-pseud-icon-remove');
+    addIconImg.style.display = 'none';
+    addIconFallback.style.display = '';
+    addIconRemoveBtn.style.display = 'none';
+    document.getElementById('add-pseud-icon-file').value = '';
+    renderColorSwatches('add-color-swatches', addPseudSelectedColor);
+    addPseudFeedback.textContent = '';
+    addPseudFeedback.className = 'inline-feedback';
+    addPseudModal.style.display = '';
+    document.getElementById('add-pseud-name-input').focus();
+  });
+
+  cancelAddPseudBtn.addEventListener('click', function() {
+    addPseudModal.style.display = 'none';
+  });
+
+  addPseudModal.addEventListener('click', function(e) {
+    if (e.target === addPseudModal) addPseudModal.style.display = 'none';
+  });
+
+  // Icon upload for add modal
+  var addPseudIconFileInput = document.getElementById('add-pseud-icon-file');
+  addPseudIconFileInput.addEventListener('change', function() {
+    var file = addPseudIconFileInput.files[0];
+    if (!file) return;
+    var allowedTypes = ['image/gif', 'image/png', 'image/jpeg', 'image/webp'];
+    if (allowedTypes.indexOf(file.type) === -1) {
+      showToast('Invalid file type. Use GIF, PNG, JPG, or WebP.', 'error');
+      return;
+    }
+    // We'll upload icon after creating the pseud, so just preview for now
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var iconImg = document.getElementById('add-pseud-icon-img');
+      var iconFallback = document.getElementById('add-pseud-icon-fallback');
+      var iconRemoveBtn = document.getElementById('add-pseud-icon-remove');
+      iconImg.src = e.target.result;
+      iconImg.style.display = 'block';
+      iconFallback.style.display = 'none';
+      iconRemoveBtn.style.display = '';
+    };
+    reader.readAsDataURL(file);
+  });
+
+  document.getElementById('add-pseud-icon-remove').addEventListener('click', function() {
+    addingPseudIconKey = null;
+    var iconImg = document.getElementById('add-pseud-icon-img');
+    var iconFallback = document.getElementById('add-pseud-icon-fallback');
+    var iconRemoveBtn = document.getElementById('add-pseud-icon-remove');
+    iconImg.style.display = 'none';
+    iconFallback.style.display = '';
+    iconRemoveBtn.style.display = 'none';
+    addPseudIconFileInput.value = '';
+  });
+
+  saveAddPseudBtn.addEventListener('click', function() {
+    var name = document.getElementById('add-pseud-name-input').value.trim();
+    var desc = document.getElementById('add-pseud-desc-input').value.trim();
 
     if (!name) {
       setFeedback(addPseudFeedback, 'Name is required.', true);
       return;
     }
 
-    addPseudBtn.disabled = true;
+    saveAddPseudBtn.disabled = true;
     setFeedback(addPseudFeedback, 'Adding…', false);
 
     fetch('/api/pseuds', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name, description: desc || null }),
+      body: JSON.stringify({
+        name: name,
+        description: desc || null,
+        theme_color: addPseudSelectedColor,
+        icon_key: addingPseudIconKey,
+      }),
     })
     .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
     .then(function(result) {
-      addPseudBtn.disabled = false;
+      saveAddPseudBtn.disabled = false;
       if (result.ok) {
-        document.getElementById('new-pseud-name').value = '';
-        document.getElementById('new-pseud-desc').value = '';
-        setFeedback(addPseudFeedback, 'Alias added!', false);
+        // If a file was selected, upload it now
+        var iconFile = addPseudIconFileInput.files[0];
+        if (iconFile && result.data && result.data.id) {
+          var formData = new FormData();
+          formData.append('file', iconFile);
+          formData.append('type', 'pseud');
+          formData.append('id', String(result.data.id));
+          fetch('/api/upload', { method: 'POST', body: formData })
+            .catch(function() {});
+        }
+        addPseudModal.style.display = 'none';
         showToast('Alias created!');
-        loadPseuds();
+        setTimeout(loadPseuds, 500);
       } else {
         setFeedback(addPseudFeedback, result.data.error || 'Failed to add alias.', true);
       }
     })
     .catch(function() {
-      addPseudBtn.disabled = false;
+      saveAddPseudBtn.disabled = false;
       setFeedback(addPseudFeedback, 'Network error.', true);
     });
   });
+
+  // ─── Set Default Pseud ──────────────────────────────────
+  function setDefaultPseud(pseudId) {
+    fetch('/api/pseuds/' + encodeURIComponent(pseudId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_default: 1 }),
+    })
+    .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
+    .then(function(result) {
+      if (result.ok) {
+        showToast('Default alias updated!');
+        setTimeout(loadPseuds, 500);
+      } else {
+        showToast(result.data.error || 'Failed to set default.', 'error');
+      }
+    })
+    .catch(function() {
+      showToast('Network error.', 'error');
+    });
+  }
 
   // ─── Edit modal ───────────────────────────────────────
   var editModal = document.getElementById('pseud-edit-modal');
@@ -828,6 +1055,10 @@ const themesJSON = JSON.stringify(
     document.getElementById('edit-pseud-name').value = pseud.name || '';
     document.getElementById('edit-pseud-desc').value = pseud.description || '';
     editingPseudIconKey = pseud.icon_key || null;
+    editPseudSelectedColor = pseud.theme_color || DEFAULT_THEME_COLOR;
+
+    // Render color swatches for edit modal
+    renderColorSwatches('edit-color-swatches', editPseudSelectedColor);
 
     // Update icon preview
     var iconImg = document.getElementById('edit-pseud-icon-img');
@@ -1082,7 +1313,10 @@ const themesJSON = JSON.stringify(
 
   // Close modal on Escape
   document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape' && editModal.style.display !== 'none') closeEditModal();
+    if (e.key === 'Escape') {
+      if (editModal.style.display !== 'none') closeEditModal();
+      if (addPseudModal && addPseudModal.style.display !== 'none') addPseudModal.style.display = 'none';
+    }
   });
 
   savePseudBtn.addEventListener('click', function() {
@@ -1107,6 +1341,7 @@ const themesJSON = JSON.stringify(
         icon_key: editingPseudIconKey,
         banner_key: editingPseudBannerKey,
         pinned_work_ids: editingPseudPinnedIds,
+        theme_color: editPseudSelectedColor,
       }),
     })
     .then(function(res) { return res.json().then(function(data) { return { ok: res.ok, data: data }; }); })
@@ -1727,11 +1962,18 @@ const themesJSON = JSON.stringify(
   /* ═══════════════════════════════════════════════════════ */
   /*  Pseud list & cards                                   */
   /* ═══════════════════════════════════════════════════════ */
+  .aliases-header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4, 16px);
+    margin-bottom: var(--space-4, 16px);
+  }
+
   .pseuds-list {
     display: flex;
     flex-direction: column;
-    gap: var(--space-2, 8px);
-    margin-bottom: var(--space-5, 20px);
+    gap: var(--space-3, 12px);
   }
 
   .pseuds-empty {
@@ -1751,19 +1993,62 @@ const themesJSON = JSON.stringify(
     padding: var(--space-3, 12px) var(--space-4, 16px);
     background: var(--md-sys-color-surface-container-high);
     border: 1px solid var(--md-sys-color-outline-variant);
-    border-radius: var(--md-sys-shape-corner-small, 8px);
-    transition: border-color 200ms;
+    border-left: 4px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium, 12px);
+    transition: border-color 200ms, box-shadow 200ms;
+    position: relative;
   }
 
   .pseud-card:hover {
     border-color: var(--md-sys-color-outline);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
   }
 
-  .pseud-info {
+  .pseud-card-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3, 12px);
+    min-width: 0;
+    flex: 1;
+  }
+
+  .pseud-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--md-sys-shape-corner-full, 100px);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--md-sys-color-surface-container);
+    flex-shrink: 0;
+    border: 2px solid var(--md-sys-color-outline-variant);
+  }
+
+  .pseud-avatar-img {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--md-sys-shape-corner-full, 100px);
+    object-fit: cover;
+  }
+
+  .pseud-avatar-initial {
+    font-size: var(--md-sys-typescale-title-medium-size, 16px);
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .pseud-card-info {
     display: flex;
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+  }
+
+  .pseud-name-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2, 8px);
   }
 
   .pseud-name {
@@ -1773,20 +2058,42 @@ const themesJSON = JSON.stringify(
     word-break: break-word;
   }
 
+  .pseud-badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: var(--md-sys-typescale-label-medium-size, 12px);
+    font-weight: 600;
+    padding: 1px 8px;
+    border-radius: var(--md-sys-shape-corner-full, 100px);
+    line-height: 1.5;
+  }
+
+  .pseud-badge--primary {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+  }
+
   .pseud-desc {
     color: var(--md-sys-color-on-surface-variant);
     font-size: var(--md-sys-typescale-body-small-size, 12px);
     word-break: break-word;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
-  .pseud-actions {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1, 4px);
+  .pseud-stats {
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: var(--md-sys-typescale-body-small-size, 12px);
+    opacity: 0.7;
+  }
+
+  .pseud-card-right {
+    position: relative;
     flex-shrink: 0;
   }
 
-  .btn-icon {
+  .pseud-menu-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1797,22 +2104,92 @@ const themesJSON = JSON.stringify(
     background: transparent;
     color: var(--md-sys-color-on-surface-variant);
     cursor: pointer;
-    transition: background 200ms, color 200ms;
+    font-size: 20px;
+    line-height: 1;
+    transition: background 200ms;
   }
 
-  .btn-icon:hover {
+  .pseud-menu-btn:hover {
     background: var(--md-sys-color-surface-container-highest);
-    color: var(--md-sys-color-on-surface);
   }
 
-  .btn-icon--danger:hover {
-    background: var(--md-sys-color-error-container);
+  .pseud-dropdown {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 100;
+    min-width: 160px;
+    background: var(--md-sys-color-surface-container-high);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small, 8px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+    overflow: hidden;
+  }
+
+  .pseud-dropdown--open {
+    display: block;
+  }
+
+  .pseud-dropdown-item {
+    display: block;
+    width: 100%;
+    padding: var(--space-2, 8px) var(--space-4, 16px);
+    background: none;
+    border: none;
+    text-align: left;
+    font-size: var(--md-sys-typescale-body-medium-size, 14px);
+    color: var(--md-sys-color-on-surface);
+    cursor: pointer;
+    transition: background 150ms;
+  }
+
+  .pseud-dropdown-item:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+
+  .pseud-dropdown-item--danger {
     color: var(--md-sys-color-error);
   }
 
-  .pseud-add-form {
-    border-top: 1px solid var(--md-sys-color-outline-variant);
-    padding-top: var(--space-4, 16px);
+  .pseud-dropdown-item--danger:hover {
+    background: var(--md-sys-color-error-container);
+  }
+
+  /* ═══════════════════════════════════════════════════════ */
+  /*  Color picker swatches                                */
+  /* ═══════════════════════════════════════════════════════ */
+  .color-picker-swatches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2, 8px);
+  }
+
+  .color-swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--md-sys-shape-corner-full, 100px);
+    border: 2px solid transparent;
+    cursor: pointer;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 150ms, transform 150ms;
+    outline: none;
+  }
+
+  .color-swatch:hover {
+    transform: scale(1.1);
+  }
+
+  .color-swatch--selected {
+    border-color: var(--md-sys-color-on-surface);
+  }
+
+  .color-swatch-check {
+    width: 16px;
+    height: 16px;
   }
 
   /* ═══════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Issue
Closes #53

## Summary

Upgrades the Settings → Aliases section from a simple text list to a professional card-driven UI.

### Visual Identity
- Each pseud card shows avatar (icon image or initial letter with theme color)
- Theme color accent on the left border of each card
- Color picker with 10 M3-aligned preset swatches in Add/Edit modals

### Primary/Default Pseud
- `is_default` column on pseuds table (partial unique index — one per user)
- "Set as Default" option in the three-dot dropdown menu
- "Primary" badge next to the default pseud name
- Auto-promotes another pseud if the default is deleted

### Stats & Context
- `work_count` + `series_count` displayed under each pseud name
- API joins creatorships + serial_works for both counts

### Card-Driven UI
- Compact cards with: avatar/initial, name, description, stats row, Primary badge
- Three-dot (⋮) dropdown menu with Edit / Set as Default / Delete
- "Add Alias" opens a modal (matching existing edit modal pattern)
- Add Alias modal includes name, description, icon upload, color picker

## Schema Changes
- `019_pseud_enhancements.sql`: `theme_color TEXT`, `is_default INTEGER`, partial unique index
- Applied to remote D1. Existing users backfilled (first pseud → default).

## Files Changed
- `schema/019_pseud_enhancements.sql` — new migration
- `src/lib/types.ts` — Pseud interface updated
- `src/pages/api/pseuds/index.ts` — GET returns series_count; POST accepts theme_color
- `src/pages/api/pseuds/[id].ts` — PUT accepts theme_color + is_default; DELETE promotes new default
- `src/pages/settings/index.astro` — full Alias section refactor

## Acceptance Criteria
- [x] Each pseud shows as a card with icon, name, description, stats, color dot, Primary badge
- [x] Three-dot menu provides Edit / Set as Default / Delete actions
- [x] Setting default clears previous and updates badge immediately
- [x] Add Alias opens modal with name, description, icon upload, color picker
- [x] Stats row shows work count and series count
- [x] Existing edit modal still works for icon, banner, pinned works
- [x] Local build passes clean