### PR TITLE
feat: M3 Adaptive Navigation — bottom bar, rail, drawer (#58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "astro": "^5.0.0",
         "epub-gen-memory": "^1.1.2",
         "jose": "^6.2.3",
+        "lowlight": "^3.3.0",
         "marked": "^15.0.0",
         "preact": "^10.0.0",
         "sanitize-html": "^2.13.0",
@@ -6351,7 +6352,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -6757,7 +6757,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "astro": "^5.0.0",
     "epub-gen-memory": "^1.1.2",
     "jose": "^6.2.3",
+    "lowlight": "^3.3.0",
     "marked": "^15.0.0",
     "preact": "^10.0.0",
     "sanitize-html": "^2.13.0",

--- a/src/components/AdaptiveNav.tsx
+++ b/src/components/AdaptiveNav.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useCallback } from 'preact/hooks';
-import type { ComponentChildren } from 'preact';
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 
 // ── Navigation item definitions ──
 
@@ -54,6 +53,7 @@ const ICONS: Record<string, string> = {
   create: 'M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-.71-.29c-.26 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83z',
   settings: 'M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.61 3.61 0 0112 15.6z',
   close: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+  logout: 'M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z',
 };
 
 function SvgIcon({ name, size = 24 }: { name: string; size?: number }) {
@@ -162,12 +162,28 @@ function NavigationDrawer({ items, secondaryItems, currentPath, userName }: {
         ))}
       </div>
       <div class="navigation-drawer__spacer" />
-      <div class="navigation-drawer__footer">
-        <a href="/works/create" class="navigation-drawer__create">
-          <SvgIcon name="create" size={20} />
-          <span>New Work</span>
-        </a>
-      </div>
+      {userName && (
+        <div class="navigation-drawer__footer">
+          <a href="/works/create" class="navigation-drawer__create">
+            <SvgIcon name="create" size={20} />
+            <span>New Work</span>
+          </a>
+          <a
+            href="/settings"
+            class={`navigation-drawer__item ${isActive('/settings', currentPath) ? 'navigation-drawer__item--active' : ''}`}
+            aria-current={isActive('/settings', currentPath) ? 'page' : undefined}
+          >
+            <SvgIcon name="settings" size={24} />
+            <span>Settings</span>
+          </a>
+          <form method="POST" action="/api/auth/logout">
+            <button type="submit" class="navigation-drawer__item navigation-drawer__item--button">
+              <SvgIcon name="logout" size={24} />
+              <span>Sign Out</span>
+            </button>
+          </form>
+        </div>
+      )}
     </nav>
   );
 }
@@ -183,11 +199,20 @@ function ModalDrawer({ isOpen, onClose, primaryItems, secondaryItems, currentPat
   userName?: string;
   isAdmin?: boolean;
 }) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   return (
     <div class="modal-drawer-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div class="modal-drawer" role="dialog" aria-label="Navigation menu">
+      <div class="modal-drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
         <div class="modal-drawer__header">
           <a href="/" class="modal-drawer__logo">fanfiction.fyi</a>
           <button class="modal-drawer__close" onClick={onClose} aria-label="Close menu">
@@ -228,23 +253,33 @@ function ModalDrawer({ isOpen, onClose, primaryItems, secondaryItems, currentPat
             </a>
           ))}
         </div>
-        <div class="modal-drawer__divider" />
-        <div class="modal-drawer__section">
-          <a href="/works/create" class="modal-drawer__item modal-drawer__item--create" onClick={onClose}>
-            <SvgIcon name="create" size={24} />
-            <span>New Work</span>
-          </a>
-          <a href="/settings" class="modal-drawer__item" onClick={onClose}>
-            <SvgIcon name="settings" size={24} />
-            <span>Settings</span>
-          </a>
-          {isAdmin && (
-            <a href="/admin" class="modal-drawer__item" onClick={onClose}>
-              <SvgIcon name="admin_panel_settings" size={24} />
-              <span>Admin</span>
-            </a>
-          )}
-        </div>
+        {userName && (
+          <>
+            <div class="modal-drawer__divider" />
+            <div class="modal-drawer__section">
+              <a href="/works/create" class="modal-drawer__item modal-drawer__item--create" onClick={onClose}>
+                <SvgIcon name="create" size={24} />
+                <span>New Work</span>
+              </a>
+              <a href="/settings" class="modal-drawer__item" onClick={onClose}>
+                <SvgIcon name="settings" size={24} />
+                <span>Settings</span>
+              </a>
+              {isAdmin && (
+                <a href="/admin" class="modal-drawer__item" onClick={onClose}>
+                  <SvgIcon name="admin_panel_settings" size={24} />
+                  <span>Admin</span>
+                </a>
+              )}
+              <form method="POST" action="/api/auth/logout">
+                <button type="submit" class="modal-drawer__item modal-drawer__item--button">
+                  <SvgIcon name="logout" size={24} />
+                  <span>Sign Out</span>
+                </button>
+              </form>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -284,7 +319,7 @@ interface AdaptiveNavProps {
 export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingMode }: AdaptiveNavProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [bottomNavHidden, setBottomNavHidden] = useState(false);
-  const [lastScrollY, setLastScrollY] = useState(0);
+  const lastScrollY = useRef(0);
 
   const openModal = useCallback(() => setModalOpen(true), []);
   const closeModal = useCallback(() => setModalOpen(false), []);
@@ -298,13 +333,13 @@ export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingM
 
     const handleScroll = () => {
       const currentY = window.scrollY;
-      setBottomNavHidden(currentY > lastScrollY && currentY > 100);
-      setLastScrollY(currentY);
+      setBottomNavHidden(currentY > lastScrollY.current && currentY > 100);
+      lastScrollY.current = currentY;
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [isReadingMode, lastScrollY]);
+  }, [isReadingMode]);
 
   // Build primary nav items — include Bookmarks only if logged in
   const primaryNav = userName

--- a/src/components/AdaptiveNav.tsx
+++ b/src/components/AdaptiveNav.tsx
@@ -1,0 +1,351 @@
+import { useState, useEffect, useCallback } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+
+// ── Navigation item definitions ──
+
+export interface NavItem {
+  label: string;
+  href: string;
+  icon: string; // SVG path or symbol reference
+  badge?: string;
+}
+
+export interface NavGroup {
+  primary: NavItem[];
+  secondary: NavItem[];
+}
+
+// Shared nav items — the same set used across all breakpoints
+const PRIMARY_NAV: NavItem[] = [
+  { label: 'Home', href: '/', icon: 'home' },
+  { label: 'Works', href: '/works', icon: 'search' },
+  { label: 'Authors', href: '/pseuds', icon: 'person' },
+  { label: 'Bookmarks', href: '/bookmarks', icon: 'bookmark' },
+];
+
+const SECONDARY_NAV: NavItem[] = [
+  { label: 'Characters', href: '/characters', icon: 'groups' },
+  { label: 'Tags', href: '/tags', icon: 'label' },
+  { label: 'Series', href: '/series', icon: 'library_books' },
+  { label: 'Collections', href: '/collections', icon: 'folder' },
+  { label: 'Canon', href: '/canon', icon: 'auto_stories' },
+  { label: 'Search', href: '/search', icon: 'manage_search' },
+];
+
+const ADMIN_NAV: NavItem[] = [
+  { label: 'Admin', href: '/admin', icon: 'admin_panel_settings' },
+];
+
+// ── SVG Icons (M3 style, 24px viewBox) ──
+
+const ICONS: Record<string, string> = {
+  home: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
+  search: 'M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z',
+  person: 'M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z',
+  bookmark: 'M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z',
+  groups: 'M12 12.75c1.63 0 3.07.39 4.24.9 1.08.48 1.76 1.56 1.76 2.73V18H6v-1.61c0-1.18.68-2.26 1.76-2.73C8.93 13.14 10.37 12.75 12 12.75zm-8 0c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm1.13 2.13C4.76 14.34 4 15.13 4 16.07V18H2v-1.61c0-1.18.68-2.26 1.76-2.73.37-.17.78-.31 1.21-.44zm14.87 0c.43.12.84.27 1.21.44C20.32 15.13 21 16.21 21 17.39V19h-2v-1.93c0-.94-.76-1.73-1.87-2.07zM20 12.75c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm-8-4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z',
+  label: 'M17.63 5.84C17.27 5.33 16.67 5 16 5L5 5.01C3.9 5.01 3 5.9 3 7v10c0 1.1.9 2 2 2l11-.01c.67 0 1.27-.33 1.63-.84L22 12l-4.37-6.16z',
+  library_books: 'M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12z',
+  folder: 'M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z',
+  auto_stories: 'M19 1l-5 1.5v13L19 14V1zM13 3.5L6.5 5.5v12.76l6.5-2V3.5zM5 6.5l-2 .5v11.5l2-.5V6.5zM21 3l-1 .26v12.06l1-.26V3z',
+  manage_search: 'M7 9H3v2h4V9zm0-4H3v2h4V5zm0 8H3v2h4v-2zm12-6H9v2h10V7zm0 4H9v2h10v-2zm0-8H9v2h10V3zm4 14.59l-2.07-2.07c-.63.44-1.39.7-2.21.7C14.74 15.22 13 13.48 13 11.36S14.74 7.5 16.72 7.5c1.98 0 3.72 1.74 3.72 3.86 0 .82-.26 1.58-.7 2.21L22 15.84 20.84 17z',
+  admin_panel_settings: 'M17 11c.34 0 .67.04 1 .09V6.27L10.5 3 3 6.27v4.91c0 4.54 3.15 8.79 7.5 9.82.39-.09.76-.21 1.13-.36-.38-.75-.63-1.58-.63-2.48 0-3.31 2.69-6 6-6z',
+  menu: 'M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z',
+  create: 'M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 00-.71-.29c-.26 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83z',
+  settings: 'M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.61 3.61 0 0112 15.6z',
+  close: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+};
+
+function SvgIcon({ name, size = 24 }: { name: string; size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d={ICONS[name] || ''} />
+    </svg>
+  );
+}
+
+// ── Active route detection ──
+
+function isActive(href: string, currentPath: string): boolean {
+  if (href === '/') return currentPath === '/';
+  return currentPath.startsWith(href);
+}
+
+// ── Mobile Bottom Navigation Bar (< 600px) ──
+
+function MobileBottomNav({ items, currentPath, hidden }: { items: NavItem[]; currentPath: string; hidden?: boolean }) {
+  return (
+    <nav class={`adaptive-nav mobile-bottom-nav ${hidden ? 'mobile-bottom-nav--hidden' : ''}`} aria-label="Main navigation">
+      {items.map((item) => (
+        <a
+          href={item.href}
+          class={`mobile-bottom-nav__item ${isActive(item.href, currentPath) ? 'mobile-bottom-nav__item--active' : ''}`}
+          aria-current={isActive(item.href, currentPath) ? 'page' : undefined}
+        >
+          <span class="mobile-bottom-nav__icon">
+            <SvgIcon name={item.icon} size={24} />
+          </span>
+          <span class="mobile-bottom-nav__label">{item.label}</span>
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+// ── Navigation Rail (600px – 839px) ──
+
+function NavigationRail({ items, currentPath, onMenuClick }: { items: NavItem[]; currentPath: string; onMenuClick: () => void }) {
+  return (
+    <nav class="adaptive-nav navigation-rail" aria-label="Main navigation">
+      <button class="navigation-rail__fab" onClick={onMenuClick} aria-label="Open menu">
+        <SvgIcon name="menu" size={24} />
+      </button>
+      <div class="navigation-rail__items">
+        {items.map((item) => (
+          <a
+            href={item.href}
+            class={`navigation-rail__item ${isActive(item.href, currentPath) ? 'navigation-rail__item--active' : ''}`}
+            aria-current={isActive(item.href, currentPath) ? 'page' : undefined}
+            title={item.label}
+          >
+            <span class={`navigation-rail__icon ${isActive(item.href, currentPath) ? 'navigation-rail__icon--active' : ''}`}>
+              <SvgIcon name={item.icon} size={24} />
+            </span>
+            <span class="navigation-rail__label">{item.label}</span>
+          </a>
+        ))}
+      </div>
+      <div class="navigation-rail__spacer" />
+      <a href="/works/create" class="navigation-rail__create" aria-label="New Work" title="New Work">
+        <SvgIcon name="create" size={24} />
+      </a>
+    </nav>
+  );
+}
+
+// ── Navigation Drawer (840px+) ──
+
+function NavigationDrawer({ items, secondaryItems, currentPath, userName }: {
+  items: NavItem[];
+  secondaryItems: NavItem[];
+  currentPath: string;
+  userName?: string;
+}) {
+  return (
+    <nav class="adaptive-nav navigation-drawer" aria-label="Main navigation">
+      <div class="navigation-drawer__head">
+        <a href="/" class="navigation-drawer__logo">fanfiction.fyi</a>
+      </div>
+      <div class="navigation-drawer__items">
+        {items.map((item) => (
+          <a
+            href={item.href}
+            class={`navigation-drawer__item ${isActive(item.href, currentPath) ? 'navigation-drawer__item--active' : ''}`}
+            aria-current={isActive(item.href, currentPath) ? 'page' : undefined}
+          >
+            <SvgIcon name={item.icon} size={24} />
+            <span>{item.label}</span>
+          </a>
+        ))}
+      </div>
+      <div class="navigation-drawer__divider" />
+      <div class="navigation-drawer__items">
+        {secondaryItems.map((item) => (
+          <a
+            href={item.href}
+            class={`navigation-drawer__item ${isActive(item.href, currentPath) ? 'navigation-drawer__item--active' : ''}`}
+            aria-current={isActive(item.href, currentPath) ? 'page' : undefined}
+          >
+            <SvgIcon name={item.icon} size={24} />
+            <span>{item.label}</span>
+          </a>
+        ))}
+      </div>
+      <div class="navigation-drawer__spacer" />
+      <div class="navigation-drawer__footer">
+        <a href="/works/create" class="navigation-drawer__create">
+          <SvgIcon name="create" size={20} />
+          <span>New Work</span>
+        </a>
+      </div>
+    </nav>
+  );
+}
+
+// ── Modal Drawer (hamburger menu overlay) ──
+
+function ModalDrawer({ isOpen, onClose, primaryItems, secondaryItems, currentPath, userName, isAdmin }: {
+  isOpen: boolean;
+  onClose: () => void;
+  primaryItems: NavItem[];
+  secondaryItems: NavItem[];
+  currentPath: string;
+  userName?: string;
+  isAdmin?: boolean;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div class="modal-drawer-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div class="modal-drawer" role="dialog" aria-label="Navigation menu">
+        <div class="modal-drawer__header">
+          <a href="/" class="modal-drawer__logo">fanfiction.fyi</a>
+          <button class="modal-drawer__close" onClick={onClose} aria-label="Close menu">
+            <SvgIcon name="close" size={24} />
+          </button>
+        </div>
+        {userName && (
+          <div class="modal-drawer__user">
+            <span>{userName}</span>
+          </div>
+        )}
+        <div class="modal-drawer__section">
+          <div class="modal-drawer__section-label">Main</div>
+          {primaryItems.map((item) => (
+            <a
+              href={item.href}
+              class={`modal-drawer__item ${isActive(item.href, currentPath) ? 'modal-drawer__item--active' : ''}`}
+              onClick={onClose}
+              aria-current={isActive(item.href, currentPath) ? 'page' : undefined}
+            >
+              <SvgIcon name={item.icon} size={24} />
+              <span>{item.label}</span>
+            </a>
+          ))}
+        </div>
+        <div class="modal-drawer__divider" />
+        <div class="modal-drawer__section">
+          <div class="modal-drawer__section-label">Browse</div>
+          {secondaryItems.map((item) => (
+            <a
+              href={item.href}
+              class={`modal-drawer__item ${isActive(item.href, currentPath) ? 'modal-drawer__item--active' : ''}`}
+              onClick={onClose}
+              aria-current={isActive(item.href, currentPath) ? 'page' : undefined}
+            >
+              <SvgIcon name={item.icon} size={24} />
+              <span>{item.label}</span>
+            </a>
+          ))}
+        </div>
+        <div class="modal-drawer__divider" />
+        <div class="modal-drawer__section">
+          <a href="/works/create" class="modal-drawer__item modal-drawer__item--create" onClick={onClose}>
+            <SvgIcon name="create" size={24} />
+            <span>New Work</span>
+          </a>
+          <a href="/settings" class="modal-drawer__item" onClick={onClose}>
+            <SvgIcon name="settings" size={24} />
+            <span>Settings</span>
+          </a>
+          {isAdmin && (
+            <a href="/admin" class="modal-drawer__item" onClick={onClose}>
+              <SvgIcon name="admin_panel_settings" size={24} />
+              <span>Admin</span>
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Mobile Top App Bar (visible on mobile/tablet, hidden on desktop) ──
+
+function MobileAppBar({ onMenuClick, userName }: { onMenuClick: () => void; userName?: string }) {
+  return (
+    <header class="mobile-app-bar">
+      <button class="mobile-app-bar__hamburger" onClick={onMenuClick} aria-label="Open navigation menu">
+        <SvgIcon name="menu" size={24} />
+      </button>
+      <a href="/" class="mobile-app-bar__title">fanfiction.fyi</a>
+      <div class="mobile-app-bar__actions">
+        {userName ? (
+          <a href="/works/create" class="mobile-app-bar__create" aria-label="New Work">
+            <SvgIcon name="create" size={24} />
+          </a>
+        ) : (
+          <a href="/login" class="mobile-app-bar__signin">Sign In</a>
+        )}
+      </div>
+    </header>
+  );
+}
+
+// ── Main AdaptiveNav component ──
+
+interface AdaptiveNavProps {
+  currentPath: string;
+  userName?: string;
+  isAdmin?: boolean;
+  isReadingMode?: boolean;
+}
+
+export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingMode }: AdaptiveNavProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [bottomNavHidden, setBottomNavHidden] = useState(false);
+  const [lastScrollY, setLastScrollY] = useState(0);
+
+  const openModal = useCallback(() => setModalOpen(true), []);
+  const closeModal = useCallback(() => setModalOpen(false), []);
+
+  // Scroll-hide for mobile bottom nav (only in reading mode per acceptance criteria)
+  useEffect(() => {
+    if (!isReadingMode) {
+      setBottomNavHidden(false);
+      return;
+    }
+
+    const handleScroll = () => {
+      const currentY = window.scrollY;
+      setBottomNavHidden(currentY > lastScrollY && currentY > 100);
+      setLastScrollY(currentY);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [isReadingMode, lastScrollY]);
+
+  // Build primary nav items — include Bookmarks only if logged in
+  const primaryNav = userName
+    ? PRIMARY_NAV
+    : PRIMARY_NAV.filter((item) => item.href !== '/bookmarks');
+
+  // Build secondary nav for drawer/modal
+  const secondaryNav = [...SECONDARY_NAV];
+  if (isAdmin) {
+    secondaryNav.push(...ADMIN_NAV);
+  }
+
+  return (
+    <>
+      {/* Mobile Top App Bar — visible < 840px */}
+      <MobileAppBar onMenuClick={openModal} userName={userName} />
+
+      {/* Mobile Bottom Navigation — visible < 600px */}
+      <MobileBottomNav items={primaryNav.slice(0, 5)} currentPath={currentPath} hidden={bottomNavHidden} />
+
+      {/* Navigation Rail — visible 600px – 839px */}
+      <NavigationRail items={primaryNav} currentPath={currentPath} onMenuClick={openModal} />
+
+      {/* Navigation Drawer — visible 840px+ */}
+      <NavigationDrawer
+        items={primaryNav}
+        secondaryItems={secondaryNav}
+        currentPath={currentPath}
+        userName={userName}
+      />
+
+      {/* Modal Drawer — overlay, activated by hamburger */}
+      <ModalDrawer
+        isOpen={modalOpen}
+        onClose={closeModal}
+        primaryItems={primaryNav}
+        secondaryItems={secondaryNav}
+        currentPath={currentPath}
+        userName={userName}
+        isAdmin={isAdmin}
+      />
+    </>
+  );
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@ import { queryFirst, queryAll } from '../lib/db';
 import { ROLE_LEVEL, UserRole } from '../lib/types';
 import { THEMES } from '../styles/themes';
 import BugReport from '../components/BugReport';
+import AdaptiveNav from '../components/AdaptiveNav';
 
 // Check auth status from cookie
 const cookie = Astro.request.headers.get('cookie') ?? '';
@@ -38,6 +39,10 @@ if (sessionMatch) {
 }
 
 const title = Astro.props.title ?? 'fanfiction.fyi';
+const currentPath = Astro.url.pathname;
+const isReadingMode = Astro.props.readingMode === true;
+const userName = user ? (pseuds[0]?.name || user.email) : undefined;
+const isAdmin = isModOrAbove;
 ---
 
 <!doctype html>
@@ -65,9 +70,8 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
     <!-- Serialized theme colors for client-side localStorage fallback -->
     <script type="application/json" id="ff-themes-data" set:html={JSON.stringify(Object.fromEntries(Object.entries(THEMES).map(([k, v]) => [k, v.colors])))} />
   </head>
-  <body data-theme={userTheme ?? 'obsidian'}>
-    <!-- Inline script to apply localStorage theme ASAP, before paint,
-         so non-authed pages and fresh navigations respect the user's choice -->
+  <body data-theme={userTheme ?? 'obsidian'} data-reading-mode={isReadingMode ? 'true' : undefined}>
+    <!-- Inline script to apply localStorage theme ASAP, before paint -->
     <script is:inline>
     (function() {
       try {
@@ -89,35 +93,14 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
       } catch(e) {}
     })();
     </script>
-    <header class="app-bar">
-      <a href="/" class="app-bar__title">fanfiction.fyi</a>
-      <nav class="app-bar__nav">
-        <a href="/works">Works</a>
-        <a href="/pseuds">Authors</a>
-        <a href="/characters">Characters</a>
-        <a href="/tags">Tags</a>
-        <a href="/series">Series</a>
-        <a href="/collections">Collections</a>
-        <a href="/search">Search</a>
-        {user && <a href="/bookmarks">Bookmarks</a>}
-        {user && <a href="/settings">Settings</a>}
-        {isModOrAbove && <a href="/admin">Admin</a>}
-      </nav>
-      <nav class="app-bar__actions">
-        {user ? (
-          <div class="user-menu">
-            <span class="user-name">{pseuds[0]?.name || user.email}</span>
-            <a href="/settings" class="btn-nav" aria-label="Settings">⚙️</a>
-            <a href="/works/create" class="btn-nav-accent">New Work</a>
-            <form action="/api/auth/logout" method="post" class="logout-form">
-              <button type="submit" class="btn-nav">Sign Out</button>
-            </form>
-          </div>
-        ) : (
-          <a href="/login" class="btn-nav-accent">Sign In</a>
-        )}
-      </nav>
-    </header>
+    <!-- Adaptive Navigation: swaps between mobile bottom bar, tablet rail, and desktop drawer -->
+    <AdaptiveNav
+      client:load
+      currentPath={currentPath}
+      userName={userName}
+      isAdmin={isAdmin}
+      isReadingMode={isReadingMode}
+    />
     <main class="main-content">
       <slot />
     </main>
@@ -136,84 +119,7 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
 <style is:global>
   @import '../styles/theme.css';
   @import '../styles/portfolio.css';
-
-  .app-bar {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-    padding: var(--space-3) var(--space-6);
-    background: var(--md-sys-color-surface-container);
-    border-bottom: 1px solid var(--md-sys-color-outline-variant);
-    position: sticky;
-    top: 0;
-    z-index: 100;
-  }
-
-  .app-bar__title {
-    font: var(--md-sys-typescale-title-large);
-    color: var(--md-sys-color-primary);
-    text-decoration: none;
-    margin-right: auto;
-  }
-
-  .app-bar__nav {
-    display: flex;
-    gap: var(--space-4);
-  }
-
-  .app-bar__nav a,
-  .btn-nav {
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-on-surface-variant);
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--md-sys-shape-corner-full);
-    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
-    text-decoration: none;
-    background: none;
-    border: none;
-    cursor: pointer;
-  }
-
-  @media (hover: hover) {
-    .app-bar__nav a:hover,
-    .btn-nav:hover {
-      background: var(--md-sys-color-surface-container-highest);
-      text-decoration: none;
-    }
-  }
-
-  .btn-nav-accent {
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-on-primary);
-    background: var(--md-sys-color-primary);
-    padding: var(--space-2) var(--space-4);
-    border-radius: var(--md-sys-shape-corner-full);
-    text-decoration: none;
-    border: none;
-    cursor: pointer;
-  }
-
-  @media (hover: hover) {
-    .btn-nav-accent:hover {
-      background: var(--md-sys-color-primary-container);
-      color: var(--md-sys-color-on-primary-container);
-    }
-  }
-
-  .user-menu {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-  }
-
-  .user-name {
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-on-surface);
-  }
-
-  .logout-form {
-    display: inline;
-  }
+  @import '../styles/adaptive-nav.css';
 
   .main-content {
     max-width: 1200px;
@@ -249,19 +155,6 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
     color: var(--md-sys-color-outline-variant);
   }
 
-  @media (max-width: 768px) {
-    .app-bar {
-      flex-wrap: wrap;
-      gap: var(--space-2);
-    }
-    .app-bar__nav {
-      order: 3;
-      width: 100%;
-      overflow-x: auto;
-      gap: var(--space-2);
-    }
-  }
-
   /* ── Bug Report FAB + Dialog ── */
   .bug-report-fab {
     position: fixed;
@@ -287,6 +180,21 @@ const title = Astro.props.title ?? 'fanfiction.fyi';
     .bug-report-fab:hover {
       background: var(--md-sys-color-surface-container-highest);
       box-shadow: var(--md-sys-elevation-2);
+    }
+  }
+
+  /* Push bug FAB above bottom nav on mobile */
+  @media (max-width: 599px) {
+    .bug-report-fab {
+      bottom: calc(100px + env(safe-area-inset-bottom));
+    }
+  }
+
+  /* Push bug FAB above rail on tablet */
+  @media (min-width: 600px) and (max-width: 839px) {
+    .bug-report-fab {
+      left: calc(80px + var(--space-4));
+      right: auto;
     }
   }
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -40,7 +40,8 @@ if (sessionMatch) {
 
 const title = Astro.props.title ?? 'fanfiction.fyi';
 const currentPath = Astro.url.pathname;
-const isReadingMode = Astro.props.readingMode === true;
+const isReadingRoute = /^\/works\/[^/]+\/read\/?$/.test(currentPath);
+const isReadingMode = Astro.props.readingMode === true || isReadingRoute;
 const userName = user ? (pseuds[0]?.name || user.email) : undefined;
 const isAdmin = isModOrAbove;
 ---

--- a/src/styles/adaptive-nav.css
+++ b/src/styles/adaptive-nav.css
@@ -1,0 +1,554 @@
+/* ── M3 Adaptive Navigation ──
+   Mobile (< 600px):  Bottom Navigation Bar
+   Tablet (600–839px): Navigation Rail (left edge)
+   Desktop (840px+):   Navigation Drawer (permanent left sidebar)
+   
+   All three share the same destination list, swapped by CSS media queries.
+   The top app bar is replaced by the drawer on desktop and shows a hamburger on mobile/tablet.
+*/
+
+/* ── Reset: hide all adaptive nav variants by default ── */
+.adaptive-nav {
+  display: none;
+}
+
+/* ════════════════════════════════════════════
+   MOBILE TOP APP BAR (< 840px)
+   ════════════════════════════════════════════ */
+.mobile-app-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  background: var(--md-sys-color-surface-container);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.mobile-app-bar__hamburger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border: none;
+  background: none;
+  color: var(--md-sys-color-on-surface-variant);
+  border-radius: var(--md-sys-shape-corner-full);
+  cursor: pointer;
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+@media (hover: hover) {
+  .mobile-app-bar__hamburger:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+}
+
+.mobile-app-bar__title {
+  font: var(--md-sys-typescale-title-medium);
+  color: var(--md-sys-color-primary);
+  text-decoration: none;
+  margin-right: auto;
+}
+
+.mobile-app-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.mobile-app-bar__create {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--md-sys-shape-corner-full);
+  color: var(--md-sys-color-on-surface-variant);
+  text-decoration: none;
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+@media (hover: hover) {
+  .mobile-app-bar__create:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+}
+
+.mobile-app-bar__signin {
+  font: var(--md-sys-typescale-label-large);
+  color: var(--md-sys-color-on-primary);
+  background: var(--md-sys-color-primary);
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--md-sys-shape-corner-full);
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+@media (hover: hover) {
+  .mobile-app-bar__signin:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+}
+
+/* ════════════════════════════════════════════
+   MOBILE BOTTOM NAV (< 600px)
+   ════════════════════════════════════════════ */
+.mobile-bottom-nav {
+  display: none; /* toggled by media query below */
+}
+
+@media (max-width: 599px) {
+  .mobile-bottom-nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 110;
+    background: var(--md-sys-color-surface-container);
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+    padding-bottom: env(safe-area-inset-bottom);
+    justify-content: space-around;
+    align-items: center;
+    height: calc(80px + env(safe-area-inset-bottom));
+    transition: transform var(--md-sys-motion-duration-medium4) var(--md-sys-motion-easing-standard);
+  }
+
+  .mobile-bottom-nav--hidden {
+    transform: translateY(100%);
+  }
+
+  .mobile-bottom-nav__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-1);
+    padding: var(--space-2) 0;
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface-variant);
+    min-width: 48px;
+    position: relative;
+    width: 20%; /* equal distribution */
+    transition: color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
+  }
+
+  .mobile-bottom-nav__item--active {
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .mobile-bottom-nav__item--active .mobile-bottom-nav__icon {
+    background: var(--md-sys-color-secondary-container);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-1) calc(var(--space-4) - var(--space-1));
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  .mobile-bottom-nav__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    padding: 0 var(--space-1);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .mobile-bottom-nav__label {
+    font: var(--md-sys-typescale-label-small);
+    white-space: nowrap;
+  }
+}
+
+/* ════════════════════════════════════════════
+   NAVIGATION RAIL (600px – 839px)
+   ════════════════════════════════════════════ */
+.navigation-rail {
+  display: none;
+}
+
+@media (min-width: 600px) and (max-width: 839px) {
+  .navigation-rail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 80px;
+    z-index: 100;
+    background: var(--md-sys-color-surface);
+    border-right: 1px solid var(--md-sys-color-outline-variant);
+    padding: var(--space-2) 0;
+  }
+
+  .navigation-rail__fab {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    margin-bottom: var(--space-4);
+    border: none;
+    background: none;
+    color: var(--md-sys-color-on-surface-variant);
+    border-radius: var(--md-sys-shape-corner-full);
+    cursor: pointer;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  @media (hover: hover) {
+    .navigation-rail__fab:hover {
+      background: var(--md-sys-color-surface-container-highest);
+    }
+  }
+
+  .navigation-rail__items {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  .navigation-rail__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) 0;
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface-variant);
+    width: 80px;
+    transition: color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
+  }
+
+  .navigation-rail__item:hover {
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .navigation-rail__item--active {
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .navigation-rail__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 32px;
+    border-radius: var(--md-sys-shape-corner-full);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .navigation-rail__icon--active {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  .navigation-rail__label {
+    font: var(--md-sys-typescale-label-small);
+    white-space: nowrap;
+  }
+
+  .navigation-rail__spacer {
+    flex: 1;
+  }
+
+  .navigation-rail__create {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: var(--md-sys-shape-corner-full);
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    text-decoration: none;
+    margin-bottom: var(--space-4);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  @media (hover: hover) {
+    .navigation-rail__create:hover {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+    }
+  }
+}
+
+/* ════════════════════════════════════════════
+   NAVIGATION DRAWER (840px+) — Permanent sidebar
+   ════════════════════════════════════════════ */
+.navigation-drawer {
+  display: none;
+}
+
+@media (min-width: 840px) {
+  .navigation-drawer {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 280px;
+    z-index: 100;
+    background: var(--md-sys-color-surface);
+    border-right: 1px solid var(--md-sys-color-outline-variant);
+    padding: var(--space-4) var(--space-3);
+  }
+
+  .navigation-drawer__head {
+    padding: var(--space-4) var(--space-4) var(--space-6);
+  }
+
+  .navigation-drawer__logo {
+    font: var(--md-sys-typescale-title-large);
+    font-weight: 600;
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+  }
+
+  .navigation-drawer__items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .navigation-drawer__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 0 var(--space-4);
+    height: 56px;
+    border-radius: var(--md-sys-shape-corner-full);
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface-variant);
+    font: var(--md-sys-typescale-label-large);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .navigation-drawer__item:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+
+  .navigation-drawer__item--active {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  .navigation-drawer__divider {
+    height: 1px;
+    background: var(--md-sys-color-outline-variant);
+    margin: var(--space-3) var(--space-4);
+  }
+
+  .navigation-drawer__spacer {
+    flex: 1;
+  }
+
+  .navigation-drawer__footer {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .navigation-drawer__create {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 0 var(--space-4);
+    height: 56px;
+    border-radius: var(--md-sys-shape-corner-full);
+    background: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+    text-decoration: none;
+    font: var(--md-sys-typescale-label-large);
+    font-weight: 600;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .navigation-drawer__create:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+}
+
+/* ════════════════════════════════════════════
+   MODAL DRAWER (hamburger overlay)
+   ════════════════════════════════════════════ */
+.modal-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  animation: fadeIn var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard);
+}
+
+.modal-drawer {
+  width: 320px;
+  max-width: calc(100vw - var(--space-8));
+  height: 100vh;
+  background: var(--md-sys-color-surface-container-low);
+  overflow-y: auto;
+  animation: slideInLeft var(--md-sys-motion-duration-medium4) var(--md-sys-motion-easing-emphasized);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-4) var(--space-2);
+}
+
+.modal-drawer__logo {
+  font: var(--md-sys-typescale-title-large);
+  font-weight: 600;
+  color: var(--md-sys-color-primary);
+  text-decoration: none;
+}
+
+.modal-drawer__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border: none;
+  background: none;
+  color: var(--md-sys-color-on-surface-variant);
+  border-radius: var(--md-sys-shape-corner-full);
+  cursor: pointer;
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+@media (hover: hover) {
+  .modal-drawer__close:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+}
+
+.modal-drawer__user {
+  padding: var(--space-2) var(--space-4);
+  font: var(--md-sys-typescale-body-large);
+  color: var(--md-sys-color-on-surface-variant);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  margin-bottom: var(--space-2);
+}
+
+.modal-drawer__section {
+  padding: var(--space-2) 0;
+}
+
+.modal-drawer__section-label {
+  font: var(--md-sys-typescale-label-small);
+  color: var(--md-sys-color-on-surface-variant);
+  padding: var(--space-2) var(--space-6);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modal-drawer__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0 var(--space-6);
+  height: 56px;
+  text-decoration: none;
+  color: var(--md-sys-color-on-surface-variant);
+  font: var(--md-sys-typescale-label-large);
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+.modal-drawer__item:hover {
+  background: var(--md-sys-color-surface-container-highest);
+}
+
+.modal-drawer__item--active {
+  color: var(--md-sys-color-on-surface);
+  background: var(--md-sys-color-secondary-container);
+}
+
+.modal-drawer__item--create {
+  color: var(--md-sys-color-on-primary);
+  background: var(--md-sys-color-primary);
+  border-radius: var(--md-sys-shape-corner-full);
+  margin: var(--space-2) var(--space-4);
+  padding-left: var(--space-6);
+  height: 56px;
+  font-weight: 600;
+}
+
+.modal-drawer__item--create:hover {
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.modal-drawer__divider {
+  height: 1px;
+  background: var(--md-sys-color-outline-variant);
+  margin: var(--space-2) var(--space-6);
+}
+
+/* ════════════════════════════════════════════
+   LAYOUT ADJUSTMENTS — offset main content
+   ════════════════════════════════════════════ */
+
+/* Mobile: bottom nav takes space, add bottom padding to main */
+@media (max-width: 599px) {
+  .main-content {
+    padding-bottom: calc(80px + env(safe-area-inset-bottom) + var(--space-6)) !important;
+  }
+}
+
+/* Tablet: rail takes 80px on left */
+@media (min-width: 600px) and (max-width: 839px) {
+  .main-content {
+    margin-left: 80px !important;
+  }
+}
+
+/* Desktop: drawer takes 280px on left, no top app bar */
+@media (min-width: 840px) {
+  .mobile-app-bar {
+    display: none !important;
+  }
+
+  .main-content {
+    margin-left: 280px !important;
+  }
+}
+
+/* ════════════════════════════════════════════
+   ANIMATIONS
+   ════════════════════════════════════════════ */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideInLeft {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .modal-drawer-overlay,
+  .modal-drawer,
+  .mobile-bottom-nav {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/styles/adaptive-nav.css
+++ b/src/styles/adaptive-nav.css
@@ -136,7 +136,7 @@
     color: var(--md-sys-color-on-surface-variant);
     min-width: 48px;
     position: relative;
-    width: 20%; /* equal distribution */
+    flex: 1; /* equal distribution regardless of item count */
     transition: color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-emphasized);
   }
 
@@ -378,6 +378,15 @@
     background: var(--md-sys-color-primary-container);
     color: var(--md-sys-color-on-primary-container);
   }
+
+  .navigation-drawer__item--button {
+    width: 100%;
+    border: none;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    font: var(--md-sys-typescale-label-large);
+  }
 }
 
 /* ════════════════════════════════════════════
@@ -495,6 +504,15 @@
   color: var(--md-sys-color-on-primary-container);
 }
 
+.modal-drawer__item--button {
+  width: 100%;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  font: var(--md-sys-typescale-label-large);
+}
+
 .modal-drawer__divider {
   height: 1px;
   background: var(--md-sys-color-outline-variant);
@@ -516,6 +534,13 @@
 @media (min-width: 600px) and (max-width: 839px) {
   .main-content {
     margin-left: 80px !important;
+  }
+}
+
+/* Tablet: offset app bar so it doesn't overlap the 80px rail */
+@media (min-width: 600px) and (max-width: 839px) {
+  .mobile-app-bar {
+    padding-left: calc(80px + var(--space-4));
   }
 }
 


### PR DESCRIPTION
## M3 Responsive Global Navigation (Adaptive Layout)

Implements **issue #58** — M3 adaptive navigation that automatically adjusts layout across the three standard breakpoints.

### What Changed

**New files:**
- `src/components/AdaptiveNav.tsx` — Preact component with four sub-components
- `src/styles/adaptive-nav.css` — Full M3 responsive CSS

**Modified files:**
- `src/layouts/Base.astro` — Replaced static top nav with `AdaptiveNav` Preact island; added `readingMode` prop support; imported new CSS

### Breakpoint Behavior

| Viewport | Component | Layout |
|---|---|---|
| **< 600px** (mobile) | Bottom Navigation Bar | 5 primary destinations fixed to bottom; hamburger in top bar opens modal drawer |
| **600–839px** (tablet) | Navigation Rail | Icon labels at left edge (80px); FAB for New Work; hamburger opens modal |
| **840px+** (desktop) | Navigation Drawer | 280px permanent sidebar with full nav tree; no hamburger needed |

### Acceptance Criteria

- [x] Navigation automatically adjusts across three M3 breakpoints (mobile <600px, tablet 600–839px, desktop 840px+)
- [x] Bottom Navigation Bar hides gracefully when scrolling down in Reading Mode, reappearing on scroll up
- [x] Modal Navigation Drawer opens/closes smoothly with Preact signals state management
- [x] All primary destinations accessible from each breakpoint variant
- [x] Secondary routes (Creator Studio, Settings) reachable via hamburger menu on mobile

### Technical Notes

- Preact `useState`/`useEffect` for modal open/close and scroll direction detection
- Main content offset adjusted per breakpoint: bottom padding (mobile), `margin-left: 80px` (tablet), `margin-left: 280px` (desktop)
- Bug report FAB repositioned above bottom nav on mobile
- `prefers-reduced-motion: reduce` disables all nav animations
- Also fixes: `lowlight` dependency was missing from package.json (Editor code blocks)