### PR TITLE
Reading Focus Mode & Quick Navigation (#59)

### DIFF
--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+import { useScrollDirection } from '../hooks/useScrollDirection';
 
 interface Chapter {
   id: number;
@@ -33,6 +34,225 @@ const REACTION_EMOJIS: Record<string, string> = {
   mindblown: '🤯',
 };
 
+const FONT_SIZES = [
+  { key: 'small', label: 'S' },
+  { key: 'default', label: 'M' },
+  { key: 'large', label: 'L' },
+  { key: 'x-large', label: 'XL' },
+] as const;
+
+// ── Focus Sheet Component (inline) ──
+interface FocusSheetProps {
+  open: boolean;
+  onClose: () => void;
+  chapters: Chapter[];
+  currentChapterId: number;
+  workId: number;
+  fontSize: string;
+  moodDisabled: boolean;
+  onFontSizeChange: (size: string) => void;
+  onMoodToggle: () => void;
+  prevChapter: Chapter | null;
+  nextChapter: Chapter | null;
+}
+
+function FocusSheet({
+  open,
+  onClose,
+  chapters,
+  currentChapterId,
+  workId,
+  fontSize,
+  moodDisabled,
+  onFontSizeChange,
+  onMoodToggle,
+  prevChapter,
+  nextChapter,
+}: FocusSheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  // Focus trap & escape handling
+  useEffect(() => {
+    if (!open) return;
+
+    previousFocus.current = document.activeElement as HTMLElement;
+
+    // Focus the first focusable element in the sheet
+    requestAnimationFrame(() => {
+      if (sheetRef.current) {
+        const focusable = sheetRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length) focusable[0].focus();
+      }
+    });
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (!sheetRef.current) return;
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab') {
+        const focusable = sheetRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      // Restore focus on close
+      if (previousFocus.current) {
+        previousFocus.current.focus();
+      }
+    };
+  }, [open, onClose]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        class={`focus-sheet-backdrop${open ? ' open' : ''}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Sheet */}
+      <div
+        ref={sheetRef}
+        class={`focus-sheet${open ? ' open' : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Reading options"
+      >
+        {/* Drag handle (mobile bottom sheet) */}
+        <div class="focus-sheet-drag-handle" aria-hidden="true">
+          <div class="focus-sheet-drag-indicator" />
+        </div>
+
+        {/* Close button */}
+        <div class="focus-sheet-header">
+          <span class="focus-sheet-title">Reading Options</span>
+          <button
+            class="focus-sheet-close"
+            onClick={onClose}
+            aria-label="Close reading options"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Chapters section */}
+        <div class="focus-sheet-section">
+          <div class="focus-sheet-section-title">Chapters</div>
+          <ol class="focus-sheet-chapter-list">
+            {chapters.map((c) => (
+              <li
+                class={`focus-sheet-chapter-item${c.id === currentChapterId ? ' current' : ''}`}
+              >
+                <a href={`/works/${workId}/read?chapter=${c.id}`} onClick={onClose}>
+                  {c.position}. {c.title}
+                </a>
+                <span class="chapter-words">
+                  {c.word_count?.toLocaleString() || '?'} words
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        {/* Settings section */}
+        <div class="focus-sheet-section">
+          <div class="focus-sheet-section-title">Settings</div>
+
+          {/* Font size */}
+          <div class="focus-sheet-setting-row">
+            <span class="focus-sheet-setting-label">Font Size</span>
+            <div class="focus-sheet-size-buttons">
+              {FONT_SIZES.map((fs) => (
+                <button
+                  class={`focus-sheet-size-btn${fontSize === fs.key ? ' active' : ''}`}
+                  onClick={() => onFontSizeChange(fs.key)}
+                  aria-label={`Font size ${fs.label}`}
+                >
+                  {fs.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Mood toggle */}
+          <div class="focus-sheet-setting-row">
+            <span class="focus-sheet-setting-label">Mood Engine</span>
+            <button
+              class={`focus-sheet-toggle-btn${moodDisabled ? '' : ' active'}`}
+              onClick={onMoodToggle}
+              aria-label={`Mood engine ${moodDisabled ? 'off' : 'on'}`}
+            >
+              {moodDisabled ? 'Off' : 'On'}
+            </button>
+          </div>
+        </div>
+
+        {/* Navigation section */}
+        <div class="focus-sheet-section">
+          <div class="focus-sheet-section-title">Navigation</div>
+          <div class="focus-sheet-nav-buttons">
+            {prevChapter ? (
+              <a
+                href={`/works/${workId}/read?chapter=${prevChapter.id}`}
+                class="focus-sheet-nav-btn"
+                onClick={onClose}
+              >
+                ← Previous Chapter
+              </a>
+            ) : (
+              <span class="focus-sheet-nav-btn disabled">← Previous Chapter</span>
+            )}
+            {nextChapter ? (
+              <a
+                href={`/works/${workId}/read?chapter=${nextChapter.id}`}
+                class="focus-sheet-nav-btn"
+                onClick={onClose}
+              >
+                Next Chapter →
+              </a>
+            ) : (
+              <span class="focus-sheet-nav-btn disabled">Next Chapter →</span>
+            )}
+          </div>
+          <a href={`/works/${workId}`} class="focus-sheet-exit-btn">
+            ✕ Exit Reading
+          </a>
+        </div>
+      </div>
+    </>
+  );
+}
+
 export default function ReadingMode({
   workId,
   chapters,
@@ -44,69 +264,59 @@ export default function ReadingMode({
   moodDisabled,
   reactionCounts: initialReactionCounts,
   myReactions: initialMyReactions,
-  fontSize,
+  fontSize: initialFontSize,
   workTitle,
 }: ReadingModeProps) {
   const [progressWidth, setProgressWidth] = useState(0);
-  const [headerVisible, setHeaderVisible] = useState(false);
-  const [toolbarVisible, setToolbarVisible] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
   const [shortcutsVisible, setShortcutsVisible] = useState(true);
+  const [currentFontSize, setCurrentFontSize] = useState(initialFontSize);
   const [reactionState, setReactionState] = useState(() => ({
     counts: { ...initialReactionCounts },
     mine: [...initialMyReactions],
   }));
 
-  const lastScrollY = useRef(typeof window !== 'undefined' ? window.scrollY : 0);
   const maxScrollPct = useRef(0);
+
+  // ── Scroll direction hook ──
+  const { direction, scrollY } = useScrollDirection(5);
+
+  // Header visibility: visible at top, hides on scroll down, shows on scroll up
+  const scrolled = scrollY > 0;
+  const headerVisible = direction === 'up' || scrollY <= 0;
 
   // Find prev/next chapters
   const currentIndex = chapters.findIndex((c) => c.id === currentChapterId);
   const prevChapter = currentIndex > 0 ? chapters[currentIndex - 1] : null;
   const nextChapter = currentIndex < chapters.length - 1 ? chapters[currentIndex + 1] : null;
 
+  // ── Progress from scroll direction hook ──
+  useEffect(() => {
+    const winH = window.innerHeight;
+    const docH = document.documentElement.scrollHeight;
+    const pct = docH <= winH ? 100 : Math.min(100, (scrollY / (docH - winH)) * 100);
+    setProgressWidth(pct);
+  }, [scrollY]);
+
   // ── Reaction rollback helper ──
-  // Reverts optimistic update when the server request fails
   const revertReaction = useCallback((reaction: string, wasMine: boolean) => {
     setReactionState((prev) => {
       if (wasMine) {
-        // Was mine (remove was rolled back) → re-add it
         return {
           counts: { ...prev.counts, [reaction]: (prev.counts[reaction] || 0) + 1 },
           mine: [...prev.mine, reaction],
         };
       } else {
-        // Was not mine (add was rolled back) → remove it
         return {
-          counts: { ...prev.counts, [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1) },
+          counts: {
+            ...prev.counts,
+            [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1),
+          },
           mine: prev.mine.filter((r) => r !== reaction),
         };
       }
     });
   }, []);
-
-  // ── Progress bar & header/toolbar visibility ──
-  const handleScroll = useCallback(() => {
-    const winH = window.innerHeight;
-    const docH = document.documentElement.scrollHeight;
-    const scrolled = window.scrollY;
-    const pct = docH <= winH ? 100 : Math.min(100, (scrolled / (docH - winH)) * 100);
-    setProgressWidth(pct);
-
-    const delta = scrolled - lastScrollY.current;
-    if (delta < -10) setHeaderVisible(true);
-    else if (delta > 10) setHeaderVisible(false);
-    lastScrollY.current = scrolled;
-
-    if (scrolled > 300) setToolbarVisible(true);
-    else setToolbarVisible(false);
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    handleScroll();
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [handleScroll]);
 
   // ── Keyboard shortcuts ──
   useEffect(() => {
@@ -114,7 +324,14 @@ export default function ReadingMode({
     const nextHref = nextChapter ? `/works/${workId}/read?chapter=${nextChapter.id}` : null;
 
     function onKeyDown(e: KeyboardEvent) {
-      if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'TEXTAREA') return;
+      if (
+        (e.target as HTMLElement).tagName === 'INPUT' ||
+        (e.target as HTMLElement).tagName === 'TEXTAREA'
+      )
+        return;
+
+      // If sheet is open, only Escape is handled (by the sheet's own handler)
+      if (sheetOpen) return;
 
       if (e.key === 'ArrowLeft' && prevHref) {
         window.location.href = prevHref;
@@ -123,13 +340,13 @@ export default function ReadingMode({
       } else if (e.key === 'Escape') {
         window.location.href = `/works/${workId}`;
       } else if (e.key === 'c' || e.key === 'C') {
-        setDrawerOpen((prev) => !prev);
+        setSheetOpen((prev) => !prev);
       }
     }
 
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [prevChapter, nextChapter, workId]);
+  }, [prevChapter, nextChapter, workId, sheetOpen]);
 
   // ── Shortcuts hint (fade out after 5s) ──
   useEffect(() => {
@@ -166,25 +383,33 @@ export default function ReadingMode({
     async (reaction: string) => {
       const isMine = reactionState.mine.includes(reaction);
 
-      // Optimistic update
       if (isMine) {
         setReactionState((prev) => ({
-          counts: { ...prev.counts, [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1) },
+          counts: {
+            ...prev.counts,
+            [reaction]: Math.max(0, (prev.counts[reaction] || 0) - 1),
+          },
           mine: prev.mine.filter((r) => r !== reaction),
         }));
       } else {
         setReactionState((prev) => ({
-          counts: { ...prev.counts, [reaction]: (prev.counts[reaction] || 0) + 1 },
+          counts: {
+            ...prev.counts,
+            [reaction]: (prev.counts[reaction] || 0) + 1,
+          },
           mine: [...prev.mine, reaction],
         }));
       }
 
       try {
-        const res = await fetch(`/api/works/${workId}/chapters/${currentChapterId}/reactions`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ reaction }),
-        });
+        const res = await fetch(
+          `/api/works/${workId}/chapters/${currentChapterId}/reactions`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reaction }),
+          },
+        );
         if (!res.ok) {
           revertReaction(reaction, isMine);
         }
@@ -194,6 +419,28 @@ export default function ReadingMode({
     },
     [workId, currentChapterId, reactionState.mine, reactionState.counts, revertReaction],
   );
+
+  // ── Font size change handler ──
+  const handleFontSizeChange = useCallback((size: string) => {
+    setCurrentFontSize(size);
+    // Update the data-font-size attribute on the nearest .reading-container
+    const container = document.querySelector('.reading-container');
+    if (container) {
+      container.setAttribute('data-font-size', size);
+    }
+  }, []);
+
+  // ── Mood toggle handler ──
+  const handleMoodToggle = useCallback(async () => {
+    try {
+      const res = await fetch('/api/user/mood-toggle', { method: 'POST' });
+      if (res.ok) {
+        window.location.reload();
+      }
+    } catch {
+      // silently fail
+    }
+  }, []);
 
   const moodAttr = moodDisabled ? 'off' : currentMood || 'none';
 
@@ -209,45 +456,17 @@ export default function ReadingMode({
         style={{ width: `${progressWidth}%` }}
       />
 
-      {/* Ambient Header */}
-      <header class={`reading-header${headerVisible ? ' visible' : ''}`}>
-        <button class="reading-toolbar-btn" onClick={() => setDrawerOpen(true)} aria-label="Chapters">
-          ☰
-        </button>
-        <div class="reading-header-title">{workTitle}</div>
-        <div class="reading-header-chapter">
+      {/* Top App Bar — M3 Center-Aligned */}
+      <header
+        class="focus-top-bar"
+        data-visible={headerVisible ? 'true' : 'false'}
+        data-elevated={scrolled ? 'true' : 'false'}
+      >
+        <div class="focus-bar-title">{workTitle}</div>
+        <div class="focus-bar-meta">
           Ch. {currentChapterPosition} of {chapters.length}
         </div>
-        <a href={`/works/${workId}`} class="reading-header-exit">
-          Exit Reading
-        </a>
       </header>
-
-      {/* Chapter Drawer Overlay */}
-      <div
-        class={`reading-drawer-overlay${drawerOpen ? ' open' : ''}`}
-        onClick={() => setDrawerOpen(false)}
-      />
-
-      {/* Chapter Drawer */}
-      <nav class={`reading-chapters-drawer${drawerOpen ? ' open' : ''}`} aria-label="Chapter list">
-        <div class="reading-drawer-title">
-          <span>Chapters</span>
-          <button class="reading-drawer-close" onClick={() => setDrawerOpen(false)} aria-label="Close chapter list">
-            ×
-          </button>
-        </div>
-        <ol class="reading-drawer-list">
-          {chapters.map((c) => (
-            <li class={`reading-drawer-item${c.id === currentChapterId ? ' current' : ''}`}>
-              <a href={`/works/${workId}/read?chapter=${c.id}`}>
-                {c.position}. {c.title}
-              </a>
-              <span class="chapter-words">{c.word_count?.toLocaleString() || '?'} words</span>
-            </li>
-          ))}
-        </ol>
-      </nav>
 
       {/* Reaction bar — rendered here in the flow where it appears in the chapter */}
       {authed ? (
@@ -273,29 +492,33 @@ export default function ReadingMode({
         </div>
       )}
 
-      {/* Bottom Toolbar */}
-      <div class={`reading-toolbar${toolbarVisible ? ' visible' : ''}`}>
-        {prevChapter && (
-          <a href={`/works/${workId}/read?chapter=${prevChapter.id}`} class="reading-toolbar-btn">
-            ← Prev
-          </a>
-        )}
-        <button class="reading-toolbar-btn" onClick={() => setDrawerOpen(true)}>
-          ☰ Ch. {currentChapterPosition}/{chapters.length}
-        </button>
-        <a href={`/works/${workId}`} class="reading-toolbar-btn">
-          ✕ Exit
-        </a>
-        {nextChapter && (
-          <a href={`/works/${workId}/read?chapter=${nextChapter.id}`} class="reading-toolbar-btn">
-            Next →
-          </a>
-        )}
-      </div>
+      {/* FAB — bottom-right */}
+      <button
+        class="focus-fab"
+        onClick={() => setSheetOpen(true)}
+        aria-label="Open reading options"
+      >
+        ☰
+      </button>
+
+      {/* Focus Sheet */}
+      <FocusSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        chapters={chapters}
+        currentChapterId={currentChapterId}
+        workId={workId}
+        fontSize={currentFontSize}
+        moodDisabled={moodDisabled}
+        onFontSizeChange={handleFontSizeChange}
+        onMoodToggle={handleMoodToggle}
+        prevChapter={prevChapter}
+        nextChapter={nextChapter}
+      />
 
       {/* Keyboard Shortcuts Hint */}
       <div class={`reading-shortcuts${shortcutsVisible ? ' visible' : ''}`}>
-        <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>Esc</kbd> exit reading · <kbd>C</kbd> chapters
+        <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>Esc</kbd> exit reading · <kbd>C</kbd> options
       </div>
     </>
   );

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -38,7 +38,7 @@ const FONT_SIZES = [
   { key: 'small', label: 'S' },
   { key: 'default', label: 'M' },
   { key: 'large', label: 'L' },
-  { key: 'x-large', label: 'XL' },
+  { key: 'xlarge', label: 'XL' },
 ] as const;
 
 // ── Focus Sheet Component (inline) ──
@@ -171,6 +171,7 @@ function FocusSheet({
           <ol class="focus-sheet-chapter-list">
             {chapters.map((c) => (
               <li
+                key={c.id}
                 class={`focus-sheet-chapter-item${c.id === currentChapterId ? ' current' : ''}`}
               >
                 <a href={`/works/${workId}/read?chapter=${c.id}`} onClick={onClose}>
@@ -194,6 +195,7 @@ function FocusSheet({
             <div class="focus-sheet-size-buttons">
               {FONT_SIZES.map((fs) => (
                 <button
+                  key={fs.key}
                   class={`focus-sheet-size-btn${fontSize === fs.key ? ' active' : ''}`}
                   onClick={() => onFontSizeChange(fs.key)}
                   aria-label={`Font size ${fs.label}`}
@@ -267,7 +269,6 @@ export default function ReadingMode({
   fontSize: initialFontSize,
   workTitle,
 }: ReadingModeProps) {
-  const [progressWidth, setProgressWidth] = useState(0);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [shortcutsVisible, setShortcutsVisible] = useState(true);
   const [currentFontSize, setCurrentFontSize] = useState(initialFontSize);
@@ -279,7 +280,7 @@ export default function ReadingMode({
   const maxScrollPct = useRef(0);
 
   // ── Scroll direction hook ──
-  const { direction, scrollY } = useScrollDirection(5);
+  const { direction, progress, scrollY } = useScrollDirection(5);
 
   // Header visibility: visible at top, hides on scroll down, shows on scroll up
   const scrolled = scrollY > 0;
@@ -289,14 +290,6 @@ export default function ReadingMode({
   const currentIndex = chapters.findIndex((c) => c.id === currentChapterId);
   const prevChapter = currentIndex > 0 ? chapters[currentIndex - 1] : null;
   const nextChapter = currentIndex < chapters.length - 1 ? chapters[currentIndex + 1] : null;
-
-  // ── Progress from scroll direction hook ──
-  useEffect(() => {
-    const winH = window.innerHeight;
-    const docH = document.documentElement.scrollHeight;
-    const pct = docH <= winH ? 100 : Math.min(100, (scrollY / (docH - winH)) * 100);
-    setProgressWidth(pct);
-  }, [scrollY]);
 
   // ── Reaction rollback helper ──
   const revertReaction = useCallback((reaction: string, wasMine: boolean) => {
@@ -331,7 +324,13 @@ export default function ReadingMode({
         return;
 
       // If sheet is open, only Escape is handled (by the sheet's own handler)
-      if (sheetOpen) return;
+      if (sheetOpen) {
+        if (e.key === 'c' || e.key === 'C') {
+          setSheetOpen(false);
+          return;
+        }
+        return;
+      }
 
       if (e.key === 'ArrowLeft' && prevHref) {
         window.location.href = prevHref;
@@ -433,7 +432,11 @@ export default function ReadingMode({
   // ── Mood toggle handler ──
   const handleMoodToggle = useCallback(async () => {
     try {
-      const res = await fetch('/api/user/mood-toggle', { method: 'POST' });
+      const res = await fetch('/api/user/profile', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mood_disabled: !moodDisabled }),
+      });
       if (res.ok) {
         window.location.reload();
       }
@@ -453,7 +456,7 @@ export default function ReadingMode({
       <div
         class="reading-progress-bar"
         data-mood={moodAttr}
-        style={{ width: `${progressWidth}%` }}
+        style={{ width: `${progress}%` }}
       />
 
       {/* Top App Bar — M3 Center-Aligned */}

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+interface ScrollDirection {
+  direction: 'up' | 'down' | 'idle';
+  progress: number;
+  scrollY: number;
+}
+
+export function useScrollDirection(deltaThreshold = 5): ScrollDirection {
+  const [state, setState] = useState<ScrollDirection>({
+    direction: 'idle',
+    progress: 0,
+    scrollY: typeof window !== 'undefined' ? window.scrollY : 0,
+  });
+
+  const lastScrollY = useRef(typeof window !== 'undefined' ? window.scrollY : 0);
+  const rafId = useRef<number | null>(null);
+
+  const handleScroll = useCallback(() => {
+    if (rafId.current !== null) return; // debounce via rAF
+
+    rafId.current = requestAnimationFrame(() => {
+      const winH = window.innerHeight;
+      const docH = document.documentElement.scrollHeight;
+      const scrolled = window.scrollY;
+      const pct = docH <= winH ? 100 : Math.min(100, (scrolled / (docH - winH)) * 100);
+
+      const delta = scrolled - lastScrollY.current;
+      let direction: 'up' | 'down' | 'idle' = 'idle';
+      if (delta < -deltaThreshold) direction = 'up';
+      else if (delta > deltaThreshold) direction = 'down';
+
+      lastScrollY.current = scrolled;
+
+      setState({ direction, progress: pct, scrollY: scrolled });
+      rafId.current = null;
+    });
+  }, [deltaThreshold]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // initial
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+    };
+  }, [handleScroll]);
+
+  return state;
+}

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -204,7 +204,7 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
     .reading-container[data-font-size="small"] { font-size: 0.9375rem; }
     .reading-container[data-font-size="default"] { font-size: 1rem; }
     .reading-container[data-font-size="large"] { font-size: 1.125rem; }
-    .reading-container[data-font-size="x-large"] { font-size: 1.25rem; }
+    .reading-container[data-font-size="xlarge"] { font-size: 1.25rem; }
 
     /* ── Work Metadata (minimal, top) ── */
     .reading-work-meta {
@@ -723,7 +723,7 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
 
     /* ── Reduced Motion ── */
     @media (prefers-reduced-motion: reduce) {
-      .reading-progress-bar, .focus-top-bar, .focus-sheet, .focus-sheet-backdrop {
+      .reading-progress-bar, .focus-top-bar, .focus-sheet, .focus-sheet-backdrop, .focus-fab {
         transition: none !important;
       }
     }

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -153,43 +153,45 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
       border-radius: 0 2px 2px 0;
     }
 
-    /* ── Ambient Header ── */
-    .reading-header {
+    /* ── Focus Top App Bar (M3 Center-Aligned) ── */
+    .focus-top-bar {
       position: fixed;
       top: 0;
       left: 0;
       right: 0;
       z-index: 900;
-      background: linear-gradient(to bottom, var(--md-sys-color-surface) 60%, transparent);
-      transform: translateY(-100%);
-      transition: transform 0.3s ease;
+      background: transparent;
+      transform: translateY(0);
+      transition: transform var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard),
+                  background-color var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard),
+                  box-shadow var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard);
       padding: var(--space-3) var(--space-6);
       display: flex;
+      flex-direction: column;
       align-items: center;
-      gap: var(--space-4);
+      justify-content: center;
+      gap: 0;
+      pointer-events: none;
     }
-    .reading-header.visible { transform: translateY(0); }
-    .reading-header-title {
+    .focus-top-bar[data-visible="false"] {
+      transform: translateY(-100%);
+    }
+    .focus-top-bar[data-elevated="true"] {
+      background: var(--md-sys-color-surface);
+      box-shadow: var(--md-sys-elevation-2);
+      pointer-events: auto;
+    }
+    .focus-bar-title {
       font: var(--md-sys-typescale-title-medium);
       color: var(--md-sys-color-on-surface);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      flex: 1;
+      max-width: 100%;
     }
-    .reading-header-chapter {
+    .focus-bar-meta {
       font: var(--md-sys-typescale-body-small);
       color: var(--md-sys-color-on-surface-variant);
-      white-space: nowrap;
-    }
-    .reading-header-exit {
-      font: var(--md-sys-typescale-label-large);
-      color: var(--md-sys-color-primary);
-      background: var(--md-sys-color-primary-container);
-      border: none;
-      border-radius: var(--md-sys-shape-corner-full);
-      padding: var(--space-2) var(--space-4);
-      cursor: pointer;
       white-space: nowrap;
     }
 
@@ -376,56 +378,161 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
       color: var(--md-sys-color-outline);
     }
 
-    /* ── Chapter List (collapsible) ── */
-    .reading-chapters-drawer {
+    /* ── FAB (Floating Action Button) ── */
+    .focus-fab {
       position: fixed;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      width: 320px;
-      max-width: 85vw;
-      background: var(--md-sys-color-surface-container);
-      transform: translateX(100%);
-      transition: transform 0.3s ease;
-      z-index: 950;
-      overflow-y: auto;
-      padding: var(--space-6);
-      box-shadow: -4px 0 24px rgba(0,0,0,0.3);
+      bottom: var(--space-4);
+      right: var(--space-4);
+      z-index: 800;
+      width: 56px;
+      height: 56px;
+      border-radius: var(--md-sys-shape-corner-large);
+      background: var(--md-sys-color-primary-container);
+      color: var(--md-sys-color-on-primary-container);
+      border: none;
+      cursor: pointer;
+      font-size: 1.375rem;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: var(--md-sys-elevation-3);
+      transition: transform var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                  box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
     }
-    .reading-chapters-drawer.open { transform: translateX(0); }
-    .reading-drawer-overlay {
+    .focus-fab:hover {
+      transform: scale(1.05);
+      box-shadow: var(--md-sys-elevation-3);
+    }
+    .focus-fab:active {
+      transform: scale(0.97);
+    }
+
+    /* ── Focus Sheet Backdrop ── */
+    .focus-sheet-backdrop {
       position: fixed;
       inset: 0;
       background: rgba(0,0,0,0.5);
       z-index: 940;
       opacity: 0;
       pointer-events: none;
-      transition: opacity 0.3s;
+      transition: opacity var(--md-sys-motion-duration-medium2) var(--md-sys-motion-easing-standard);
     }
-    .reading-drawer-overlay.open { opacity: 1; pointer-events: auto; }
-    .reading-drawer-title {
+    .focus-sheet-backdrop.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    /* ── Focus Sheet (Bottom Sheet mobile / Side Sheet desktop) ── */
+    .focus-sheet {
+      position: fixed;
+      z-index: 950;
+      background: var(--md-sys-color-surface-container-low);
+      overflow-y: auto;
+      /* Mobile: Bottom Sheet */
+      bottom: 0;
+      left: 0;
+      right: 0;
+      max-height: 85vh;
+      border-radius: var(--md-sys-shape-corner-extra-large) var(--md-sys-shape-corner-extra-large) 0 0;
+      transform: translateY(100%);
+      transition: transform var(--md-sys-motion-duration-medium4) var(--md-sys-motion-easing-emphasized);
+      box-shadow: var(--md-sys-elevation-3);
+    }
+    .focus-sheet.open {
+      transform: translateY(0);
+    }
+
+    /* Desktop: Side Sheet (from right) */
+    @media (min-width: 769px) {
+      .focus-sheet {
+        top: 0;
+        bottom: 0;
+        left: auto;
+        right: 0;
+        width: 360px;
+        max-width: 85vw;
+        max-height: 100vh;
+        border-radius: 0;
+        transform: translateX(100%);
+        transition: transform var(--md-sys-motion-duration-medium4) var(--md-sys-motion-easing-emphasized);
+      }
+      .focus-sheet.open {
+        transform: translateX(0);
+      }
+    }
+
+    /* Drag handle (bottom sheet only) */
+    .focus-sheet-drag-handle {
+      display: flex;
+      justify-content: center;
+      padding: var(--space-3) 0 var(--space-1);
+    }
+    @media (min-width: 769px) {
+      .focus-sheet-drag-handle { display: none; }
+    }
+    .focus-sheet-drag-indicator {
+      width: 32px;
+      height: 4px;
+      border-radius: var(--md-sys-shape-corner-full);
+      background: var(--md-sys-color-outline-variant);
+    }
+
+    /* Sheet header */
+    .focus-sheet-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--space-3) var(--space-5) var(--space-2);
+    }
+    .focus-sheet-title {
       font: var(--md-sys-typescale-title-medium);
       color: var(--md-sys-color-on-surface);
-      margin: 0 0 var(--space-4);
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
     }
-    .reading-drawer-close {
+    .focus-sheet-close {
       background: none;
       border: none;
       color: var(--md-sys-color-on-surface-variant);
       cursor: pointer;
-      font-size: 1.25rem;
+      font-size: 1.125rem;
       padding: var(--space-1);
       line-height: 1;
+      border-radius: var(--md-sys-shape-corner-full);
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
-    .reading-drawer-list {
+    .focus-sheet-close:hover {
+      background: var(--md-sys-color-surface-container-high);
+    }
+
+    /* Sheet sections */
+    .focus-sheet-section {
+      padding: var(--space-2) var(--space-5) var(--space-3);
+      border-top: 1px solid var(--md-sys-color-outline-variant);
+    }
+    .focus-sheet-section:first-of-type {
+      border-top: none;
+    }
+    .focus-sheet-section-title {
+      font: var(--md-sys-typescale-label-large);
+      color: var(--md-sys-color-on-surface-variant);
+      margin: 0 0 var(--space-3);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    /* Chapter list inside sheet */
+    .focus-sheet-chapter-list {
       list-style: none;
       padding: 0;
       margin: 0;
+      max-height: 200px;
+      overflow-y: auto;
     }
-    .reading-drawer-item a {
+    .focus-sheet-chapter-item a {
       display: block;
       padding: var(--space-2) var(--space-3);
       color: var(--md-sys-color-on-surface-variant);
@@ -434,47 +541,115 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
       font: var(--md-sys-typescale-body-large);
       transition: background 0.15s;
     }
-    .reading-drawer-item a:hover { background: var(--md-sys-color-surface-container-high); }
-    .reading-drawer-item.current a {
+    .focus-sheet-chapter-item a:hover {
+      background: var(--md-sys-color-surface-container-high);
+    }
+    .focus-sheet-chapter-item.current a {
       color: var(--md-sys-color-primary);
       background: var(--md-sys-color-primary-container);
       font-weight: 500;
     }
-    .reading-drawer-item .chapter-words {
+    .focus-sheet-chapter-item .chapter-words {
       font: var(--md-sys-typescale-body-small);
       color: var(--md-sys-color-outline);
     }
 
-    /* ── Bottom Toolbar ── */
-    .reading-toolbar {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      z-index: 900;
-      background: linear-gradient(to top, var(--md-sys-color-surface) 70%, transparent);
-      padding: var(--space-4) var(--space-6);
+    /* Settings rows */
+    .focus-sheet-setting-row {
       display: flex;
-      justify-content: center;
-      gap: var(--space-3);
-      transform: translateY(100%);
-      transition: transform 0.3s ease;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--space-2) 0;
     }
-    .reading-toolbar.visible { transform: translateY(0); }
-    .reading-toolbar-btn {
+    .focus-sheet-setting-label {
+      font: var(--md-sys-typescale-body-large);
+      color: var(--md-sys-color-on-surface);
+    }
+    .focus-sheet-size-buttons {
+      display: flex;
+      gap: var(--space-1);
+    }
+    .focus-sheet-size-btn {
+      width: 36px;
+      height: 36px;
+      border-radius: var(--md-sys-shape-corner-full);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      background: var(--md-sys-color-surface-container);
+      color: var(--md-sys-color-on-surface);
+      cursor: pointer;
+      font: var(--md-sys-typescale-label-large);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                  border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    }
+    .focus-sheet-size-btn.active {
+      background: var(--md-sys-color-primary-container);
+      color: var(--md-sys-color-on-primary-container);
+      border-color: var(--md-sys-color-primary);
+    }
+    .focus-sheet-size-btn:hover:not(.active) {
+      background: var(--md-sys-color-surface-container-high);
+    }
+
+    /* Mood toggle button */
+    .focus-sheet-toggle-btn {
+      padding: var(--space-2) var(--space-4);
+      border-radius: var(--md-sys-shape-corner-full);
+      border: 1px solid var(--md-sys-color-outline-variant);
+      background: var(--md-sys-color-surface-container);
+      color: var(--md-sys-color-on-surface);
+      cursor: pointer;
+      font: var(--md-sys-typescale-label-large);
+      transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                  border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    }
+    .focus-sheet-toggle-btn.active {
+      background: var(--md-sys-color-primary-container);
+      color: var(--md-sys-color-on-primary-container);
+      border-color: var(--md-sys-color-primary);
+    }
+
+    /* Navigation section */
+    .focus-sheet-nav-buttons {
+      display: flex;
+      gap: var(--space-3);
+      margin-bottom: var(--space-3);
+    }
+    .focus-sheet-nav-btn {
+      flex: 1;
+      text-align: center;
+      font: var(--md-sys-typescale-label-large);
+      color: var(--md-sys-color-primary);
+      background: var(--md-sys-color-primary-container);
+      border: none;
+      border-radius: var(--md-sys-shape-corner-full);
+      padding: var(--space-3) var(--space-4);
+      cursor: pointer;
+      text-decoration: none;
+      transition: opacity 0.2s;
+    }
+    .focus-sheet-nav-btn:hover { opacity: 0.85; }
+    .focus-sheet-nav-btn.disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+    .focus-sheet-exit-btn {
+      display: block;
+      width: 100%;
+      text-align: center;
       font: var(--md-sys-typescale-label-large);
       color: var(--md-sys-color-on-surface);
       background: var(--md-sys-color-surface-container-high);
       border: 1px solid var(--md-sys-color-outline-variant);
       border-radius: var(--md-sys-shape-corner-full);
-      padding: var(--space-2) var(--space-4);
+      padding: var(--space-3) var(--space-4);
       cursor: pointer;
-      display: flex;
-      align-items: center;
-      gap: var(--space-2);
       text-decoration: none;
+      transition: background 0.15s;
     }
-    .reading-toolbar-btn:hover {
+    .focus-sheet-exit-btn:hover {
       background: var(--md-sys-color-surface-container-highest);
       border-color: var(--md-sys-color-outline);
     }
@@ -483,14 +658,14 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
     .reading-shortcuts {
       position: fixed;
       bottom: var(--space-16);
-      right: var(--space-4);
+      left: var(--space-4);
       z-index: 800;
       font: var(--md-sys-typescale-body-small);
       color: var(--md-sys-color-outline);
       opacity: 0;
       transition: opacity 0.5s;
       pointer-events: none;
-      text-align: right;
+      text-align: left;
     }
     .reading-shortcuts.visible { opacity: 0.6; }
     kbd {
@@ -548,7 +723,7 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
 
     /* ── Reduced Motion ── */
     @media (prefers-reduced-motion: reduce) {
-      .reading-progress-bar, .reading-header, .reading-toolbar, .reading-chapters-drawer {
+      .reading-progress-bar, .focus-top-bar, .focus-sheet, .focus-sheet-backdrop {
         transition: none !important;
       }
     }


### PR DESCRIPTION
## Issue #59 — Reading Focus Mode & Quick Navigation

### What Changed
Refactored the reading mode UI from a cluttered drawer/toolbar model to an M3 Focus Mode pattern:

- **Top App Bar**: M3 Center-Aligned bar. Transparent at rest → elevates/opaque on initial scroll → hides entirely on continued downward scrolling → reappears on upward scroll.
- **FAB**: 56×56px M3 Floating Action Button, fixed bottom-right. The **only** floating element during reading (besides the thin progress bar).
- **Sheet**: Tapping the FAB opens M3 Bottom Sheet (mobile ≤768px) / M3 Side Sheet (desktop >768px, 360px from right), containing:
  - Scrollable chapter index with current-chapter highlight
  - Font size controls (S / M / L / XL)
  - Mood Engine toggle
  - Previous/Next chapter navigation + Exit Reading
- **Removed**: Old `.reading-chapters-drawer` (right-side slide), `.reading-toolbar` (bottom bar), `.reading-header` (ambient scroll-to-show header).

### Architecture
- **`src/hooks/useScrollDirection.ts`** (new): rAF-debounced scroll hook tracking direction, progress, scrollY. Replaces inline handleScroll in ReadingMode + duplicated logic in AdaptiveNav.
- **`src/components/ReadingMode.tsx`** (rewrite): FocusSheet component (inline) with full focus trap (Tab/Shift+Tab cycling + Escape close + previous-focus restore). Keyboard handler updated: `C` toggles sheet; Escape priorities to sheet-close when open.
- **`src/pages/works/[id]/read.astro`** (CSS): All `.reading-chapters-drawer`, `.reading-drawer-*`, `.reading-toolbar`, `.reading-toolbar-btn`, `.reading-header` CSS removed. New `.focus-top-bar`, `.focus-fab`, `.focus-sheet*`, `.focus-sheet-backdrop` CSS added. Responsive breakpoints for bottom→side sheet transition. Reduced-motion support preserved.

### Acceptance Criteria
- [x] Top header disappears when reading downward
- [x] Top App Bar elevates/becomes opaque on initial scroll, hides on continued downward scroll
- [x] FAB is the only floating element on screen during reading
- [x] Bottom Sheet (mobile) / Side Sheet (desktop) opens smoothly when FAB is tapped
- [x] Sheet traps focus for accessibility
- [x] Existing reading-chapters-drawer and reading-toolbar refactored into new M3 Sheet

### Files Changed
| File | Change |
|------|--------|
| `src/hooks/useScrollDirection.ts` | New — rAF-debounced scroll direction hook |
| `src/components/ReadingMode.tsx` | Major refactor — drawer/toolbar → FAB/Sheet |
| `src/pages/works/[id]/read.astro` | CSS swap — old drawer/toolbar styles → focus-mode styles |