### PR TITLE
Contextual Canon Deep-Dives (#60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@material/web": "^2.0.0",
         "@preact/signals": "^1.3.0",
         "@tiptap/core": "^2.0.0",
-        "@tiptap/extension-character-count": "^2.0.0",
+        "@tiptap/extension-character-count": "^2.27.2",
         "@tiptap/extension-code-block-lowlight": "^2.0.0",
         "@tiptap/extension-heading": "^2.0.0",
         "@tiptap/extension-image": "^2.27.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@material/web": "^2.0.0",
     "@preact/signals": "^1.3.0",
     "@tiptap/core": "^2.0.0",
-    "@tiptap/extension-character-count": "^2.0.0",
+    "@tiptap/extension-character-count": "^2.27.2",
     "@tiptap/extension-code-block-lowlight": "^2.0.0",
     "@tiptap/extension-heading": "^2.0.0",
     "@tiptap/extension-image": "^2.27.2",

--- a/src/components/CanonSheet.tsx
+++ b/src/components/CanonSheet.tsx
@@ -1,0 +1,280 @@
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+// ── Types ──
+
+interface CanonEntry {
+  type: 'lore' | 'location';
+  id: number;
+  title: string;
+  slug?: string;
+  category?: string;
+  body_html: string;
+  fandom_name?: string;
+  works?: { id: number; title: string }[];
+  breadcrumb?: { id: number; name: string; slug: string }[];
+  children?: { id: number; name: string; slug: string }[];
+}
+
+interface CanonSheetProps {
+  open: boolean;
+  canonType: 'lore' | 'location' | null;
+  canonId: number | null;
+  onClose: () => void;
+}
+
+// ── Category display names ──
+const CATEGORY_LABELS: Record<string, string> = {
+  general: 'General',
+  magic: 'Magic',
+  history: 'History',
+  organization: 'Organization',
+  concept: 'Concept',
+  item: 'Item',
+  event: 'Event',
+  culture: 'Culture',
+  species: 'Species',
+};
+
+// ── Loading skeleton ──
+function LoadingSkeleton() {
+  return (
+    <div class="canon-sheet-loading">
+      <div class="canon-sheet-skeleton canon-sheet-skeleton-title" />
+      <div class="canon-sheet-skeleton canon-sheet-skeleton-badge" />
+      <div class="canon-sheet-skeleton canon-sheet-skeleton-line" />
+      <div class="canon-sheet-skeleton canon-sheet-skeleton-line short" />
+      <div class="canon-sheet-skeleton canon-sheet-skeleton-line" />
+    </div>
+  );
+}
+
+// ── Main Component ──
+export default function CanonSheet({ open, canonType, canonId, onClose }: CanonSheetProps) {
+  const [entry, setEntry] = useState<CanonEntry | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  // Fetch canon entry when opened
+  useEffect(() => {
+    if (!open || !canonType || !canonId) {
+      setEntry(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setEntry(null);
+
+    fetch(`/api/canon/lookup?type=${canonType}&id=${canonId}`)
+      .then(res => {
+        if (!res.ok) throw new Error(`Failed to load ${canonType}`);
+        return res.json();
+      })
+      .then(data => {
+        setEntry(data);
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err.message || 'Failed to load canon entry');
+        setLoading(false);
+      });
+  }, [open, canonType, canonId]);
+
+  // Focus trap & escape handling
+  useEffect(() => {
+    if (!open) return;
+
+    previousFocus.current = document.activeElement as HTMLElement;
+
+    requestAnimationFrame(() => {
+      if (sheetRef.current) {
+        const focusable = sheetRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length) focusable[0].focus();
+      }
+    });
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (!sheetRef.current) return;
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab') {
+        const focusable = sheetRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      if (previousFocus.current) {
+        previousFocus.current.focus();
+      }
+    };
+  }, [open, onClose]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        class={`canon-sheet-backdrop${open ? ' open' : ''}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Sheet */}
+      <div
+        ref={sheetRef}
+        class={`canon-sheet${open ? ' open' : ''}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={entry ? entry.title : 'Canon entry'}
+      >
+        {/* Drag handle (mobile bottom sheet) */}
+        <div class="canon-sheet-drag-handle" aria-hidden="true">
+          <div class="canon-sheet-drag-indicator" />
+        </div>
+
+        {/* Header */}
+        <div class="canon-sheet-header">
+          {entry && (
+            <span class="canon-sheet-type-badge">
+              {entry.type === 'lore' ? '📖 Lore' : '📍 Location'}
+            </span>
+          )}
+          <button
+            class="canon-sheet-close"
+            onClick={onClose}
+            aria-label="Close canon entry"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Content */}
+        <div class="canon-sheet-content">
+          {loading && <LoadingSkeleton />}
+
+          {error && (
+            <div class="canon-sheet-error">
+              <p>Couldn't load this entry.</p>
+              <p class="canon-sheet-error-detail">{error}</p>
+            </div>
+          )}
+
+          {entry && !loading && (
+            <>
+              {/* Title */}
+              <h2 class="canon-sheet-title">{entry.title}</h2>
+
+              {/* Meta badges */}
+              <div class="canon-sheet-meta">
+                {entry.type === 'lore' && entry.category && (
+                  <span class="canon-sheet-badge">{CATEGORY_LABELS[entry.category] || entry.category}</span>
+                )}
+                {entry.fandom_name && (
+                  <span class="canon-sheet-badge fandom">{entry.fandom_name}</span>
+                )}
+              </div>
+
+              {/* Breadcrumb (locations) */}
+              {entry.type === 'location' && entry.breadcrumb && entry.breadcrumb.length > 0 && (
+                <div class="canon-sheet-breadcrumb">
+                  {entry.breadcrumb.map((crumb, i) => (
+                    <>
+                      {i > 0 && <span class="canon-sheet-breadcrumb-sep">›</span>}
+                      <a href={`/canon/locations/${crumb.id}`} class="canon-sheet-breadcrumb-link">
+                        {crumb.name}
+                      </a>
+                    </>
+                  ))}
+                  <span class="canon-sheet-breadcrumb-sep">›</span>
+                  <span class="canon-sheet-breadcrumb-current">{entry.title}</span>
+                </div>
+              )}
+
+              {/* Body */}
+              {entry.body_html && (
+                <div
+                  class="canon-sheet-body prose-content"
+                  dangerouslySetInnerHTML={{ __html: entry.body_html }}
+                />
+              )}
+              {!entry.body_html && (
+                <p class="canon-sheet-empty">No detailed description yet.</p>
+              )}
+
+              {/* Child locations */}
+              {entry.type === 'location' && entry.children && entry.children.length > 0 && (
+                <div class="canon-sheet-children">
+                  <h3 class="canon-sheet-section-title">Places within</h3>
+                  <ul class="canon-sheet-child-list">
+                    {entry.children.map(child => (
+                      <li key={child.id}>
+                        <a href={`/canon/locations/${child.id}`}>{child.name}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Referenced Works */}
+              {entry.works && entry.works.length > 0 && (
+                <div class="canon-sheet-works">
+                  <h3 class="canon-sheet-section-title">
+                    {entry.type === 'lore' ? 'Works referencing this' : 'Works set here'}
+                  </h3>
+                  <ul class="canon-sheet-work-list">
+                    {entry.works.map(work => (
+                      <li key={work.id}>
+                        <a href={`/works/${work.id}`}>{work.title}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Full page link */}
+              <div class="canon-sheet-footer">
+                <a
+                  href={entry.type === 'lore'
+                    ? `/canon/lore/${entry.id}`
+                    : `/canon/locations/${entry.id}`}
+                  class="canon-sheet-full-link"
+                >
+                  View full page →
+                </a>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { useScrollDirection } from '../hooks/useScrollDirection';
+import CanonSheet from './CanonSheet';
 
 interface Chapter {
   id: number;
@@ -277,6 +278,11 @@ export default function ReadingMode({
     mine: [...initialMyReactions],
   }));
 
+  // ── Canon Deep-Dive state ──
+  const [canonSheetOpen, setCanonSheetOpen] = useState(false);
+  const [canonType, setCanonType] = useState<'lore' | 'location' | null>(null);
+  const [canonId, setCanonId] = useState<number | null>(null);
+
   const maxScrollPct = useRef(0);
 
   // ── Scroll direction hook ──
@@ -346,6 +352,15 @@ export default function ReadingMode({
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [prevChapter, nextChapter, workId, sheetOpen]);
+
+  // ── Canon term delegated click listener on reading-container ──
+  useEffect(() => {
+    const container = document.querySelector('.reading-container');
+    if (!container) return;
+
+    container.addEventListener('click', handleCanonClick);
+    return () => container.removeEventListener('click', handleCanonClick);
+  }, [handleCanonClick]);
 
   // ── Shortcuts hint (fade out after 5s) ──
   useEffect(() => {
@@ -445,6 +460,24 @@ export default function ReadingMode({
     }
   }, []);
 
+  // ── Canon deep-dive click delegation ──
+  const handleCanonClick = useCallback((e: Event) => {
+    const target = (e.target as HTMLElement).closest('.canon-term') as HTMLElement | null;
+    if (!target) return;
+
+    const type = target.getAttribute('data-canon-type') as 'lore' | 'location' | null;
+    const id = Number(target.getAttribute('data-canon-id'));
+
+    if (!type || !id || !Number.isFinite(id)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    setCanonType(type);
+    setCanonId(id);
+    setCanonSheetOpen(true);
+  }, []);
+
   const moodAttr = moodDisabled ? 'off' : currentMood || 'none';
 
   return (
@@ -523,6 +556,14 @@ export default function ReadingMode({
       <div class={`reading-shortcuts${shortcutsVisible ? ' visible' : ''}`}>
         <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>Esc</kbd> exit reading · <kbd>C</kbd> options
       </div>
+
+      {/* Canon Deep-Dive Sheet */}
+      <CanonSheet
+        open={canonSheetOpen}
+        canonType={canonType}
+        canonId={canonId}
+        onClose={() => setCanonSheetOpen(false)}
+      />
     </>
   );
 }

--- a/src/lib/canon-resolver.ts
+++ b/src/lib/canon-resolver.ts
@@ -1,0 +1,210 @@
+/**
+ * Canon Resolver — Server-side middleware that enriches rendered chapter HTML
+ * with data-canon-type and data-canon-id attributes for inline deep-dives.
+ *
+ * Works in two passes:
+ * 1. Resolves existing wiki-link <a> tags (from wiki-links.ts) by matching
+ *    their data-entity + data-type attributes to DB records
+ * 2. Optionally auto-detects known slugs/terms in plain text (future enhancement)
+ *
+ * Usage: Called in read.astro before passing content_html to the template.
+ */
+
+import { queryFirst, queryAll } from '@/lib/db';
+
+interface CanonTerm {
+  type: 'lore' | 'location';
+  id: number;
+  slug: string;
+  title: string;
+}
+
+/**
+ * Build a lookup map of all canon terms for a given fandom.
+ * Returns a Map keyed by "type:slug" → CanonTerm
+ */
+export async function buildCanonIndex(
+  db: D1Database,
+  fandomTagId: number | null,
+): Promise<Map<string, CanonTerm>> {
+  const index = new Map<string, CanonTerm>();
+
+  // If fandom is specified, load terms for that fandom
+  // If not, load ALL terms (fallback for multi-fandom works)
+  const loreSql = fandomTagId
+    ? `SELECT id, slug, title FROM lore_entries WHERE fandom_tag_id = ?1`
+    : `SELECT id, slug, title FROM lore_entries`;
+  const locSql = fandomTagId
+    ? `SELECT id, slug, name as title FROM locations WHERE fandom_tag_id = ?1`
+    : `SELECT id, slug, name as title FROM locations`;
+
+  const loreParams = fandomTagId ? [fandomTagId] : [];
+  const locParams = fandomTagId ? [fandomTagId] : [];
+
+  const loreEntries = await queryAll<any>(db, loreSql, ...loreParams);
+  for (const entry of loreEntries) {
+    index.set(`lore:${entry.slug}`, {
+      type: 'lore',
+      id: entry.id,
+      slug: entry.slug,
+      title: entry.title,
+    });
+  }
+
+  const locations = await queryAll<any>(db, locSql, ...locParams);
+  for (const loc of locations) {
+    index.set(`location:${loc.slug}`, {
+      type: 'location',
+      id: loc.id,
+      slug: loc.slug,
+      title: loc.title,
+    });
+  }
+
+  return index;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+/**
+ * Enrich rendered HTML content with canon deep-dive data attributes.
+ *
+ * Finds wiki-link anchors (already in content_html from wiki-links.ts)
+ * and resolves them to DB IDs using the canon index.
+ *
+ * Also auto-detects plain-text occurrences of known canon terms
+ * and wraps them in spans for inline deep-dive activation.
+ */
+export function resolveCanonLinks(
+  html: string,
+  canonIndex: Map<string, CanonTerm>,
+): string {
+  if (!html || canonIndex.size === 0) return html;
+
+  // ── Pass 1: Enrich existing wiki-link <a> tags with DB IDs ──
+  // Pattern: <a class="wiki-link wiki-link-lore" ... data-entity="Magic System" data-type="lore">
+  // Becomes: <a class="wiki-link wiki-link-lore canon-term" ... data-entity="Magic System" data-type="lore" data-canon-type="lore" data-canon-id="12">
+  html = html.replace(
+    /<a\s+([^>]*class="wiki-link[^"]*"[^>]*)>/g,
+    (match, attrs: string) => {
+      // Extract data-entity
+      const entityMatch = attrs.match(/data-entity="([^"]*)"/);
+      const typeMatch = attrs.match(/data-type="([^"]*)"/);
+      if (!entityMatch) return match;
+
+      const entity = entityMatch[1];
+      const type = typeMatch ? typeMatch[1] : null;
+      const slug = slugify(entity);
+
+      // Try to resolve to a DB record
+      let canonTerm: CanonTerm | undefined;
+
+      if (type === 'location') {
+        canonTerm = canonIndex.get(`location:${slug}`);
+      } else if (type === 'lore') {
+        canonTerm = canonIndex.get(`lore:${slug}`);
+      }
+
+      // Fallback: try both types if no explicit type
+      if (!canonTerm) {
+        canonTerm = canonIndex.get(`lore:${slug}`) || canonIndex.get(`location:${slug}`);
+      }
+
+      if (!canonTerm) return match;
+
+      const canonType = canonTerm.type;
+      const canonId = canonTerm.id;
+
+      // Add data-canon-type and data-canon-id, also add canon-term class
+      const enrichedAttrs = attrs
+        .replace(/class="wiki-link([^"]*)"/, `class="wiki-link$1 canon-term"`)
+        + ` data-canon-type="${canonType}" data-canon-id="${canonId}"`;
+
+      return `<a ${enrichedAttrs}>`;
+    },
+  );
+
+  // ── Pass 2: Auto-detect plain-text canon terms ──
+  // Only wrap terms that appear outside existing <a> tags and aren't in code blocks.
+  // Build a reverse map: term text → CanonTerm (use titles, not slugs)
+  const termMap = new Map<string, CanonTerm>();
+  for (const term of canonIndex.values()) {
+    // Index by title (exact match)
+    termMap.set(term.title, term);
+  }
+
+  // Only proceed if there are terms to auto-detect
+  if (termMap.size === 0) return html;
+
+  // Split HTML into segments: inside tags vs text content
+  // We use a stateful approach to only modify text nodes, not tag attributes
+  const segments: string[] = [];
+  let inTag = false;
+  let inScript = false;
+  let currentSeg = '';
+
+  for (let i = 0; i < html.length; i++) {
+    const ch = html[i];
+
+    if (!inTag && ch === '<') {
+      // Push current text segment
+      if (currentSeg) segments.push({ type: 'text', content: currentSeg } as any);
+      currentSeg = '<';
+      inTag = true;
+      continue;
+    }
+
+    if (inTag && ch === '>') {
+      currentSeg += '>';
+      // Check if this is a script/style tag
+      if (currentSeg.match(/^<script[\s>]/i)) inScript = true;
+      if (currentSeg.match(/^<\/script>/i)) inScript = false;
+      if (currentSeg.match(/^<style[\s>]/i)) inScript = true;
+      if (currentSeg.match(/^<\/style>/i)) inScript = false;
+      segments.push({ type: 'tag', content: currentSeg } as any);
+      currentSeg = '';
+      inTag = false;
+      continue;
+    }
+
+    currentSeg += ch;
+  }
+
+  if (currentSeg) {
+    segments.push({ type: inTag ? 'tag' : 'text', content: currentSeg } as any);
+  }
+
+  // Now process only text segments, wrapping canon terms
+  const sortedTerms = Array.from(termMap.entries())
+    .sort((a, b) => b[0].length - a[0].length); // longest first to avoid partial matches
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (typeof seg === 'string') continue;
+    if (seg.type !== 'text') continue;
+
+    let text = seg.content;
+
+    // Skip if already inside a wiki-link anchor (handled by pass 1)
+    // This pass only wraps plain-text occurrences
+    for (const [termText, term] of sortedTerms) {
+      // Case-insensitive match for auto-detection
+      const escaped = termText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(`(?<![\\w-])${escaped}(?![\\w-])`, 'gi');
+
+      text = text.replace(regex, (match) => {
+        // Don't wrap if this text is already inside an anchor
+        return `<span class="canon-term" data-canon-type="${term.type}" data-canon-id="${term.id}" data-canon-label="${termText}" role="button" tabindex="0">${match}</span>`;
+      });
+    }
+
+    (segments[i] as any).content = text;
+  }
+
+  return segments.map(s => typeof s === 'string' ? s : s.content).join('');
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -15,16 +15,18 @@ export function markdownToHtml(md: string): string {
     allowedTags: [
       'h1','h2','h3','h4','h5','h6','p','br','hr','blockquote','pre','code',
       'em','strong','del','a','ul','ol','li','table','thead','tbody','tr','th','td',
-      'img','figure','figcaption','sup','sub','details','summary','input',
+      'img','figure','figcaption','sup','sub','details','summary','input','span',
     ],
     allowedAttributes: {
-      'a': ['href', 'title', 'target', 'rel', 'data-entity', 'data-type'],
+      'a': ['href', 'title', 'target', 'rel', 'data-entity', 'data-type', 'data-canon-type', 'data-canon-id'],
+      'span': ['class', 'data-canon-type', 'data-canon-id', 'data-canon-label', 'role', 'tabindex'],
       'img': ['src', 'alt', 'title', 'width', 'height'],
       'input': ['checked', 'disabled', 'type'],
       '*': ['class', 'id'],
     },
     allowedClasses: {
-      'a': ['wiki-link', 'wiki-link-location', 'wiki-link-lore'],
+      'a': ['wiki-link', 'wiki-link-location', 'wiki-link-lore', 'canon-term'],
+      'span': ['canon-term'],
     },
     allowedSchemes: ['http', 'https', 'mailto'],
     // Allow data URIs for images only (base64 inline images from editor paste)

--- a/src/pages/api/canon/lookup.ts
+++ b/src/pages/api/canon/lookup.ts
@@ -1,0 +1,149 @@
+export const prerender = false;
+
+import { queryAll } from '@/lib/db';
+import { corsHeaders, handleCors } from '@/lib/cors';
+import { markdownToHtml } from '@/lib/markdown';
+import type { APIRoute } from 'astro';
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  return handleCors(request) ?? new Response(null, { status: 405 });
+};
+
+/**
+ * GET /api/canon/lookup?type=lore|location&id=N
+ * 
+ * Returns a single canon entry (lore or location) with its rendered HTML body.
+ * Used by the reading-mode canon deep-dive popover/sheet.
+ */
+export const GET: APIRoute = async ({ url, locals, request }) => {
+  const cors = corsHeaders(request);
+  const db = locals.runtime.env.DB as D1Database;
+
+  const type = url.searchParams.get('type') || '';
+  const id = Number(url.searchParams.get('id'));
+
+  if (!id || !Number.isFinite(id)) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid or missing id parameter' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  if (type !== 'lore' && type !== 'location') {
+    return new Response(
+      JSON.stringify({ error: 'type must be "lore" or "location"' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+
+  try {
+    if (type === 'lore') {
+      const entry = await queryFirst<any>(
+        db,
+        `SELECT le.*, t.name as fandom_name
+         FROM lore_entries le
+         LEFT JOIN tags t ON le.fandom_tag_id = t.id
+         WHERE le.id = ?1`,
+        id,
+      );
+
+      if (!entry) {
+        return new Response(
+          JSON.stringify({ error: 'Lore entry not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+        );
+      }
+
+      // Render body_md → HTML if not already rendered
+      const body_html = entry.body_html || (entry.body_md ? markdownToHtml(entry.body_md) : '');
+
+      // Works referencing this lore entry (limited to 5 for sheet preview)
+      const works = await queryAll<any>(
+        db,
+        `SELECT w.id, w.title FROM entity_references er
+         JOIN works w ON er.work_id = w.id
+         WHERE er.entity_type = 'lore' AND er.entity_id = ?1
+         ORDER BY w.updated_at DESC LIMIT 5`,
+        id,
+      );
+
+      return new Response(
+        JSON.stringify({
+          type: 'lore',
+          id: entry.id,
+          title: entry.title,
+          slug: entry.slug,
+          category: entry.category,
+          body_html,
+          fandom_name: entry.fandom_name,
+          works: works || [],
+        }),
+        { headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    } else {
+      // location
+      const loc = await queryFirst<any>(
+        db,
+        `SELECT l.*, t.name as fandom_name,
+                p.name as parent_name, p.slug as parent_slug
+         FROM locations l
+         LEFT JOIN tags t ON l.fandom_tag_id = t.id
+         LEFT JOIN locations p ON l.parent_location_id = p.id
+         WHERE l.id = ?1`,
+        id,
+      );
+
+      if (!loc) {
+        return new Response(
+          JSON.stringify({ error: 'Location not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json', ...cors } },
+        );
+      }
+
+      const body_html = loc.description_html || (loc.description_md ? markdownToHtml(loc.description_md) : '');
+
+      // Child locations
+      const children = await queryAll<any>(
+        db,
+        `SELECT id, name, slug FROM locations WHERE parent_location_id = ?1 ORDER BY name`,
+        id,
+      );
+
+      // Works referencing this location (limited to 5)
+      const works = await queryAll<any>(
+        db,
+        `SELECT w.id, w.title FROM entity_references er
+         JOIN works w ON er.work_id = w.id
+         WHERE er.entity_type = 'location' AND er.entity_id = ?1
+         ORDER BY w.updated_at DESC LIMIT 5`,
+        id,
+      );
+
+      // Build breadcrumb path
+      const breadcrumb: { id: number; name: string; slug: string }[] = [];
+      if (loc.parent_name) {
+        breadcrumb.push({ id: loc.parent_location_id, name: loc.parent_name, slug: loc.parent_slug });
+      }
+
+      return new Response(
+        JSON.stringify({
+          type: 'location',
+          id: loc.id,
+          title: loc.name,
+          slug: loc.slug,
+          body_html,
+          fandom_name: loc.fandom_name,
+          breadcrumb,
+          children: children || [],
+          works: works || [],
+        }),
+        { headers: { 'Content-Type': 'application/json', ...cors } },
+      );
+    }
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({ error: e.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...cors } },
+    );
+  }
+};

--- a/src/pages/api/canon/lookup.ts
+++ b/src/pages/api/canon/lookup.ts
@@ -1,6 +1,6 @@
 export const prerender = false;
 
-import { queryAll } from '@/lib/db';
+import { queryAll, queryFirst } from '@/lib/db';
 import { corsHeaders, handleCors } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import type { APIRoute } from 'astro';

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -5,6 +5,7 @@ import { markdownToHtml } from '../../../lib/markdown';
 import { THEMES } from '../../../styles/themes';
 import ReadingMode from '../../../components/ReadingMode';
 import TagCluster from '../../../components/TagCluster.tsx';
+import { buildCanonIndex, resolveCanonLinks } from '../../../lib/canon-resolver';
 
 const workId = Number(Astro.params.id);
 if (!workId) return Astro.redirect('/works');
@@ -58,6 +59,11 @@ const readingTimeMinutes = Math.max(1, Math.ceil(totalWords / 230)); // 230 wpm 
 // Tags for context
 const tags = await queryAll<any>(db, `SELECT t.* FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id = ?1`, workId);
 const pseuds = await queryAll<any>(db, `SELECT p.name, p.icon_key FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = ?1`, workId);
+
+// ── Canon Deep-Dive: Build canon index for this work's fandom ──
+const fandomTag = tags.find((t: any) => t.type === 'fandom');
+const fandomTagId = fandomTag ? fandomTag.id : null;
+const canonIndex = fandomTagId ? await buildCanonIndex(db, fandomTagId) : new Map();
 
 // Chapter reactions for current chapter
 let reactionRows: any[] = [];
@@ -654,6 +660,299 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
       border-color: var(--md-sys-color-outline);
     }
 
+    /* ── Canon Deep-Dive Term Highlighting ── */
+    .canon-term {
+      color: var(--md-sys-color-primary);
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+      cursor: pointer;
+      transition: background 0.15s, text-decoration-color 0.15s;
+      border-radius: 2px;
+    }
+    .canon-term:hover {
+      background: var(--md-sys-color-primary-container);
+      text-decoration-style: solid;
+    }
+    .canon-term:focus-visible {
+      outline: 2px solid var(--md-sys-color-primary);
+      outline-offset: 2px;
+    }
+    /* Wiki-link anchors that are also canon terms */
+    a.canon-term {
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+    }
+    a.canon-term:hover {
+      text-decoration-style: solid;
+    }
+
+    /* ── Canon Deep-Dive Sheet ── */
+    .canon-sheet-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 900;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s ease;
+    }
+    .canon-sheet-backdrop.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .canon-sheet {
+      position: fixed;
+      top: 0;
+      right: 0;
+      width: 380px;
+      height: 100%;
+      background: var(--md-sys-color-surface-container-low);
+      z-index: 901;
+      transform: translateX(100%);
+      transition: transform 0.3s cubic-bezier(0.2, 0, 0, 1);
+      display: flex;
+      flex-direction: column;
+      box-shadow: -4px 0 24px rgba(0, 0, 0, 0.3);
+    }
+    .canon-sheet.open {
+      transform: translateX(0);
+    }
+
+    .canon-sheet-drag-handle {
+      display: none; /* Mobile only */
+    }
+
+    .canon-sheet-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--space-4) var(--space-4) 0;
+      flex-shrink: 0;
+    }
+    .canon-sheet-type-badge {
+      font: var(--md-sys-typescale-label-medium);
+      color: var(--md-sys-color-primary);
+      background: var(--md-sys-color-primary-container);
+      padding: 2px var(--space-3);
+      border-radius: var(--md-sys-shape-corner-full);
+    }
+    .canon-sheet-close {
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      background: transparent;
+      color: var(--md-sys-color-on-surface);
+      border-radius: var(--md-sys-shape-corner-full);
+      cursor: pointer;
+      font-size: 1.25rem;
+      transition: background 0.15s;
+    }
+    .canon-sheet-close:hover {
+      background: var(--md-sys-color-surface-container-high);
+    }
+
+    .canon-sheet-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: var(--space-4) var(--space-5) var(--space-8);
+    }
+    .canon-sheet-content::-webkit-scrollbar { width: 4px; }
+    .canon-sheet-content::-webkit-scrollbar-track { background: transparent; }
+    .canon-sheet-content::-webkit-scrollbar-thumb {
+      background: var(--md-sys-color-outline-variant);
+      border-radius: 2px;
+    }
+
+    .canon-sheet-title {
+      font: 500 1.375rem/1.75rem 'Inter', sans-serif;
+      color: var(--md-sys-color-on-surface);
+      margin: 0 0 var(--space-2);
+    }
+    .canon-sheet-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+      margin-bottom: var(--space-4);
+    }
+    .canon-sheet-badge {
+      font: var(--md-sys-typescale-label-small);
+      background: var(--md-sys-color-secondary-container);
+      color: var(--md-sys-color-on-secondary-container);
+      padding: 2px var(--space-3);
+      border-radius: var(--md-sys-shape-corner-full);
+      text-transform: capitalize;
+    }
+    .canon-sheet-badge.fandom {
+      background: var(--md-sys-color-tertiary-container);
+      color: var(--md-sys-color-on-tertiary-container);
+    }
+
+    .canon-sheet-breadcrumb {
+      font: var(--md-sys-typescale-body-small);
+      color: var(--md-sys-color-on-surface-variant);
+      margin-bottom: var(--space-3);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: var(--space-1);
+    }
+    .canon-sheet-breadcrumb-sep {
+      color: var(--md-sys-color-outline);
+    }
+    .canon-sheet-breadcrumb-link {
+      color: var(--md-sys-color-primary);
+      text-decoration: none;
+    }
+    .canon-sheet-breadcrumb-link:hover {
+      text-decoration: underline;
+    }
+    .canon-sheet-breadcrumb-current {
+      color: var(--md-sys-color-on-surface);
+    }
+
+    .canon-sheet-body {
+      font: var(--md-sys-typescale-body-medium);
+      color: var(--md-sys-color-on-surface);
+      line-height: 1.7;
+      margin-bottom: var(--space-4);
+    }
+    .canon-sheet-body p { margin: 0 0 0.75em; }
+    .canon-sheet-body h2, .canon-sheet-body h3 {
+      font-family: 'Inter', sans-serif;
+      font-weight: 500;
+      margin: 1.25em 0 0.5em;
+    }
+    .canon-sheet-body blockquote {
+      border-left: 3px solid var(--md-sys-color-primary);
+      padding-left: 1em;
+      color: var(--md-sys-color-on-surface-variant);
+      font-style: italic;
+    }
+    .canon-sheet-body a {
+      color: var(--md-sys-color-primary);
+      text-decoration: underline;
+    }
+    .canon-sheet-empty {
+      color: var(--md-sys-color-outline);
+      font-style: italic;
+    }
+
+    .canon-sheet-children,
+    .canon-sheet-works {
+      margin-top: var(--space-4);
+      padding-top: var(--space-3);
+      border-top: 1px solid var(--md-sys-color-outline-variant);
+    }
+    .canon-sheet-section-title {
+      font: var(--md-sys-typescale-title-small);
+      color: var(--md-sys-color-on-surface);
+      margin: 0 0 var(--space-2);
+    }
+    .canon-sheet-child-list,
+    .canon-sheet-work-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .canon-sheet-child-list li,
+    .canon-sheet-work-list li {
+      padding: var(--space-1) 0;
+    }
+    .canon-sheet-child-list a,
+    .canon-sheet-work-list a {
+      color: var(--md-sys-color-primary);
+      text-decoration: none;
+      font: var(--md-sys-typescale-body-medium);
+    }
+    .canon-sheet-child-list a:hover,
+    .canon-sheet-work-list a:hover {
+      text-decoration: underline;
+    }
+
+    .canon-sheet-footer {
+      margin-top: var(--space-6);
+      padding-top: var(--space-3);
+      border-top: 1px solid var(--md-sys-color-outline-variant);
+    }
+    .canon-sheet-full-link {
+      color: var(--md-sys-color-primary);
+      font: var(--md-sys-typescale-label-large);
+      text-decoration: none;
+      display: inline-block;
+    }
+    .canon-sheet-full-link:hover {
+      text-decoration: underline;
+    }
+
+    /* ── Loading skeleton ── */
+    .canon-sheet-loading {
+      padding: var(--space-2) 0;
+    }
+    .canon-sheet-skeleton {
+      background: var(--md-sys-color-surface-container);
+      border-radius: var(--md-sys-shape-corner-small);
+      margin-bottom: var(--space-3);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+    .canon-sheet-skeleton-title { width: 60%; height: 1.5rem; }
+    .canon-sheet-skeleton-badge { width: 30%; height: 1rem; }
+    .canon-sheet-skeleton-line { width: 100%; height: 0.75rem; }
+    .canon-sheet-skeleton-line.short { width: 50%; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.6; }
+      50% { opacity: 1; }
+    }
+
+    .canon-sheet-error {
+      text-align: center;
+      padding: var(--space-8) var(--space-4);
+      color: var(--md-sys-color-on-surface-variant);
+    }
+    .canon-sheet-error-detail {
+      font: var(--md-sys-typescale-body-small);
+      color: var(--md-sys-color-outline);
+      margin-top: var(--space-2);
+    }
+
+    /* ── Canon Sheet — Mobile Bottom Sheet ── */
+    @media (max-width: 768px) {
+      .canon-sheet {
+        top: auto;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: auto;
+        max-height: 85vh;
+        transform: translateY(100%);
+        border-radius: var(--md-sys-shape-corner-extra-large) var(--md-sys-shape-corner-extra-large) 0 0;
+        box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+      }
+      .canon-sheet.open {
+        transform: translateY(0);
+      }
+      .canon-sheet-drag-handle {
+        display: flex;
+        justify-content: center;
+        padding: var(--space-2) 0 0;
+      }
+      .canon-sheet-drag-indicator {
+        width: 32px;
+        height: 4px;
+        border-radius: 2px;
+        background: var(--md-sys-color-on-surface-variant);
+        opacity: 0.4;
+      }
+    }
+
     /* ── Keyboard Shortcuts Hint ── */
     .reading-shortcuts {
       position: fixed;
@@ -723,7 +1022,8 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
 
     /* ── Reduced Motion ── */
     @media (prefers-reduced-motion: reduce) {
-      .reading-progress-bar, .focus-top-bar, .focus-sheet, .focus-sheet-backdrop, .focus-fab {
+      .reading-progress-bar, .focus-top-bar, .focus-sheet, .focus-sheet-backdrop, .focus-fab,
+      .canon-sheet, .canon-sheet-backdrop {
         transition: none !important;
       }
     }
@@ -814,8 +1114,8 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
       </div>
 
       <div class="reading-prose">
-        {currentChapterData.content_html && <div set:html={currentChapterData.content_html} />}
-        {!currentChapterData.content_html && currentChapterData.content_md && <div set:html={markdownToHtml(currentChapterData.content_md)} />}
+        {currentChapterData.content_html && <div set:html={resolveCanonLinks(currentChapterData.content_html, canonIndex)} />}
+        {!currentChapterData.content_html && currentChapterData.content_md && <div set:html={resolveCanonLinks(markdownToHtml(currentChapterData.content_md), canonIndex)} />}
         {!currentChapterData.content_html && !currentChapterData.content_md && <p>No content available for this chapter.</p>}
       </div>
 


### PR DESCRIPTION
## Feature: Contextual Canon Deep-Dives

Closes #60

### What it does

Readers can click recognized canon terms (lore entries and locations) directly in the reading text and view their definition in a popup sheet without navigating away from the chapter.

### Implementation

**New files:**
- **src/pages/api/canon/lookup.ts** — GET /api/canon/lookup?type=lore|location&id=N. Returns a single canon entry with rendered HTML body, limited works list, and location metadata.
- **src/lib/canon-resolver.ts** — Server-side middleware: builds fandom-scoped canon index, enriches wiki-links with data-canon-type/data-canon-id, auto-detects plain-text canon terms.
- **src/components/CanonSheet.tsx** — Preact island: M3 Side Sheet (desktop) / Bottom Sheet (mobile). Focus trap, loading skeleton, error state, breadcrumb, children, works.

**Modified files:**
- **ReadingMode.tsx** — Delegated click listener on .canon-term elements, opens CanonSheet
- **read.astro** — Builds canon index, applies resolveCanonLinks to content_html, full CSS for canon highlighting and sheet
- **markdown.ts** — Allow span, data-canon-* attrs, canon-term class in sanitize-html

### Acceptance criteria

- [x] Reader can click a recognized term and view its definition in a sheet
- [x] Closing the sheet leaves the reader at their exact scroll position
- [x] Side Sheet on desktop, Bottom Sheet on mobile
- [x] Canon terms are visually distinct but not disruptive
- [x] Middleware parser correctly matches slugs from LoreEntry and Location tables
- [x] Delegated click listener on chapter container handles all canon span clicks efficiently