### PR TITLE
feat(search): M3 Faceted Search & Work Discovery

### DIFF
--- a/src/components/FilterChips.tsx
+++ b/src/components/FilterChips.tsx
@@ -1,0 +1,123 @@
+import { h } from 'preact';
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+/**
+ * FilterChips — Horizontal scrolling row of M3 Filter Chips for search facets.
+ * Supports: tag type filters, completion status, and word count ranges.
+ */
+
+interface FilterState {
+  type: string;
+  complete: string; // '' | '1' | '0'
+  word_min: number;
+  word_max: number;
+}
+
+interface FilterChipsProps {
+  filters: FilterState;
+  onChange: (filters: FilterState) => void;
+}
+
+const TYPE_CHIPS = [
+  { value: '', label: 'All' },
+  { value: 'fandom', label: 'Fandom' },
+  { value: 'character', label: 'Characters' },
+  { value: 'relationship', label: 'Relationships' },
+  { value: 'freeform', label: 'Freeform' },
+  { value: 'rating', label: 'Rating' },
+  { value: 'warning', label: 'Warnings' },
+  { value: 'category', label: 'Category' },
+];
+
+const STATUS_CHIPS = [
+  { value: '', label: 'Any Status' },
+  { value: '1', label: 'Complete' },
+  { value: '0', label: 'WIP' },
+];
+
+const WORD_CHIPS = [
+  { value: { min: 0, max: 0 }, label: 'Any Length' },
+  { value: { min: 0, max: 10000 }, label: '< 10k' },
+  { value: { min: 10000, max: 50000 }, label: '10k–50k' },
+  { value: { min: 50000, max: 100000 }, label: '50k–100k' },
+  { value: { min: 100000, max: 0 }, label: '100k+' },
+];
+
+export default function FilterChips({ filters, onChange }: FilterChipsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  function handleTypeChange(value: string) {
+    onChange({ ...filters, type: value });
+  }
+
+  function handleStatusChange(value: string) {
+    onChange({ ...filters, complete: value });
+  }
+
+  function handleWordChange(min: number, max: number) {
+    onChange({ ...filters, word_min: min, word_max: max });
+  }
+
+  // Determine active word chip
+  const activeWordChip = WORD_CHIPS.findIndex(w =>
+    w.value.min === filters.word_min && w.value.max === filters.word_max
+  );
+
+  return (
+    <div class="filter-chips-container">
+      {/* Tag Type Filter Row */}
+      <div class="filter-row">
+        <span class="filter-row__label">Type</span>
+        <div class="filter-row__chips" ref={scrollRef}>
+          {TYPE_CHIPS.map(chip => (
+            <button
+              type="button"
+              class={`filter-chip${filters.type === chip.value ? ' filter-chip--active' : ''}`}
+              onClick={() => handleTypeChange(chip.value)}
+              aria-pressed={filters.type === chip.value}
+              key={chip.value}
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Status Filter Row */}
+      <div class="filter-row">
+        <span class="filter-row__label">Status</span>
+        <div class="filter-row__chips">
+          {STATUS_CHIPS.map(chip => (
+            <button
+              type="button"
+              class={`filter-chip${filters.complete === chip.value ? ' filter-chip--active' : ''}`}
+              onClick={() => handleStatusChange(chip.value)}
+              aria-pressed={filters.complete === chip.value}
+              key={chip.value}
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Word Count Filter Row */}
+      <div class="filter-row">
+        <span class="filter-row__label">Length</span>
+        <div class="filter-row__chips">
+          {WORD_CHIPS.map((chip, i) => (
+            <button
+              type="button"
+              class={`filter-chip${activeWordChip === i ? ' filter-chip--active' : ''}`}
+              onClick={() => handleWordChange(chip.value.min, chip.value.max)}
+              aria-pressed={activeWordChip === i}
+              key={i}
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FilterChips.tsx
+++ b/src/components/FilterChips.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+import { useRef } from 'preact/hooks';
 
 /**
  * FilterChips — Horizontal scrolling row of M3 Filter Chips for search facets.

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -1,0 +1,104 @@
+import { h } from 'preact';
+
+/**
+ * WorkCard — M3 Outlined Card for search/browse results.
+ * Displays work title, author, summary, meta info, and color-coded tag chips.
+ */
+
+interface WorkTag {
+  id: number;
+  name: string;
+  type: string; // fandom | character | relationship | freeform | rating | warning | category
+}
+
+interface WorkCardProps {
+  id: number;
+  title: string;
+  pseud_name?: string | null;
+  summary?: string | null;
+  word_count: number;
+  complete: number;
+  published_at?: string | null;
+  tags: WorkTag[];
+}
+
+// Tag type display order and metadata
+const TAG_META: Record<string, { label: string; cssClass: string; icon: string }> = {
+  fandom:       { label: 'Fandom',       cssClass: 'work-tag--fandom',       icon: '📚' },
+  character:    { label: 'Characters',   cssClass: 'work-tag--character',    icon: '👤' },
+  relationship: { label: 'Relationships', cssClass: 'work-tag--relationship', icon: '❤️' },
+  freeform:    { label: 'Tags',         cssClass: 'work-tag--freeform',     icon: '🏷️' },
+  rating:       { label: 'Rating',       cssClass: 'work-tag--rating',       icon: '⭐' },
+  warning:      { label: 'Warnings',     cssClass: 'work-tag--warning',      icon: '⚠️' },
+  category:     { label: 'Category',     cssClass: 'work-tag--category',     icon: '📂' },
+};
+
+const TAG_DISPLAY_ORDER = ['rating', 'warning', 'category', 'fandom', 'relationship', 'character', 'freeform'];
+
+export default function WorkCard({ id, title, pseud_name, summary, word_count, complete, published_at, tags }: WorkCardProps) {
+  // Group and order tags
+  const grouped: Record<string, WorkTag[]> = {};
+  for (const tag of tags) {
+    if (!grouped[tag.type]) grouped[tag.type] = [];
+    grouped[tag.type].push(tag);
+  }
+
+  const visibleGroups = TAG_DISPLAY_ORDER.filter(type => grouped[type]?.length > 0);
+
+  // Truncate summary
+  const truncatedSummary = summary
+    ? (summary.length > 280 ? summary.slice(0, 280) + '…' : summary)
+    : null;
+
+  // Format date
+  const dateStr = published_at
+    ? new Date(published_at + 'Z').toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+    : 'Unpublished';
+
+  // Word count formatting
+  const formattedWords = word_count?.toLocaleString() ?? '0';
+
+  return (
+    <article class="work-card">
+      <div class="work-card__header">
+        <a href={`/works/${id}`} class="work-card__title">{title}</a>
+        {pseud_name && <span class="work-card__author">by {pseud_name}</span>}
+      </div>
+
+      {truncatedSummary && (
+        <p class="work-card__summary">{truncatedSummary}</p>
+      )}
+
+      <div class="work-card__meta">
+        <span class="work-card__meta-item">{formattedWords} words</span>
+        <span class="work-card__meta-sep">·</span>
+        <span class="work-card__meta-item">{complete ? 'Complete' : 'WIP'}</span>
+        <span class="work-card__meta-sep">·</span>
+        <span class="work-card__meta-item">{dateStr}</span>
+      </div>
+
+      {visibleGroups.length > 0 && (
+        <div class="work-card__tags">
+          {visibleGroups.map(type => {
+            const meta = TAG_META[type];
+            const groupTags = grouped[type];
+            return (
+              <span class={`work-tag-group ${meta.cssClass}`} key={type}>
+                {groupTags.map((tag, i) => (
+                  <a
+                    href={`/search?q=&type=${tag.type}`}
+                    class={`work-tag ${meta.cssClass}`}
+                    key={tag.id}
+                    title={`${tag.name} (${meta.label})`}
+                  >
+                    {tag.name}
+                  </a>
+                ))}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/pages/api/search/index.ts
+++ b/src/pages/api/search/index.ts
@@ -1,6 +1,6 @@
 export const prerender = false;
 
-import { queryAll, queryFirst } from '@/lib/db';
+import { queryAll } from '@/lib/db';
 import { corsHeaders, handleCors } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 
@@ -55,45 +55,26 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
 
   const whereClause = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
 
-  // Count query
+  // Build count and data queries from a single source of truth
   let countSql: string;
   let countBindings: any[];
-  if (ftsWhere) {
-    countSql = `SELECT COUNT(*) as total FROM works w ${ftsWhere} ${whereClause ? ' AND ' + conditions.join(' AND ') : ''}`;
-    countBindings = [...ftsBindings];
-    // Re-add non-FTS bindings for count (we already have conditions in whereClause)
-  } else {
-    countSql = `SELECT COUNT(*) as total FROM works w ${whereClause}`;
-    countBindings = [...bindings];
-  }
-
-  // Actually, let's rebuild this more cleanly
-  // The FTS MATCH needs to be in the FROM/JOIN clause, conditions go in WHERE
-  if (ftsWhere) {
-    countSql = `SELECT COUNT(*) as total FROM works w JOIN works_fts f ON f.rowid = w.id WHERE works_fts MATCH ?`;
-    countBindings = [ftsBindings[0], ...bindings];
-  } else {
-    countSql = `SELECT COUNT(*) as total FROM works w ${whereClause}`;
-    countBindings = [...bindings];
-  }
-
-  // Data query
   let dataSql: string;
   let dataBindings: any[];
+
   if (ftsWhere) {
-    dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w JOIN works_fts f ON f.rowid = w.id WHERE works_fts MATCH ?`;
-    // Append conditions (skip the published_at one since FTS already requires it)
-    const extraConditions = conditions.slice(1); // all except published_at
-    if (extraConditions.length > 0) {
-      dataSql += ' AND ' + extraConditions.join(' AND ');
-    }
+    // FTS path: include ALL conditions (including published_at) after the MATCH predicate
+    const allConditions = ' AND ' + conditions.join(' AND ');
+    countSql = `SELECT COUNT(*) as total FROM works w JOIN works_fts f ON f.rowid = w.id WHERE works_fts MATCH ?${allConditions}`;
+    countBindings = [ftsBindings[0], ...bindings];
+
+    dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w JOIN works_fts f ON f.rowid = w.id WHERE works_fts MATCH ?${allConditions} ORDER BY rank`;
     dataBindings = [ftsBindings[0], ...bindings];
-    // Order by rank for FTS relevance
-    dataSql += ' ORDER BY rank';
   } else {
-    dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${whereClause}`;
+    countSql = `SELECT COUNT(*) as total FROM works w ${whereClause}`;
+    countBindings = [...bindings];
+
+    dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${whereClause} ORDER BY w.updated_at DESC`;
     dataBindings = [...bindings];
-    dataSql += ' ORDER BY w.updated_at DESC';
   }
 
   dataSql += ' LIMIT ? OFFSET ?';
@@ -103,21 +84,42 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
   const totalRow = await db.prepare(countSql).bind(...countBindings).first<{ total: number }>();
   const total = totalRow?.total ?? 0;
 
-  // Enrich results with pseuds and tags
-  for (const w of results) {
-    const pseud = await queryAll<any>(
-      db,
-      `SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = ?1 LIMIT 1`,
-      w.id
-    );
-    w.pseud_name = pseud[0]?.name ?? null;
+  // Enrich results with pseuds and tags using batched queries
+  const workIds = results.map((w: any) => w.id);
 
-    const tags = await queryAll<any>(
+  if (workIds.length > 0) {
+    const placeholders = workIds.map(() => '?').join(', ');
+
+    const pseudRows = await queryAll<{ work_id: number; pseud_name: string | null }>(
       db,
-      `SELECT t.id, t.name, t.type FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id = ?1 ORDER BY t.type, t.name`,
-      w.id
+      `SELECT w.id AS work_id, (SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = w.id LIMIT 1) AS pseud_name FROM works w WHERE w.id IN (${placeholders})`,
+      ...workIds
     );
-    w.tags = tags;
+    const pseudByWorkId = new Map<number, string | null>(
+      pseudRows.map(row => [row.work_id, row.pseud_name ?? null])
+    );
+
+    const tagRows = await queryAll<{ work_id: number; id: number; name: string; type: string }>(
+      db,
+      `SELECT tg.work_id, t.id, t.name, t.type FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id IN (${placeholders}) ORDER BY tg.work_id, t.type, t.name`,
+      ...workIds
+    );
+    const tagsByWorkId = new Map<number, { id: number; name: string; type: string }[]>();
+    for (const row of tagRows) {
+      const tags = tagsByWorkId.get(row.work_id) ?? [];
+      tags.push({ id: row.id, name: row.name, type: row.type });
+      tagsByWorkId.set(row.work_id, tags);
+    }
+
+    for (const w of results) {
+      w.pseud_name = pseudByWorkId.get(w.id) ?? null;
+      w.tags = tagsByWorkId.get(w.id) ?? [];
+    }
+  } else {
+    for (const w of results) {
+      w.pseud_name = null;
+      w.tags = [];
+    }
   }
 
   return new Response(

--- a/src/pages/api/search/index.ts
+++ b/src/pages/api/search/index.ts
@@ -1,6 +1,6 @@
 export const prerender = false;
 
-import { queryAll } from '@/lib/db';
+import { queryAll, queryFirst } from '@/lib/db';
 import { corsHeaders, handleCors } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 
@@ -12,62 +12,112 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
   const cors = corsHeaders(request);
   const db = locals.runtime.env.DB as D1Database;
 
-  const rawQ = url.searchParams.get('q')?.trim();
-  if (!rawQ) {
-    return new Response(JSON.stringify({ error: 'Query parameter "q" is required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
-  }
-  // Sanitize FTS5 query — whitelist only safe word characters
-  // Split into words, keep only alphanumeric/CJK, rejoin with AND
-  const words = rawQ.split(/\s+/).filter(w => /^[\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]+$/.test(w));
-  const sanitizedQ = words.join(' ').trim();
-  if (!sanitizedQ) {
-    return new Response(
-      JSON.stringify({ error: 'Query parameter "q" must contain searchable terms' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      }
-    );
-  }
-  const q = sanitizedQ;
-
+  const rawQ = url.searchParams.get('q')?.trim() || '';
   const type = url.searchParams.get('type')?.trim() || undefined;
   const page = Math.max(Number(url.searchParams.get('page')) || 1, 1);
   const limit = Math.min(Number(url.searchParams.get('limit')) || 20, 100);
   const offset = (page - 1) * limit;
 
-  // Build base FTS query
-  let countSql = `SELECT COUNT(*) as total FROM works_fts f JOIN works w ON f.rowid = w.id WHERE works_fts MATCH ? AND w.published_at IS NOT NULL`;
-  let dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.published_at FROM works_fts f JOIN works w ON f.rowid = w.id WHERE works_fts MATCH ? AND w.published_at IS NOT NULL`;
-  const bindings: any[] = [q];
-  const countBindings: any[] = [q];
+  // Faceted filter params
+  const complete = url.searchParams.get('complete'); // '1' or '0'
+  const wordCountMin = Number(url.searchParams.get('word_min')) || 0;
+  const wordCountMax = Number(url.searchParams.get('word_max')) || 0;
+  // Tag IDs filter: comma-separated tag IDs
+  const tagIds = url.searchParams.get('tags')?.split(',').map(Number).filter(n => n > 0) || [];
 
-  // Optional tag type filter via taggings join
-  if (type) {
-    dataSql += ` AND w.id IN (SELECT tg.work_id FROM taggings tg JOIN tags t ON t.id = tg.tag_id WHERE t.type = ?)`;
-    countSql += ` AND w.id IN (SELECT tg.work_id FROM taggings tg JOIN tags t ON t.id = tg.tag_id WHERE t.type = ?)`;
-    bindings.push(type);
-    countBindings.push(type);
+  // Sanitize FTS5 query
+  let ftsWhere = '';
+  const ftsBindings: any[] = [];
+
+  if (rawQ) {
+    const words = rawQ.split(/\s+/).filter(w => /^[\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]+$/.test(w));
+    const sanitizedQ = words.join(' ').trim();
+    if (sanitizedQ) {
+      ftsWhere = `JOIN works_fts f ON f.rowid = w.id AND works_fts MATCH ?`;
+      ftsBindings.push(sanitizedQ);
+    }
   }
 
-  dataSql += ` ORDER BY rank LIMIT ? OFFSET ?`;
-  bindings.push(limit, offset);
+  // Build WHERE conditions
+  const conditions: string[] = ['w.published_at IS NOT NULL'];
+  const bindings: any[] = [];
 
-  const results = await queryAll<any>(db, dataSql, ...bindings);
+  if (complete === '1') conditions.push('w.complete = 1');
+  if (complete === '0') conditions.push('w.complete = 0');
+  if (wordCountMin > 0) { conditions.push('w.word_count >= ?'); bindings.push(wordCountMin); }
+  if (wordCountMax > 0) { conditions.push('w.word_count <= ?'); bindings.push(wordCountMax); }
+  if (type) { conditions.push(`w.id IN (SELECT tg.work_id FROM taggings tg JOIN tags t ON t.id = tg.tag_id WHERE t.type = ?)`); bindings.push(type); }
+  if (tagIds.length > 0) {
+    const tagPlaceholders = tagIds.map(() => '?').join(',');
+    conditions.push(`w.id IN (SELECT tg.work_id FROM taggings tg WHERE tg.tag_id IN (${tagPlaceholders}))`);
+    bindings.push(...tagIds);
+  }
+
+  const whereClause = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+
+  // Count query
+  let countSql: string;
+  let countBindings: any[];
+  if (ftsWhere) {
+    countSql = `SELECT COUNT(*) as total FROM works w ${ftsWhere} ${whereClause ? ' AND ' + conditions.join(' AND ') : ''}`;
+    countBindings = [...ftsBindings];
+    // Re-add non-FTS bindings for count (we already have conditions in whereClause)
+  } else {
+    countSql = `SELECT COUNT(*) as total FROM works w ${whereClause}`;
+    countBindings = [...bindings];
+  }
+
+  // Actually, let's rebuild this more cleanly
+  // The FTS MATCH needs to be in the FROM/JOIN clause, conditions go in WHERE
+  if (ftsWhere) {
+    countSql = `SELECT COUNT(*) as total FROM works w JOIN works_fts f ON f.rowid = w.id WHERE works_fts MATCH ?`;
+    countBindings = [ftsBindings[0], ...bindings];
+  } else {
+    countSql = `SELECT COUNT(*) as total FROM works w ${whereClause}`;
+    countBindings = [...bindings];
+  }
+
+  // Data query
+  let dataSql: string;
+  let dataBindings: any[];
+  if (ftsWhere) {
+    dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w JOIN works_fts f ON f.rowid = w.id WHERE works_fts MATCH ?`;
+    // Append conditions (skip the published_at one since FTS already requires it)
+    const extraConditions = conditions.slice(1); // all except published_at
+    if (extraConditions.length > 0) {
+      dataSql += ' AND ' + extraConditions.join(' AND ');
+    }
+    dataBindings = [ftsBindings[0], ...bindings];
+    // Order by rank for FTS relevance
+    dataSql += ' ORDER BY rank';
+  } else {
+    dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${whereClause}`;
+    dataBindings = [...bindings];
+    dataSql += ' ORDER BY w.updated_at DESC';
+  }
+
+  dataSql += ' LIMIT ? OFFSET ?';
+  dataBindings.push(limit, offset);
+
+  const results = await queryAll<any>(db, dataSql, ...dataBindings);
   const totalRow = await db.prepare(countSql).bind(...countBindings).first<{ total: number }>();
   const total = totalRow?.total ?? 0;
 
-  // Fetch first pseud for each result work
+  // Enrich results with pseuds and tags
   for (const w of results) {
     const pseud = await queryAll<any>(
       db,
       `SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = ?1 LIMIT 1`,
       w.id
     );
-    (w as any).pseud_name = pseud[0]?.name ?? null;
+    w.pseud_name = pseud[0]?.name ?? null;
+
+    const tags = await queryAll<any>(
+      db,
+      `SELECT t.id, t.name, t.type FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id = ?1 ORDER BY t.type, t.name`,
+      w.id
+    );
+    w.tags = tags;
   }
 
   return new Response(

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -1,8 +1,6 @@
 ---
 export const prerender = false;
 import Base from '../../layouts/Base.astro';
-import FilterChips from '../../components/FilterChips.tsx';
-import WorkCard from '../../components/WorkCard.tsx';
 import { queryAll } from '../../lib/db';
 
 const db = Astro.locals.runtime.env.DB as D1Database;
@@ -44,10 +42,11 @@ const whereClause = 'WHERE ' + conditions.join(' AND ');
 
 if (hasQuery && sanitizedQ) {
   const ftsJoin = `JOIN works_fts f ON f.rowid = w.id`;
-  const extraConditions = conditions.length > 1 ? ' AND ' + conditions.slice(1).join(' AND ') : '';
+  // Include ALL conditions (including published_at) after the MATCH predicate
+  const allConditions = ' AND ' + conditions.join(' AND ');
 
-  const dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${ftsJoin} WHERE works_fts MATCH ?${extraConditions} ORDER BY rank LIMIT ? OFFSET ?`;
-  const countSql = `SELECT COUNT(*) as total FROM works w ${ftsJoin} WHERE works_fts MATCH ?${extraConditions}`;
+  const dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${ftsJoin} WHERE works_fts MATCH ?${allConditions} ORDER BY rank LIMIT ? OFFSET ?`;
+  const countSql = `SELECT COUNT(*) as total FROM works w ${ftsJoin} WHERE works_fts MATCH ?${allConditions}`;
 
   results = await queryAll<any>(db, dataSql, sanitizedQ, ...bindings, limit, offset);
   const totalRow = await db.prepare(countSql).bind(sanitizedQ, ...countBindings).first<{ total: number }>();
@@ -62,18 +61,45 @@ if (hasQuery && sanitizedQ) {
   total = totalRow?.total ?? 0;
 }
 
-// Enrich with pseuds and tags
-for (const w of results) {
-  const pseud = await queryAll<any>(db, `SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = ?1 LIMIT 1`, w.id);
-  w.pseud_name = pseud[0]?.name ?? null;
-  w.tags = await queryAll<any>(db, `SELECT t.id, t.name, t.type FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id = ?1 ORDER BY t.type, t.name`, w.id);
+// Enrich with pseuds and tags using batched queries
+const workIds = results.map((w: any) => w.id);
+
+if (workIds.length > 0) {
+  const placeholders = workIds.map(() => '?').join(', ');
+
+  const pseudRows = await queryAll<any>(
+    db,
+    `SELECT w.id AS work_id, (SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = w.id LIMIT 1) AS pseud_name FROM works w WHERE w.id IN (${placeholders})`,
+    ...workIds
+  );
+  const pseudByWorkId = new Map<number, string | null>(
+    pseudRows.map((row: any) => [row.work_id, row.pseud_name ?? null])
+  );
+
+  const tagRows = await queryAll<any>(
+    db,
+    `SELECT tg.work_id, t.id, t.name, t.type FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id IN (${placeholders}) ORDER BY tg.work_id, t.type, t.name`,
+    ...workIds
+  );
+  const tagsByWorkId = new Map<number, any[]>();
+  for (const row of tagRows) {
+    const tagList = tagsByWorkId.get(row.work_id) ?? [];
+    tagList.push({ id: row.id, name: row.name, type: row.type });
+    tagsByWorkId.set(row.work_id, tagList);
+  }
+
+  for (const w of results) {
+    w.pseud_name = pseudByWorkId.get(w.id) ?? null;
+    w.tags = tagsByWorkId.get(w.id) ?? [];
+  }
+} else {
+  for (const w of results) {
+    w.pseud_name = null;
+    w.tags = [];
+  }
 }
 
 const initialFilters = JSON.stringify({ type, complete, word_min, word_max });
-const initialResults = JSON.stringify(results);
-const initialTotal = total;
-const initialPage = page;
-const initialLimit = limit;
 ---
 
 <Base title={query ? `Search: ${query} — fanfiction.fyi` : 'Search — fanfiction.fyi'}>
@@ -100,7 +126,7 @@ const initialLimit = limit;
     </form>
 
     <!-- Filter Chips -->
-    <div id="filter-chips-mount" data-initial-filters={initialFilters}></div>
+    <div id="filter-chips-mount" data-initial-filters={initialFilters} data-initial-page={page}></div>
 
     <!-- Results Meta -->
     <div id="search-results">
@@ -169,21 +195,29 @@ const initialLimit = limit;
 
 <script is:inline>
   function escapeHtml(str) {
-    var d = document.createElement('div');
-    d.textContent = str;
-    return d.innerHTML;
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   var currentFilters = { type: '', complete: '', word_min: 0, word_max: 0 };
   var currentPage = 1;
 
-  // Read initial filters from mount point
+  // Read initial filters and page from mount point
   var mountEl = document.getElementById('filter-chips-mount');
-  if (mountEl && mountEl.dataset.initialFilters) {
-    try {
-      var init = JSON.parse(mountEl.dataset.initialFilters);
-      currentFilters = init;
-    } catch(e) {}
+  if (mountEl) {
+    if (mountEl.dataset.initialFilters) {
+      try {
+        var init = JSON.parse(mountEl.dataset.initialFilters);
+        currentFilters = init;
+      } catch(e) {}
+    }
+    if (mountEl.dataset.initialPage) {
+      currentPage = Math.max(parseInt(mountEl.dataset.initialPage) || 1, 1);
+    }
   }
 
   // ── Filter Chips (inline implementation) ──
@@ -345,7 +379,7 @@ const initialLimit = limit;
 
         document.getElementById('search-results').innerHTML = html;
 
-        // Update URL
+        // Update URL with pushState so back/forward works
         var urlParams = new URLSearchParams();
         if (q) urlParams.set('q', q);
         if (currentFilters.type) urlParams.set('type', currentFilters.type);
@@ -353,7 +387,11 @@ const initialLimit = limit;
         if (currentFilters.word_min > 0) urlParams.set('word_min', String(currentFilters.word_min));
         if (currentFilters.word_max > 0) urlParams.set('word_max', String(currentFilters.word_max));
         if (currentPage > 1) urlParams.set('page', String(currentPage));
-        window.history.replaceState(null, '', '/search?' + urlParams.toString());
+        window.history.pushState(
+          { q: q, filters: Object.assign({}, currentFilters), page: currentPage },
+          '',
+          '/search?' + urlParams.toString()
+        );
       })
       .catch(function() {
         document.getElementById('search-results').innerHTML =
@@ -387,6 +425,29 @@ const initialLimit = limit;
     fetchResults();
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
+
+  // Restore state on back/forward navigation
+  window.addEventListener('popstate', function(e) {
+    var params;
+    var inputEl = document.getElementById('search-input');
+    if (e.state) {
+      currentFilters = e.state.filters || { type: '', complete: '', word_min: 0, word_max: 0 };
+      currentPage = e.state.page || 1;
+      if (inputEl) inputEl.value = e.state.q || '';
+    } else {
+      params = new URLSearchParams(location.search);
+      currentFilters = {
+        type: params.get('type') || '',
+        complete: params.get('complete') || '',
+        word_min: Number(params.get('word_min')) || 0,
+        word_max: Number(params.get('word_max')) || 0
+      };
+      currentPage = Math.max(Number(params.get('page')) || 1, 1);
+      if (inputEl) inputEl.value = params.get('q') || '';
+    }
+    renderFilterChips();
+    fetchResults();
+  });
 </script>
 
 <style is:global>
@@ -714,13 +775,5 @@ const initialLimit = limit;
     .work-card {
       padding: var(--space-3) var(--space-4);
     }
-    .work-card__tags {
-      overflow-x: auto;
-      flex-wrap: nowrap;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: none;
-      padding-bottom: 2px;
-    }
-    .work-card__tags::-webkit-scrollbar { display: none; }
   }
 </style>

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -1,56 +1,86 @@
 ---
 export const prerender = false;
 import Base from '../../layouts/Base.astro';
+import FilterChips from '../../components/FilterChips.tsx';
+import WorkCard from '../../components/WorkCard.tsx';
 import { queryAll } from '../../lib/db';
 
 const db = Astro.locals.runtime.env.DB as D1Database;
 
 const query = Astro.url.searchParams.get('q')?.trim() || '';
 const type = Astro.url.searchParams.get('type')?.trim() || '';
+const complete = Astro.url.searchParams.get('complete')?.trim() || '';
+const word_min = Number(Astro.url.searchParams.get('word_min')) || 0;
+const word_max = Number(Astro.url.searchParams.get('word_max')) || 0;
 const page = Math.max(Number(Astro.url.searchParams.get('page')) || 1, 1);
 const limit = 20;
 const offset = (page - 1) * limit;
 
+// Build SSR query
 let results: any[] = [];
 let total = 0;
 
-if (query) {
-  // Sanitize FTS5 query — strip special operators that cause SQL errors
-  const words = query.split(/\s+/).filter(w => /^[\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]+$/.test(w));
-  const sanitizedQ = words.join(' ').trim();
+// FTS search conditions
+const hasQuery = query.length > 0;
+const words = query.split(/\s+/).filter(w => /^[\w\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]+$/.test(w));
+const sanitizedQ = words.join(' ').trim();
 
-  let countSql = `SELECT COUNT(*) as total FROM works_fts f JOIN works w ON f.rowid = w.id WHERE works_fts MATCH ? AND w.published_at IS NOT NULL`;
-  let dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.published_at FROM works_fts f JOIN works w ON f.rowid = w.id WHERE works_fts MATCH ? AND w.published_at IS NOT NULL`;
-  const bindings: any[] = [sanitizedQ];
-  const countBindings: any[] = [sanitizedQ];
+// Build the count and data queries
+const conditions: string[] = ['w.published_at IS NOT NULL'];
+const bindings: any[] = [];
+const countBindings: any[] = [];
 
-  if (type) {
-    dataSql += ` AND w.id IN (SELECT tg.work_id FROM taggings tg JOIN tags t ON t.id = tg.tag_id WHERE t.type = ?)`;
-    countSql += ` AND w.id IN (SELECT tg.work_id FROM taggings tg JOIN tags t ON t.id = tg.tag_id WHERE t.type = ?)`;
-    bindings.push(type);
-    countBindings.push(type);
-  }
+if (type) {
+  conditions.push(`w.id IN (SELECT tg.work_id FROM taggings tg JOIN tags t ON t.id = tg.tag_id WHERE t.type = ?)`);
+  bindings.push(type);
+  countBindings.push(type);
+}
+if (complete === '1') { conditions.push('w.complete = 1'); }
+if (complete === '0') { conditions.push('w.complete = 0'); }
+if (word_min > 0) { conditions.push('w.word_count >= ?'); bindings.push(word_min); countBindings.push(word_min); }
+if (word_max > 0) { conditions.push('w.word_count <= ?'); bindings.push(word_max); countBindings.push(word_max); }
 
-  dataSql += ` ORDER BY rank LIMIT ? OFFSET ?`;
-  bindings.push(limit, offset);
+const whereClause = 'WHERE ' + conditions.join(' AND ');
 
-  results = await queryAll<any>(db, dataSql, ...bindings);
+if (hasQuery && sanitizedQ) {
+  const ftsJoin = `JOIN works_fts f ON f.rowid = w.id`;
+  const extraConditions = conditions.length > 1 ? ' AND ' + conditions.slice(1).join(' AND ') : '';
+
+  const dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${ftsJoin} WHERE works_fts MATCH ?${extraConditions} ORDER BY rank LIMIT ? OFFSET ?`;
+  const countSql = `SELECT COUNT(*) as total FROM works w ${ftsJoin} WHERE works_fts MATCH ?${extraConditions}`;
+
+  results = await queryAll<any>(db, dataSql, sanitizedQ, ...bindings, limit, offset);
+  const totalRow = await db.prepare(countSql).bind(sanitizedQ, ...countBindings).first<{ total: number }>();
+  total = totalRow?.total ?? 0;
+} else if (conditions.length > 1 || !hasQuery) {
+  // Browse without text search — just filters
+  const dataSql = `SELECT w.id, w.title, w.summary, w.word_count, w.complete, w.published_at, w.updated_at FROM works w ${whereClause} ORDER BY w.updated_at DESC LIMIT ? OFFSET ?`;
+  const countSql = `SELECT COUNT(*) as total FROM works w ${whereClause}`;
+
+  results = await queryAll<any>(db, dataSql, ...bindings, limit, offset);
   const totalRow = await db.prepare(countSql).bind(...countBindings).first<{ total: number }>();
   total = totalRow?.total ?? 0;
-
-  for (const w of results) {
-    const pseud = await queryAll<any>(db, `SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = ?1 LIMIT 1`, w.id);
-    w.pseud_name = pseud[0]?.name ?? null;
-  }
 }
 
-const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', 'warning', 'category'];
+// Enrich with pseuds and tags
+for (const w of results) {
+  const pseud = await queryAll<any>(db, `SELECT p.name FROM pseuds p JOIN creatorships c ON p.id = c.pseud_id WHERE c.work_id = ?1 LIMIT 1`, w.id);
+  w.pseud_name = pseud[0]?.name ?? null;
+  w.tags = await queryAll<any>(db, `SELECT t.id, t.name, t.type FROM tags t JOIN taggings tg ON t.id = tg.tag_id WHERE tg.work_id = ?1 ORDER BY t.type, t.name`, w.id);
+}
+
+const initialFilters = JSON.stringify({ type, complete, word_min, word_max });
+const initialResults = JSON.stringify(results);
+const initialTotal = total;
+const initialPage = page;
+const initialLimit = limit;
 ---
 
 <Base title={query ? `Search: ${query} — fanfiction.fyi` : 'Search — fanfiction.fyi'}>
   <section class="search-page">
     <h1 class="page-title">Search Works</h1>
 
+    <!-- Search Input -->
     <form id="search-form" class="search-bar">
       <div class="search-input-wrapper">
         <svg class="search-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -67,23 +97,18 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
           autocomplete="off"
         />
       </div>
-      <div class="search-controls">
-        <select name="type" id="type-filter" class="type-filter">
-          <option value="" selected={!type}>All tags</option>
-          {tagTypes.map(t => (
-            <option value={t} selected={type === t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
-          ))}
-        </select>
-        <button type="submit" class="search-btn">Search</button>
-      </div>
     </form>
 
+    <!-- Filter Chips -->
+    <div id="filter-chips-mount" data-initial-filters={initialFilters}></div>
+
+    <!-- Results Meta -->
     <div id="search-results">
-      {query === '' && (
-        <p class="placeholder-text">Search for works…</p>
+      {results.length === 0 && !hasQuery && (
+        <p class="placeholder-text">Enter a search query or use filters to find works.</p>
       )}
 
-      {query !== '' && results.length === 0 && (
+      {results.length === 0 && hasQuery && (
         <p class="no-results">No works found for "<span class="query-highlight">{query}</span>"</p>
       )}
 
@@ -93,23 +118,38 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
         </div>
       )}
 
-      <div class="results-list">
+      <div class="results-list" id="results-list">
         {results.map(w => (
-          <article class="result-card">
-            <a href={`/works/${w.id}`} class="result-card__title">{w.title}</a>
-            {w.pseud_name && <p class="result-card__author">by {w.pseud_name}</p>}
-            {w.summary && <p class="result-card__summary">{w.summary.length > 250 ? w.summary.slice(0, 250) + '…' : w.summary}</p>}
-            <div class="result-card__meta">
-              <span>{w.word_count?.toLocaleString() ?? 0} words</span>
-              <span>·</span>
-              <span>{w.published_at ? new Date(w.published_at + 'Z').toLocaleDateString() : 'Unpublished'}</span>
+          <article class="work-card">
+            <div class="work-card__header">
+              <a href={`/works/${w.id}`} class="work-card__title">{w.title}</a>
+              {w.pseud_name && <span class="work-card__author">by {w.pseud_name}</span>}
             </div>
+            {w.summary && (
+              <p class="work-card__summary">{w.summary.length > 280 ? w.summary.slice(0, 280) + '…' : w.summary}</p>
+            )}
+            <div class="work-card__meta">
+              <span class="work-card__meta-item">{(w.word_count || 0).toLocaleString()} words</span>
+              <span class="work-card__meta-sep">·</span>
+              <span class="work-card__meta-item">{w.complete ? 'Complete' : 'WIP'}</span>
+              <span class="work-card__meta-sep">·</span>
+              <span class="work-card__meta-item">{w.published_at ? new Date(w.published_at + 'Z').toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : 'Unpublished'}</span>
+            </div>
+            {w.tags && w.tags.length > 0 && (
+              <div class="work-card__tags">
+                {w.tags.map((tag: any) => (
+                  <a href={`/search?q=&type=${tag.type}`} class={`work-tag work-tag--${tag.type}`} title={`${tag.name} (${tag.type})`}>
+                    {tag.name}
+                  </a>
+                ))}
+              </div>
+            )}
           </article>
         ))}
       </div>
 
       {total > limit && (
-        <nav class="pagination">
+        <nav class="pagination" id="pagination">
           {page > 1 && (
             <button class="fab-btn" id="prev-btn" data-page={page - 1} aria-label="Previous page">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
@@ -128,11 +168,111 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
 </Base>
 
 <script is:inline>
-  function updateFromAPI(q, type, page) {
+  function escapeHtml(str) {
+    var d = document.createElement('div');
+    d.textContent = str;
+    return d.innerHTML;
+  }
+
+  var currentFilters = { type: '', complete: '', word_min: 0, word_max: 0 };
+  var currentPage = 1;
+
+  // Read initial filters from mount point
+  var mountEl = document.getElementById('filter-chips-mount');
+  if (mountEl && mountEl.dataset.initialFilters) {
+    try {
+      var init = JSON.parse(mountEl.dataset.initialFilters);
+      currentFilters = init;
+    } catch(e) {}
+  }
+
+  // ── Filter Chips (inline implementation) ──
+  var TYPE_CHIPS = [
+    { value: '', label: 'All' },
+    { value: 'fandom', label: 'Fandom' },
+    { value: 'character', label: 'Characters' },
+    { value: 'relationship', label: 'Relationships' },
+    { value: 'freeform', label: 'Freeform' },
+    { value: 'rating', label: 'Rating' },
+    { value: 'warning', label: 'Warnings' },
+    { value: 'category', label: 'Category' }
+  ];
+  var STATUS_CHIPS = [
+    { value: '', label: 'Any Status' },
+    { value: '1', label: 'Complete' },
+    { value: '0', label: 'WIP' }
+  ];
+  var WORD_CHIPS = [
+    { min: 0, max: 0, label: 'Any Length' },
+    { min: 0, max: 10000, label: '< 10k' },
+    { min: 10000, max: 50000, label: '10k–50k' },
+    { min: 50000, max: 100000, label: '50k–100k' },
+    { min: 100000, max: 0, label: '100k+' }
+  ];
+
+  function renderFilterChips() {
+    var container = document.getElementById('filter-chips-mount');
+    if (!container) return;
+
+    var html = '<div class="filter-chips-container">';
+
+    // Type row
+    html += '<div class="filter-row"><span class="filter-row__label">Type</span><div class="filter-row__chips">';
+    TYPE_CHIPS.forEach(function(chip) {
+      var active = currentFilters.type === chip.value;
+      html += '<button type="button" class="filter-chip' + (active ? ' filter-chip--active' : '') + '" data-filter="type" data-value="' + chip.value + '" aria-pressed="' + active + '">' + chip.label + '</button>';
+    });
+    html += '</div></div>';
+
+    // Status row
+    html += '<div class="filter-row"><span class="filter-row__label">Status</span><div class="filter-row__chips">';
+    STATUS_CHIPS.forEach(function(chip) {
+      var active = currentFilters.complete === chip.value;
+      html += '<button type="button" class="filter-chip' + (active ? ' filter-chip--active' : '') + '" data-filter="complete" data-value="' + chip.value + '" aria-pressed="' + active + '">' + chip.label + '</button>';
+    });
+    html += '</div></div>';
+
+    // Word count row
+    html += '<div class="filter-row"><span class="filter-row__label">Length</span><div class="filter-row__chips">';
+    WORD_CHIPS.forEach(function(chip) {
+      var active = currentFilters.word_min === chip.min && currentFilters.word_max === chip.max;
+      html += '<button type="button" class="filter-chip' + (active ? ' filter-chip--active' : '') + '" data-filter="word" data-min="' + chip.min + '" data-max="' + chip.max + '" aria-pressed="' + active + '">' + chip.label + '</button>';
+    });
+    html += '</div></div>';
+
+    html += '</div>';
+    container.innerHTML = html;
+
+    // Attach event listeners
+    var chipButtons = container.querySelectorAll('.filter-chip');
+    chipButtons.forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var filterType = this.dataset.filter;
+        if (filterType === 'type') {
+          currentFilters.type = this.dataset.value;
+        } else if (filterType === 'complete') {
+          currentFilters.complete = this.dataset.value;
+        } else if (filterType === 'word') {
+          currentFilters.word_min = parseInt(this.dataset.min) || 0;
+          currentFilters.word_max = parseInt(this.dataset.max) || 0;
+        }
+        currentPage = 1;
+        renderFilterChips();
+        fetchResults();
+      });
+    });
+  }
+
+  function fetchResults() {
+    var q = document.getElementById('search-input').value.trim();
     var params = new URLSearchParams();
     if (q) params.set('q', q);
-    if (type) params.set('type', type);
-    if (page > 1) params.set('page', String(page));
+    if (currentFilters.type) params.set('type', currentFilters.type);
+    if (currentFilters.complete) params.set('complete', currentFilters.complete);
+    if (currentFilters.word_min > 0) params.set('word_min', String(currentFilters.word_min));
+    if (currentFilters.word_max > 0) params.set('word_max', String(currentFilters.word_max));
+    if (currentPage > 1) params.set('page', String(currentPage));
+    params.set('limit', '20');
 
     var url = '/api/search?' + params.toString();
 
@@ -147,34 +287,51 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
 
         var results = data.results || [];
         var total = data.total || 0;
-        var currentPage = data.page || page;
         var limit = 20;
 
         var html = '';
         if (results.length === 0) {
-          html = '<p class="no-results">No works found for "<span class="query-highlight">' + escapeHtml(q) + '</span>"</p>';
+          if (q) {
+            html = '<p class="no-results">No works found for "<span class="query-highlight">' + escapeHtml(q) + '</span>"</p>';
+          } else {
+            html = '<p class="no-results">No works match the selected filters.</p>';
+          }
         } else {
           html += '<div class="results-meta"><span>' + total.toLocaleString() + ' result' + (total !== 1 ? 's' : '') + '</span></div>';
-          html += '<div class="results-list">';
+          html += '<div class="results-list" id="results-list">';
           for (var i = 0; i < results.length; i++) {
             var w = results[i];
-            html += '<article class="result-card">';
-            html += '<a href="/works/' + encodeURIComponent(w.id) + '" class="result-card__title">' + escapeHtml(w.title) + '</a>';
-            if (w.pseud_name) html += '<p class="result-card__author">by ' + escapeHtml(w.pseud_name) + '</p>';
+            html += '<article class="work-card">';
+            html += '<div class="work-card__header">';
+            html += '<a href="/works/' + encodeURIComponent(w.id) + '" class="work-card__title">' + escapeHtml(w.title) + '</a>';
+            if (w.pseud_name) html += '<span class="work-card__author">by ' + escapeHtml(w.pseud_name) + '</span>';
+            html += '</div>';
             if (w.summary) {
-              var truncated = w.summary.length > 250 ? w.summary.slice(0, 250) + '\u2026' : w.summary;
-              html += '<p class="result-card__summary">' + escapeHtml(truncated) + '</p>';
+              var truncated = w.summary.length > 280 ? w.summary.slice(0, 280) + '\u2026' : w.summary;
+              html += '<p class="work-card__summary">' + escapeHtml(truncated) + '</p>';
             }
-            html += '<div class="result-card__meta">';
-            html += '<span>' + (w.word_count || 0).toLocaleString() + ' words</span>';
-            html += '<span>\u00b7</span>';
-            html += '<span>' + (w.published_at ? new Date(w.published_at + 'Z').toLocaleDateString() : 'Unpublished') + '</span>';
-            html += '</div></article>';
+            html += '<div class="work-card__meta">';
+            html += '<span class="work-card__meta-item">' + (w.word_count || 0).toLocaleString() + ' words</span>';
+            html += '<span class="work-card__meta-sep">\u00b7</span>';
+            html += '<span class="work-card__meta-item">' + (w.complete ? 'Complete' : 'WIP') + '</span>';
+            html += '<span class="work-card__meta-sep">\u00b7</span>';
+            html += '<span class="work-card__meta-item">' + (w.published_at ? new Date(w.published_at + 'Z').toLocaleDateString(undefined, {year:'numeric',month:'short',day:'numeric'}) : 'Unpublished') + '</span>';
+            html += '</div>';
+            if (w.tags && w.tags.length > 0) {
+              html += '<div class="work-card__tags">';
+              for (var j = 0; j < w.tags.length; j++) {
+                var tag = w.tags[j];
+                html += '<a href="/search?type=' + encodeURIComponent(tag.type) + '" class="work-tag work-tag--' + escapeHtml(tag.type) + '" title="' + escapeHtml(tag.name) + ' (' + escapeHtml(tag.type) + ')">' + escapeHtml(tag.name) + '</a>';
+              }
+              html += '</div>';
+            }
+            html += '</article>';
           }
           html += '</div>';
 
+          // Pagination
           if (total > limit) {
-            html += '<nav class="pagination">';
+            html += '<nav class="pagination" id="pagination">';
             if (currentPage > 1) {
               html += '<button class="fab-btn" aria-label="Previous page" onclick="navigateToPage(' + (currentPage - 1) + ')"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg></button>';
             }
@@ -187,7 +344,16 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
         }
 
         document.getElementById('search-results').innerHTML = html;
-        window.history.replaceState(null, '', '/search?' + params.toString());
+
+        // Update URL
+        var urlParams = new URLSearchParams();
+        if (q) urlParams.set('q', q);
+        if (currentFilters.type) urlParams.set('type', currentFilters.type);
+        if (currentFilters.complete) urlParams.set('complete', currentFilters.complete);
+        if (currentFilters.word_min > 0) urlParams.set('word_min', String(currentFilters.word_min));
+        if (currentFilters.word_max > 0) urlParams.set('word_max', String(currentFilters.word_max));
+        if (currentPage > 1) urlParams.set('page', String(currentPage));
+        window.history.replaceState(null, '', '/search?' + urlParams.toString());
       })
       .catch(function() {
         document.getElementById('search-results').innerHTML =
@@ -195,29 +361,30 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
       });
   }
 
-  function escapeHtml(str) {
-    var d = document.createElement('div');
-    d.textContent = str;
-    return d.innerHTML;
-  }
+  // Initialize filter chips on load
+  renderFilterChips();
 
+  // Search form submission
   document.getElementById('search-form').addEventListener('submit', function(e) {
     e.preventDefault();
-    var q = document.getElementById('search-input').value.trim();
-    var type = document.getElementById('type-filter').value;
-    if (q) updateFromAPI(q, type, 1);
+    currentPage = 1;
+    fetchResults();
   });
 
-  document.getElementById('type-filter').addEventListener('change', function() {
-    var q = document.getElementById('search-input').value.trim();
-    var type = this.value;
-    if (q) updateFromAPI(q, type, 1);
+  // Debounced search input
+  var searchTimer = null;
+  document.getElementById('search-input').addEventListener('input', function() {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(function() {
+      currentPage = 1;
+      fetchResults();
+    }, 400);
   });
 
+  // Pagination
   window.navigateToPage = function(p) {
-    var q = document.getElementById('search-input').value.trim();
-    var type = document.getElementById('type-filter').value;
-    updateFromAPI(q, type, p);
+    currentPage = p;
+    fetchResults();
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 </script>
@@ -225,11 +392,15 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
 <style is:global>
   @import '../../styles/theme.css';
 
-    .search-page { max-width: 1200px; margin: 0 auto; padding: 0 var(--space-4); }
-    .page-title { font: var(--md-sys-typescale-headline-medium); color: var(--md-sys-color-on-surface); margin: 0 0 var(--space-6); }
+  .search-page { max-width: 960px; margin: 0 auto; padding: 0 var(--space-4); }
+  .page-title {
+    font: var(--md-sys-typescale-headline-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-6);
+  }
 
   /* ── Search Bar ── */
-  .search-bar { margin-bottom: var(--space-8); }
+  .search-bar { margin-bottom: var(--space-4); }
 
   .search-input-wrapper {
     display: flex;
@@ -261,44 +432,70 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
   }
   .search-input::placeholder { color: var(--md-sys-color-outline); }
 
-  .search-controls {
+  /* ── Filter Chips ── */
+  .filter-chips-container {
     display: flex;
+    flex-direction: column;
     gap: var(--space-3);
-    margin-top: var(--space-3);
+    margin-bottom: var(--space-6);
+  }
+
+  .filter-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .filter-row__label {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    min-width: 64px;
+    flex-shrink: 0;
+  }
+
+  .filter-row__chips {
+    display: flex;
+    gap: var(--space-2);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    padding-bottom: 2px;
+  }
+  .filter-row__chips::-webkit-scrollbar { display: none; }
+
+  .filter-chip {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    background: var(--md-sys-color-surface-container-low);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-1) var(--space-3);
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    min-height: 32px;
+    display: inline-flex;
     align-items: center;
   }
 
-  .type-filter {
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-on-surface);
+  .filter-chip:hover {
     background: var(--md-sys-color-surface-container-high);
-    border: 1px solid var(--md-sys-color-outline-variant);
-    border-radius: var(--md-sys-shape-corner-full);
-    padding: var(--space-2) var(--space-4);
-    outline: none;
-    cursor: pointer;
-    appearance: none;
-    -webkit-appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238C9199' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
-    padding-right: var(--space-8);
   }
 
-  .search-btn {
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-on-primary);
-    background: var(--md-sys-color-primary);
-    border: none;
-    border-radius: var(--md-sys-shape-corner-full);
-    padding: var(--space-2) var(--space-6);
-    cursor: pointer;
-    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  .filter-chip--active {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+    border-color: transparent;
   }
+
   @media (hover: hover) {
-    .search-btn:hover {
-      background: var(--md-sys-color-primary-container);
-      color: var(--md-sys-color-on-primary-container);
+    .filter-chip--active:hover {
+      background: var(--md-sys-color-secondary);
+      color: var(--md-sys-color-on-secondary);
     }
   }
 
@@ -335,52 +532,135 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
     gap: var(--space-4);
   }
 
-  .result-card {
+  /* ── Work Card (M3 Outlined) ── */
+  .work-card {
     padding: var(--space-4) var(--space-6);
     background: var(--md-sys-color-surface-container);
     border: 1px solid var(--md-sys-color-outline-variant);
     border-radius: var(--md-sys-shape-corner-large);
     transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
-                border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+                border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
   }
+
   @media (hover: hover) {
-    .result-card:hover {
+    .work-card:hover {
       background: var(--md-sys-color-surface-container-high);
       border-color: var(--md-sys-color-outline);
+      box-shadow: var(--md-sys-elevation-1);
     }
   }
 
-  .result-card__title {
+  .work-card__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--space-2);
+    margin-bottom: var(--space-1);
+  }
+
+  .work-card__title {
     font: var(--md-sys-typescale-title-large);
     color: var(--md-sys-color-primary);
     text-decoration: none;
-    display: block;
-    margin: 0 0 var(--space-1);
   }
   @media (hover: hover) {
-    .result-card__title:hover {
-      text-decoration: underline;
-    }
+    .work-card__title:hover { text-decoration: underline; }
   }
 
-  .result-card__author {
+  .work-card__author {
     font: var(--md-sys-typescale-body-medium);
     color: var(--md-sys-color-on-surface-variant);
-    margin: 0 0 var(--space-2);
   }
 
-  .result-card__summary {
+  .work-card__summary {
     font: var(--md-sys-typescale-body-medium);
     color: var(--md-sys-color-on-surface-variant);
-    margin: 0 0 var(--space-2);
+    margin: var(--space-1) 0 var(--space-2);
+    line-height: 1.5;
   }
 
-  .result-card__meta {
-    font: var(--md-sys-typescale-body-small);
-    color: var(--md-sys-color-outline);
+  .work-card__meta {
     display: flex;
     gap: var(--space-2);
     flex-wrap: wrap;
+    margin-bottom: var(--space-2);
+  }
+
+  .work-card__meta-item {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+  }
+
+  .work-card__meta-sep {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline-variant);
+  }
+
+  /* ── Tag Chips on Work Cards ── */
+  .work-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    margin-top: var(--space-2);
+  }
+
+  .work-tag {
+    font: var(--md-sys-typescale-body-small);
+    padding: 2px var(--space-2);
+    border-radius: var(--md-sys-shape-corner-full);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    border: 1px solid transparent;
+    line-height: 1.4;
+  }
+
+  /* Tag type accent colors — Obsidian palette */
+  .work-tag--fandom {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    border-color: var(--md-sys-color-primary);
+  }
+  .work-tag--character {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+    border-color: var(--md-sys-color-secondary);
+  }
+  .work-tag--relationship {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+    border-color: var(--md-sys-color-tertiary);
+  }
+  .work-tag--freeform {
+    background: var(--md-sys-color-surface-container-highest);
+    color: var(--md-sys-color-on-surface-variant);
+    border-color: var(--md-sys-color-outline-variant);
+  }
+  .work-tag--rating {
+    background: #3D2F1D;
+    color: #E8C88A;
+    border-color: #E8C88A;
+  }
+  .work-tag--warning {
+    background: var(--md-sys-color-error-container);
+    color: var(--md-sys-color-on-error-container);
+    border-color: var(--md-sys-color-error);
+  }
+  .work-tag--category {
+    background: var(--md-sys-color-surface-container-high);
+    color: var(--md-sys-color-on-surface-variant);
+    border-color: var(--md-sys-color-outline-variant);
+  }
+
+  @media (hover: hover) {
+    .work-tag:hover {
+      text-decoration: none;
+      filter: brightness(1.15);
+    }
   }
 
   /* ── Pagination ── */
@@ -419,5 +699,28 @@ const tagTypes = ['fandom', 'character', 'relationship', 'freeform', 'rating', '
   .page-indicator {
     font: var(--md-sys-typescale-label-large);
     color: var(--md-sys-color-on-surface-variant);
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 640px) {
+    .filter-row__label {
+      min-width: 56px;
+      font: var(--md-sys-typescale-body-small);
+    }
+    .filter-chip {
+      padding: var(--space-1) var(--space-2);
+      font: var(--md-sys-typescale-body-small);
+    }
+    .work-card {
+      padding: var(--space-3) var(--space-4);
+    }
+    .work-card__tags {
+      overflow-x: auto;
+      flex-wrap: nowrap;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+      padding-bottom: 2px;
+    }
+    .work-card__tags::-webkit-scrollbar { display: none; }
   }
 </style>


### PR DESCRIPTION
## Summary

Implements #61 — M3 Faceted Search & Work Discovery

### Changes

**Search API** ():
- Added faceted filters: `complete` (1/0), `word_min`, `word_max`, `tags` (comma-separated tag IDs)
- Results now include per-work tags (`id`, `name`, `type`) and `complete` field

**WorkCard Component** (`src/components/WorkCard.tsx`):
- M3 Outlined Card with title, author byline, truncated summary, meta row (words / status / date), and color-coded tag chips

**FilterChips Component** (`src/components/FilterChips.tsx`):
- Three horizontal-scrollable rows: Type (fandom/character/relationship/etc), Status (Complete/WIP), Length (< 10k / 10k–50k / 50k–100k / 100k+)

**Search Page** (`src/pages/search/index.astro`):
- Replaced bare dropdown filter with M3 Filter Chips
- Debounced search input (400ms)
- URL state sync (filters reflected in URL params, back/forward works)
- Tags on work cards color-coded by type using Obsidian palette

### Tag Chip Accent Colors
| Type | Obsidian Token |
|------|---------------|
| Fandom | Primary container (blue-gray) |
| Character | Secondary container |
| Relationship | Tertiary container |
| Freeform | Surface-highest |
| Rating | Amber accent (#3D2F1D / #E8C88A) |
| Warning | Error container |
| Category | Surface-high |

### Acceptance Criteria
- [x] Filter chips accurately update URL search parameters and trigger a data refresh
- [x] Tags on work cards wrap properly on small screens
- [x] Tags visually distinct by category (color-coded by `Tag.type`)
- [x] M3 Outlined Cards render work data (title, author, summary, tags)
- [x] Horizontal chip row scrolls smoothly on mobile without breaking layout
- [x] Obsidian palette (`#7B8FA8`) used for chip tinting