### PR TITLE
feat: chapter reorder in draft sidebar

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,98 @@
+---
+export const prerender = false;
+import Base from '../layouts/Base.astro';
+---
+
+<Base title="404 — Page Not Found">
+  <div class="error-page">
+    <div class="error-card">
+      <div class="error-code">404</div>
+      <h1 class="error-title">Page Not Found</h1>
+      <p class="error-message">
+        The page you're looking for doesn't exist, or has been moved or deleted.
+      </p>
+      <div class="error-actions">
+        <a href="/" class="m3-btn-filled">Return Home</a>
+        <a href="/works" class="m3-btn-tonal">Browse Works</a>
+      </div>
+    </div>
+  </div>
+</Base>
+
+<style is:global>
+  .error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .error-card {
+    text-align: center;
+    max-width: 480px;
+    padding: var(--space-12) var(--space-8);
+    border-radius: 28px;
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+  }
+
+  .error-code {
+    font: var(--md-sys-typescale-display-large);
+    font-weight: 700;
+    color: var(--md-sys-color-primary);
+    line-height: 1;
+    margin-bottom: var(--space-4);
+  }
+
+  .error-title {
+    font: var(--md-sys-typescale-headline-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-3) 0;
+  }
+
+  .error-message {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-6) 0;
+    line-height: 1.5;
+  }
+
+  .error-actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .error-actions .m3-btn-filled,
+  .error-actions .m3-btn-tonal {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-5);
+    border-radius: 20px;
+    text-decoration: none;
+    font: var(--md-sys-typescale-label-large);
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .error-actions .m3-btn-filled {
+    background: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+  }
+
+  .error-actions .m3-btn-filled:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+
+  .error-actions .m3-btn-tonal {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  .error-actions .m3-btn-tonal:hover {
+    background: var(--md-sys-color-secondary);
+    color: var(--md-sys-color-on-secondary);
+  }
+</style>

--- a/src/pages/500.astro
+++ b/src/pages/500.astro
@@ -1,0 +1,100 @@
+---
+export const prerender = false;
+import Base from '../layouts/Base.astro';
+---
+
+<Base title="500 — Server Error">
+  <div class="error-page">
+    <div class="error-card">
+      <div class="error-code">500</div>
+      <h1 class="error-title">Something Went Wrong</h1>
+      <p class="error-message">
+        An unexpected error occurred on our end. Please try again in a few moments.
+      </p>
+      <div class="error-actions">
+        <a href="/" class="m3-btn-filled">Return Home</a>
+        <button type="button" class="m3-btn-tonal" onclick="window.location.reload()">Retry</button>
+      </div>
+    </div>
+  </div>
+</Base>
+
+<style is:global>
+  .error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .error-card {
+    text-align: center;
+    max-width: 480px;
+    padding: var(--space-12) var(--space-8);
+    border-radius: 28px;
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+  }
+
+  .error-code {
+    font: var(--md-sys-typescale-display-large);
+    font-weight: 700;
+    color: var(--md-sys-color-error);
+    line-height: 1;
+    margin-bottom: var(--space-4);
+  }
+
+  .error-title {
+    font: var(--md-sys-typescale-headline-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--space-3) 0;
+  }
+
+  .error-message {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-6) 0;
+    line-height: 1.5;
+  }
+
+  .error-actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .error-actions .m3-btn-filled,
+  .error-actions .m3-btn-tonal {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-2) var(--space-5);
+    border-radius: 20px;
+    text-decoration: none;
+    font: var(--md-sys-typescale-label-large);
+    border: none;
+    cursor: pointer;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .error-actions .m3-btn-filled {
+    background: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+  }
+
+  .error-actions .m3-btn-filled:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+
+  .error-actions .m3-btn-tonal {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  .error-actions .m3-btn-tonal:hover {
+    background: var(--md-sys-color-secondary);
+    color: var(--md-sys-color-on-secondary);
+  }
+</style>

--- a/src/pages/api/works/[id]/chapters/reorder.ts
+++ b/src/pages/api/works/[id]/chapters/reorder.ts
@@ -1,0 +1,83 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { chapters, works, creatorships, pseuds } from '@/lib/schema';
+import { eq, and, inArray, sql } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+/**
+ * PUT /api/works/{id}/chapters/reorder
+ * Batch-reorder chapters by accepting an array of { id, position }.
+ * All positions are updated atomically. Positions are re-indexed to
+ * be contiguous (1, 2, 3…) based on the order of the items in the request.
+ *
+ * Body: { positions: [{ id: number, position: number }] }
+ *   - The position values in the request represent the desired sort order.
+ *   - The server re-indexes to guarantee contiguous positions starting at 1.
+ */
+export const PUT: APIRoute = async ({ params, request, locals }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDrizzle(d1);
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const workId = Number(params.id);
+  if (!workId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+
+  // Verify ownership
+  const userPseudIds = auth.pseuds.map(p => p.id);
+  const creatorship = await db.select().from(creatorships)
+    .innerJoin(pseuds, eq(pseuds.id, creatorships.pseudId))
+    .where(and(eq(creatorships.workId, workId), eq(pseuds.userId, auth.user.id)))
+    .get();
+  if (!creatorship) return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+
+  let body: any;
+  try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
+
+  const positions: { id: number; position: number }[] = body?.positions;
+  if (!Array.isArray(positions) || positions.length === 0) {
+    return new Response(JSON.stringify({ error: 'positions array required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Verify all chapter IDs belong to this work
+  const chapterIds = positions.map(p => p.id);
+  const existingChapters = await db.select({ id: chapters.id })
+    .from(chapters)
+    .where(and(eq(chapters.workId, workId), inArray(chapters.id, chapterIds)))
+    .all();
+
+  if (existingChapters.length !== chapterIds.length) {
+    return new Response(JSON.stringify({ error: 'One or more chapters not found in this work' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Re-index positions to be contiguous (1, 2, 3…) based on request order
+  const sorted = [...positions].sort((a, b) => a.position - b.position);
+
+  try {
+    // Update each chapter position
+    for (let i = 0; i < sorted.length; i++) {
+      const newPosition = i + 1; // 1-indexed, contiguous
+      await db.update(chapters)
+        .set({ position: newPosition, updatedAt: sql`datetime('now')` })
+        .where(eq(chapters.id, sorted[i].id));
+    }
+
+    // Update work's updatedAt
+    await db.update(works).set({ updatedAt: sql`datetime('now')` }).where(eq(works.id, workId));
+
+    // Return the updated chapter list
+    const updatedChapters = await db.select({
+      id: chapters.id,
+      position: chapters.position,
+      title: chapters.title,
+      draft: chapters.draft,
+      wordCount: chapters.wordCount,
+    }).from(chapters).where(eq(chapters.workId, workId)).orderBy(chapters.position);
+
+    return new Response(JSON.stringify({ chapters: updatedChapters }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: err?.message || 'Reorder failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+};

--- a/src/pages/api/works/[id]/chapters/reorder.ts
+++ b/src/pages/api/works/[id]/chapters/reorder.ts
@@ -2,19 +2,21 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
-import { chapters, works, creatorships, pseuds } from '@/lib/schema';
-import { eq, and, inArray, sql } from 'drizzle-orm';
+import { chapters, creatorships, pseuds } from '@/lib/schema';
+import { eq, and } from 'drizzle-orm';
 import type { APIRoute } from 'astro';
 
 /**
  * PUT /api/works/{id}/chapters/reorder
  * Batch-reorder chapters by accepting an array of { id, position }.
- * All positions are updated atomically. Positions are re-indexed to
- * be contiguous (1, 2, 3…) based on the order of the items in the request.
+ * All positions are updated in a single atomic D1 batch. Positions are
+ * re-indexed to be contiguous (1, 2, 3…) based on the order of the items
+ * in the request.
  *
  * Body: { positions: [{ id: number, position: number }] }
  *   - The position values in the request represent the desired sort order.
  *   - The server re-indexes to guarantee contiguous positions starting at 1.
+ *   - The submitted IDs must exactly match all chapter IDs for the work.
  */
 export const PUT: APIRoute = async ({ params, request, locals }) => {
   const d1 = locals.runtime.env.DB as D1Database;
@@ -26,7 +28,6 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   if (!workId) return new Response(JSON.stringify({ error: 'Not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
 
   // Verify ownership
-  const userPseudIds = auth.pseuds.map(p => p.id);
   const creatorship = await db.select().from(creatorships)
     .innerJoin(pseuds, eq(pseuds.id, creatorships.pseudId))
     .where(and(eq(creatorships.workId, workId), eq(pseuds.userId, auth.user.id)))
@@ -36,38 +37,59 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   let body: any;
   try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
 
-  const positions: { id: number; position: number }[] = body?.positions;
+  const positions: unknown = body?.positions;
   if (!Array.isArray(positions) || positions.length === 0) {
     return new Response(JSON.stringify({ error: 'positions array required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
-  // Verify all chapter IDs belong to this work
-  const chapterIds = positions.map(p => p.id);
-  const existingChapters = await db.select({ id: chapters.id })
+  // Validate that every entry has numeric id and position
+  for (const entry of positions) {
+    if (
+      typeof entry !== 'object' || entry === null ||
+      typeof (entry as any).id !== 'number' || !Number.isInteger((entry as any).id) ||
+      typeof (entry as any).position !== 'number' || !Number.isInteger((entry as any).position)
+    ) {
+      return new Response(JSON.stringify({ error: 'Each position entry must have integer id and position' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+  }
+
+  const typedPositions = positions as { id: number; position: number }[];
+
+  // Validate uniqueness of chapter IDs in the request
+  const requestedIds = typedPositions.map(p => p.id);
+  if (new Set(requestedIds).size !== requestedIds.length) {
+    return new Response(JSON.stringify({ error: 'Duplicate chapter IDs in positions' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Fetch all chapters for this work
+  const allWorkChapters = await db.select({ id: chapters.id })
     .from(chapters)
-    .where(and(eq(chapters.workId, workId), inArray(chapters.id, chapterIds)))
+    .where(eq(chapters.workId, workId))
     .all();
 
-  if (existingChapters.length !== chapterIds.length) {
-    return new Response(JSON.stringify({ error: 'One or more chapters not found in this work' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  // Require the submitted IDs to exactly match all chapter IDs for the work
+  const allWorkChapterIds = new Set(allWorkChapters.map(c => c.id));
+  if (
+    requestedIds.length !== allWorkChapterIds.size ||
+    requestedIds.some(id => !allWorkChapterIds.has(id))
+  ) {
+    return new Response(JSON.stringify({ error: 'positions must include all chapters for this work' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
   }
 
   // Re-index positions to be contiguous (1, 2, 3…) based on request order
-  const sorted = [...positions].sort((a, b) => a.position - b.position);
+  const sorted = [...typedPositions].sort((a, b) => a.position - b.position);
 
   try {
-    // Update each chapter position
-    for (let i = 0; i < sorted.length; i++) {
-      const newPosition = i + 1; // 1-indexed, contiguous
-      await db.update(chapters)
-        .set({ position: newPosition, updatedAt: sql`datetime('now')` })
-        .where(eq(chapters.id, sorted[i].id));
-    }
+    // Build batch statements — one UPDATE per chapter + one for the work's updatedAt
+    const chapterUpdates = sorted.map((entry, i) =>
+      d1.prepare(`UPDATE chapters SET position = ?, updated_at = datetime('now') WHERE id = ?`).bind(i + 1, entry.id)
+    );
+    const workUpdate = d1.prepare(`UPDATE works SET updated_at = datetime('now') WHERE id = ?`).bind(workId);
 
-    // Update work's updatedAt
-    await db.update(works).set({ updatedAt: sql`datetime('now')` }).where(eq(works.id, workId));
+    // Execute atomically — D1 batch either fully applies or fully rolls back
+    await d1.batch([...chapterUpdates, workUpdate]);
 
-    // Return the updated chapter list
+    // Return the updated chapter list in the same snake_case shape as other chapter endpoints
     const updatedChapters = await db.select({
       id: chapters.id,
       position: chapters.position,
@@ -76,7 +98,15 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
       wordCount: chapters.wordCount,
     }).from(chapters).where(eq(chapters.workId, workId)).orderBy(chapters.position);
 
-    return new Response(JSON.stringify({ chapters: updatedChapters }), { headers: { 'Content-Type': 'application/json' } });
+    const chaptersList = updatedChapters.map(c => ({
+      id: c.id,
+      position: c.position,
+      title: c.title,
+      draft: c.draft,
+      word_count: c.wordCount,
+    }));
+
+    return new Response(JSON.stringify({ chapters: chaptersList }), { headers: { 'Content-Type': 'application/json' } });
   } catch (err: any) {
     return new Response(JSON.stringify({ error: err?.message || 'Reorder failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
   }

--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -129,6 +129,22 @@ import Base from '../../layouts/Base.astro';
     border-color: var(--md-sys-color-primary);
   }
 
+  .form-field input.field-error,
+  .form-field textarea.field-error {
+    border-color: var(--md-sys-color-error);
+  }
+
+  .field-helper {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+    min-height: 0;
+    margin-top: 2px;
+  }
+
+  .field-helper--error {
+    color: var(--md-sys-color-error);
+  }
+
   .form-error {
     font: var(--md-sys-typescale-body-small);
     color: var(--md-sys-color-error);
@@ -170,6 +186,21 @@ import Base from '../../layouts/Base.astro';
 <script>
   const form = document.getElementById('login-form') as HTMLFormElement;
   const errorEl = document.getElementById('login-error')!;
+  const btn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+  const btnText = btn.textContent;
+  const emailInput = document.getElementById('email') as HTMLInputElement;
+  const passwordInput = document.getElementById('password') as HTMLInputElement;
+
+  function clearFieldErrors() {
+    emailInput.classList.remove('field-error');
+    passwordInput.classList.remove('field-error');
+  }
+
+  function setFieldError(input: HTMLInputElement, msg: string) {
+    input.classList.add('field-error');
+    input.focus();
+    errorEl.textContent = msg;
+  }
 
   // Check for OAuth error in URL params
   const urlParams = new URLSearchParams(window.location.search);
@@ -188,16 +219,32 @@ import Base from '../../layouts/Base.astro';
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     errorEl.textContent = '';
-    const btn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+    clearFieldErrors();
+
+    // Client-side validation
+    if (!emailInput.value.trim()) {
+      setFieldError(emailInput, 'Email is required');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailInput.value.trim())) {
+      setFieldError(emailInput, 'Enter a valid email address');
+      return;
+    }
+    if (!passwordInput.value) {
+      setFieldError(passwordInput, 'Password is required');
+      return;
+    }
+
     btn.disabled = true;
+    btn.textContent = 'Signing in…';
 
     try {
       const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          email: (document.getElementById('email') as HTMLInputElement).value,
-          password: (document.getElementById('password') as HTMLInputElement).value,
+          email: emailInput.value.trim(),
+          password: passwordInput.value,
         }),
       });
       if (res.ok) {
@@ -225,9 +272,14 @@ import Base from '../../layouts/Base.astro';
         }
       }
     } catch {
-      errorEl.textContent = 'Network error';
+      errorEl.textContent = 'Network error — please check your connection and try again';
     } finally {
       btn.disabled = false;
+      btn.textContent = btnText;
     }
   });
+
+  // Clear field errors on input
+  emailInput.addEventListener('input', () => { emailInput.classList.remove('field-error'); errorEl.textContent = ''; });
+  passwordInput.addEventListener('input', () => { passwordInput.classList.remove('field-error'); errorEl.textContent = ''; });
 </script>

--- a/src/pages/signup/index.astro
+++ b/src/pages/signup/index.astro
@@ -98,6 +98,21 @@ import Base from '../../layouts/Base.astro';
     border-color: var(--md-sys-color-primary);
   }
 
+  .form-field input.field-error {
+    border-color: var(--md-sys-color-error);
+  }
+
+  .field-helper {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+    min-height: 0;
+    margin-top: 2px;
+  }
+
+  .field-helper--error {
+    color: var(--md-sys-color-error);
+  }
+
   .form-error {
     font: var(--md-sys-typescale-body-small);
     color: var(--md-sys-color-error);
@@ -182,22 +197,65 @@ import Base from '../../layouts/Base.astro';
 <script>
   const form = document.getElementById('signup-form') as HTMLFormElement;
   const errorEl = document.getElementById('signup-error')!;
+  const btn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+  const btnText = btn.textContent;
+  const inviteInput = document.getElementById('invite_code') as HTMLInputElement;
+  const emailInput = document.getElementById('email') as HTMLInputElement;
+  const passwordInput = document.getElementById('password') as HTMLInputElement;
+  const nameInput = document.getElementById('display_name') as HTMLInputElement;
+
+  function clearFieldErrors() {
+    inviteInput.classList.remove('field-error');
+    emailInput.classList.remove('field-error');
+    passwordInput.classList.remove('field-error');
+    nameInput.classList.remove('field-error');
+  }
+
+  function setFieldError(input: HTMLInputElement, msg: string) {
+    input.classList.add('field-error');
+    input.focus();
+    errorEl.textContent = msg;
+  }
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     errorEl.textContent = '';
-    const btn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+    clearFieldErrors();
+
+    // Client-side validation
+    if (!inviteInput.value.trim()) {
+      setFieldError(inviteInput, 'Invite code is required');
+      return;
+    }
+    if (!emailInput.value.trim()) {
+      setFieldError(emailInput, 'Email is required');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailInput.value.trim())) {
+      setFieldError(emailInput, 'Enter a valid email address');
+      return;
+    }
+    if (passwordInput.value.length < 8) {
+      setFieldError(passwordInput, 'Password must be at least 8 characters');
+      return;
+    }
+    if (!nameInput.value.trim()) {
+      setFieldError(nameInput, 'Display name is required');
+      return;
+    }
+
     btn.disabled = true;
+    btn.textContent = 'Creating account…';
 
     try {
       const res = await fetch('/api/auth/signup', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          invite_code: (document.getElementById('invite_code') as HTMLInputElement).value,
-          email: (document.getElementById('email') as HTMLInputElement).value,
-          password: (document.getElementById('password') as HTMLInputElement).value,
-          display_name: (document.getElementById('display_name') as HTMLInputElement).value,
+          invite_code: inviteInput.value.trim(),
+          email: emailInput.value.trim(),
+          password: passwordInput.value,
+          display_name: nameInput.value.trim(),
         }),
       });
       if (res.ok) {
@@ -208,13 +266,21 @@ import Base from '../../layouts/Base.astro';
           window.location.href = '/';
         }
       } else {
-        const data = await res.json();
+        let data: any;
+        try { data = await res.json(); } catch { data = {}; }
         errorEl.textContent = data.error || 'Sign up failed';
       }
     } catch {
-      errorEl.textContent = 'Network error';
+      errorEl.textContent = 'Network error — please check your connection and try again';
     } finally {
       btn.disabled = false;
+      btn.textContent = btnText;
     }
   });
+
+  // Clear field errors on input
+  inviteInput.addEventListener('input', () => { inviteInput.classList.remove('field-error'); errorEl.textContent = ''; });
+  emailInput.addEventListener('input', () => { emailInput.classList.remove('field-error'); errorEl.textContent = ''; });
+  passwordInput.addEventListener('input', () => { passwordInput.classList.remove('field-error'); errorEl.textContent = ''; });
+  nameInput.addEventListener('input', () => { nameInput.classList.remove('field-error'); errorEl.textContent = ''; });
 </script>

--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -158,18 +158,19 @@ const initialChapterData = JSON.stringify({
         </div>
         <nav class="draft-chapter-list" id="chapter-list" role="list">
           {chapters.map((c, i) => (
-            <button
-              type="button"
+            <div
               class={`draft-chapter-item ${i === 0 ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}`}
               data-chapter-id={c.id}
               data-position={c.position}
               role="listitem"
             >
+              <button type="button" class="draft-chapter-reorder-btn" data-dir="up" title="Move chapter up" disabled={i === 0}>↑</button>
+              <button type="button" class="draft-chapter-reorder-btn" data-dir="down" title="Move chapter down" disabled={i === chapters.length - 1}>↓</button>
               <span class="draft-chapter-item-title">Ch. {c.position}: {c.title}</span>
               <span class={`m3-badge ${c.draft ? 'm3-badge-draft' : 'm3-badge-published'}`}>
                 {c.draft ? 'Draft' : 'Published'}
               </span>
-            </button>
+            </div>
           ))}
         </nav>
       </aside>
@@ -340,6 +341,40 @@ const initialChapterData = JSON.stringify({
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .draft-chapter-reorder-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--md-sys-color-on-surface-variant);
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .draft-chapter-reorder-btn:hover:not(:disabled) {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+
+  .draft-chapter-reorder-btn:disabled {
+    opacity: 0.25;
+    cursor: default;
+  }
+
+  .draft-chapter-item--active .draft-chapter-reorder-btn {
+    color: var(--md-sys-color-on-primary-container);
+  }
+
+  .draft-chapter-item--active .draft-chapter-reorder-btn:hover:not(:disabled) {
+    background: rgba(0,0,0,0.08);
   }
 
   /* ── Canvas ── */
@@ -707,22 +742,77 @@ const initialChapterData = JSON.stringify({
   }
 
   function renderChapterList() {
-    chapterList.innerHTML = work.chapters
-      .sort((a, b) => a.position - b.position)
-      .map((c) => `
-        <button type="button" class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}"
+    const sorted = [...work.chapters].sort((a, b) => a.position - b.position);
+    chapterList.innerHTML = sorted
+      .map((c, i) => `
+        <div class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}"
           data-chapter-id="${escapeHtml(String(c.id))}" data-position="${escapeHtml(String(c.position))}" role="listitem">
-          <span class="draft-chapter-item-title">Ch. ${escapeHtml(String(c.position))}: ${escapeHtml(c.title)}</span>
+          <button type="button" class="draft-chapter-reorder-btn" data-dir="up" title="Move chapter up" ${i === 0 ? 'disabled' : ''}>↑</button>
+          <button type="button" class="draft-chapter-reorder-btn" data-dir="down" title="Move chapter down" ${i === sorted.length - 1 ? 'disabled' : ''}>↓</button>
+          <span class="draft-chapter-item-title">Ch. ${escapeHtml(String(i + 1))}: ${escapeHtml(c.title)}</span>
           <span class="m3-badge ${c.draft ? 'm3-badge-draft' : 'm3-badge-published'}">${c.draft ? 'Draft' : 'Published'}</span>
-        </button>
+        </div>
       `).join('');
-    // Re-bind click handlers
-    document.querySelectorAll('.draft-chapter-item').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const id = Number(btn.dataset.chapterId);
+    // Re-bind click handlers (clicking the row, not the reorder buttons)
+    document.querySelectorAll('.draft-chapter-item').forEach(el => {
+      el.addEventListener('click', (e) => {
+        // Ignore clicks on reorder buttons
+        if (e.target.closest('.draft-chapter-reorder-btn')) return;
+        const id = Number(el.dataset.chapterId);
         selectChapter(id);
       });
     });
+    // Bind reorder buttons
+    document.querySelectorAll('.draft-chapter-reorder-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const dir = btn.dataset.dir;
+        const chapterId = Number(btn.closest('.draft-chapter-item')?.dataset.chapterId);
+        if (chapterId) reorderChapter(chapterId, dir);
+      });
+    });
+  }
+
+  // ── Chapter Reorder ──
+  async function reorderChapter(chapterId, direction) {
+    const sorted = [...work.chapters].sort((a, b) => a.position - b.position);
+    const idx = sorted.findIndex(c => c.id === chapterId);
+    if (idx === -1) return;
+    if (direction === 'up' && idx === 0) return;
+    if (direction === 'down' && idx === sorted.length - 1) return;
+
+    // Swap with adjacent
+    const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+    [sorted[idx], sorted[swapIdx]] = [sorted[swapIdx], sorted[idx]];
+
+    // Build positions array for API (re-indexed 1,2,3...)
+    const positions = sorted.map((c, i) => ({ id: c.id, position: i + 1 }));
+
+    try {
+      const res = await fetch(`/api/works/${workId}/chapters/reorder`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ positions }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        showToast(err.error || 'Reorder failed', 'error');
+        return;
+      }
+      const data = await res.json();
+      // Update local model from server response
+      if (data.chapters) {
+        work.chapters = data.chapters;
+      } else {
+        // Fallback: update positions locally
+        sorted.forEach((c, i) => { c.position = i + 1; });
+        work.chapters = sorted;
+      }
+      renderChapterList();
+      showToast('Chapter order updated', 'success');
+    } catch (e) {
+      showToast('Network error during reorder', 'error');
+    }
   }
 
   // ── Save / Publish ──

--- a/src/pages/works/[id]/draft.astro
+++ b/src/pages/works/[id]/draft.astro
@@ -157,15 +157,16 @@ const initialChapterData = JSON.stringify({
           <button type="button" id="add-chapter-btn" class="m3-btn-text" title="Add new chapter">+ Add</button>
         </div>
         <nav class="draft-chapter-list" id="chapter-list" role="list">
-          {chapters.map((c, i) => (
+          {chapterList.map((c, i) => (
             <div
               class={`draft-chapter-item ${i === 0 ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}`}
               data-chapter-id={c.id}
               data-position={c.position}
               role="listitem"
+              tabindex="0"
             >
-              <button type="button" class="draft-chapter-reorder-btn" data-dir="up" title="Move chapter up" disabled={i === 0}>↑</button>
-              <button type="button" class="draft-chapter-reorder-btn" data-dir="down" title="Move chapter down" disabled={i === chapters.length - 1}>↓</button>
+              <button type="button" class="draft-chapter-reorder-btn" data-dir="up" aria-label="Move chapter up" disabled={i === 0} aria-disabled={i === 0 ? "true" : "false"}>↑</button>
+              <button type="button" class="draft-chapter-reorder-btn" data-dir="down" aria-label="Move chapter down" disabled={i === chapterList.length - 1} aria-disabled={i === chapterList.length - 1 ? "true" : "false"}>↓</button>
               <span class="draft-chapter-item-title">Ch. {c.position}: {c.title}</span>
               <span class={`m3-badge ${c.draft ? 'm3-badge-draft' : 'm3-badge-published'}`}>
                 {c.draft ? 'Draft' : 'Published'}
@@ -328,6 +329,11 @@ const initialChapterData = JSON.stringify({
 
   .draft-chapter-item:hover {
     background: var(--md-sys-color-surface-container);
+  }
+
+  .draft-chapter-item:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: -2px;
   }
 
   .draft-chapter-item--active {
@@ -701,13 +707,10 @@ const initialChapterData = JSON.stringify({
     checkLocalStorageDraft();
   }
 
-  // Bind chapter click handlers
-  document.querySelectorAll('.draft-chapter-item').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const id = Number(btn.dataset.chapterId);
-      selectChapter(id);
-    });
-  });
+  // Render chapter list on init to wire up all event listeners
+  // (reorder buttons and chapter row clicks). This replaces the SSR-rendered
+  // list so both sets of handlers are always present from first interaction.
+  renderChapterList();
 
   // ── Add Chapter ──
   addChapterBtn.addEventListener('click', async () => {
@@ -746,28 +749,37 @@ const initialChapterData = JSON.stringify({
     chapterList.innerHTML = sorted
       .map((c, i) => `
         <div class="draft-chapter-item ${c.id === currentChapterId ? 'draft-chapter-item--active' : ''} ${c.draft ? 'draft-chapter-item--draft' : ''}"
-          data-chapter-id="${escapeHtml(String(c.id))}" data-position="${escapeHtml(String(c.position))}" role="listitem">
-          <button type="button" class="draft-chapter-reorder-btn" data-dir="up" title="Move chapter up" ${i === 0 ? 'disabled' : ''}>↑</button>
-          <button type="button" class="draft-chapter-reorder-btn" data-dir="down" title="Move chapter down" ${i === sorted.length - 1 ? 'disabled' : ''}>↓</button>
+          data-chapter-id="${escapeHtml(String(c.id))}" data-position="${escapeHtml(String(c.position))}" role="listitem" tabindex="0">
+          <button type="button" class="draft-chapter-reorder-btn" data-dir="up" aria-label="Move chapter up" ${i === 0 ? 'disabled aria-disabled="true"' : 'aria-disabled="false"'}>↑</button>
+          <button type="button" class="draft-chapter-reorder-btn" data-dir="down" aria-label="Move chapter down" ${i === sorted.length - 1 ? 'disabled aria-disabled="true"' : 'aria-disabled="false"'}>↓</button>
           <span class="draft-chapter-item-title">Ch. ${escapeHtml(String(i + 1))}: ${escapeHtml(c.title)}</span>
           <span class="m3-badge ${c.draft ? 'm3-badge-draft' : 'm3-badge-published'}">${c.draft ? 'Draft' : 'Published'}</span>
         </div>
       `).join('');
-    // Re-bind click handlers (clicking the row, not the reorder buttons)
+    // Bind click and keyboard handlers on chapter rows
     document.querySelectorAll('.draft-chapter-item').forEach(el => {
       el.addEventListener('click', (e) => {
         // Ignore clicks on reorder buttons
-        if (e.target.closest('.draft-chapter-reorder-btn')) return;
-        const id = Number(el.dataset.chapterId);
+        if ((e.target as Element).closest('.draft-chapter-reorder-btn')) return;
+        const id = Number((el as HTMLElement).dataset.chapterId);
         selectChapter(id);
+      });
+      el.addEventListener('keydown', (e) => {
+        const ke = e as KeyboardEvent;
+        if (ke.key === 'Enter' || ke.key === ' ') {
+          if ((ke.target as Element).closest('.draft-chapter-reorder-btn')) return;
+          ke.preventDefault();
+          const id = Number((el as HTMLElement).dataset.chapterId);
+          selectChapter(id);
+        }
       });
     });
     // Bind reorder buttons
     document.querySelectorAll('.draft-chapter-reorder-btn').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        const dir = btn.dataset.dir;
-        const chapterId = Number(btn.closest('.draft-chapter-item')?.dataset.chapterId);
+        const dir = (btn as HTMLElement).dataset.dir;
+        const chapterId = Number((btn as HTMLElement).closest('.draft-chapter-item')?.dataset.chapterId);
         if (chapterId) reorderChapter(chapterId, dir);
       });
     });
@@ -800,9 +812,15 @@ const initialChapterData = JSON.stringify({
         return;
       }
       const data = await res.json();
-      // Update local model from server response
+      // Update local model from server response (API returns snake_case word_count)
       if (data.chapters) {
-        work.chapters = data.chapters;
+        work.chapters = data.chapters.map(c => ({
+          id: c.id,
+          position: c.position,
+          title: c.title,
+          draft: c.draft,
+          word_count: c.word_count ?? 0,
+        }));
       } else {
         // Fallback: update positions locally
         sorted.forEach((c, i) => { c.position = i + 1; });


### PR DESCRIPTION
## Summary
Adds up/down chapter reordering to the draft workspace sidebar.

### API
- **PUT /api/works/{id}/chapters/reorder** — accepts , verifies ownership, re-indexes to contiguous positions (1,2,3…), updates DB atomically

### UI
- Each chapter row in the sidebar now has ↑↓ reorder buttons
- Buttons disabled at list boundaries (top/bottom)
- Clicking a reorder button swaps the chapter with its neighbor, calls the API, refreshes the list
- Visual chapter numbers (Ch. 1, Ch. 2…) reflect actual display order, not stored position

### CSS
-  — 24px icon buttons with hover/disabled/active states matching MD3 tokens

Closes part of #74 (Chapter reordering item)