### PR TITLE
feat(nav): M3 adaptive navigation — #58

### DIFF
--- a/src/components/AdaptiveNav.tsx
+++ b/src/components/AdaptiveNav.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+import { signal } from '@preact/signals';
 
 // ── Navigation item definitions ──
 
@@ -17,22 +18,19 @@ export interface NavGroup {
 // Shared nav items — the same set used across all breakpoints
 const PRIMARY_NAV: NavItem[] = [
   { label: 'Home', href: '/', icon: 'home' },
-  { label: 'Works', href: '/works', icon: 'search' },
-  { label: 'Authors', href: '/pseuds', icon: 'person' },
+  { label: 'Search', href: '/search', icon: 'manage_search' },
   { label: 'Bookmarks', href: '/bookmarks', icon: 'bookmark' },
+  { label: 'Profile', href: '/studio', icon: 'studio' },
 ];
 
 const SECONDARY_NAV: NavItem[] = [
+  { label: 'Works', href: '/works', icon: 'search' },
+  { label: 'Authors', href: '/pseuds', icon: 'person' },
   { label: 'Characters', href: '/characters', icon: 'groups' },
   { label: 'Tags', href: '/tags', icon: 'label' },
   { label: 'Series', href: '/series', icon: 'library_books' },
   { label: 'Collections', href: '/collections', icon: 'folder' },
   { label: 'Canon', href: '/canon', icon: 'auto_stories' },
-  { label: 'Search', href: '/search', icon: 'manage_search' },
-];
-
-const STUDIO_NAV: NavItem[] = [
-  { label: 'Studio', href: '/studio', icon: 'studio' },
 ];
 
 const ADMIN_NAV: NavItem[] = [
@@ -121,8 +119,8 @@ function NavigationRail({ items, currentPath, onMenuClick }: { items: NavItem[];
         ))}
       </div>
       <div class="navigation-rail__spacer" />
-      <a href="/studio" class="navigation-rail__create" aria-label="Creator Studio" title="Studio">
-        <SvgIcon name="studio" size={24} />
+      <a href="/works/create" class="navigation-rail__create" aria-label="New Work" title="New Work">
+        <SvgIcon name="create" size={24} />
       </a>
     </nav>
   );
@@ -169,10 +167,6 @@ function NavigationDrawer({ items, secondaryItems, currentPath, userName }: {
       <div class="navigation-drawer__spacer" />
       {userName && (
         <div class="navigation-drawer__footer">
-          <a href="/studio" class={`navigation-drawer__item ${isActive('/studio', currentPath) ? 'navigation-drawer__item--active' : ''}`}>
-            <SvgIcon name="studio" size={24} />
-            <span>Studio</span>
-          </a>
           <a href="/works/create" class="navigation-drawer__create">
             <SvgIcon name="create" size={20} />
             <span>New Work</span>
@@ -266,10 +260,6 @@ function ModalDrawer({ isOpen, onClose, primaryItems, secondaryItems, currentPat
           <>
             <div class="modal-drawer__divider" />
             <div class="modal-drawer__section">
-              <a href="/studio" class="modal-drawer__item" onClick={onClose}>
-                <SvgIcon name="studio" size={24} />
-                <span>Studio</span>
-              </a>
               <a href="/works/create" class="modal-drawer__item modal-drawer__item--create" onClick={onClose}>
                 <SvgIcon name="create" size={24} />
                 <span>New Work</span>
@@ -309,8 +299,8 @@ function MobileAppBar({ onMenuClick, userName }: { onMenuClick: () => void; user
       <a href="/" class="mobile-app-bar__title">fanfiction.fyi</a>
       <div class="mobile-app-bar__actions">
         {userName ? (
-          <a href="/studio" class="mobile-app-bar__create" aria-label="Creator Studio">
-            <SvgIcon name="studio" size={24} />
+          <a href="/works/create" class="mobile-app-bar__create" aria-label="New Work">
+            <SvgIcon name="create" size={24} />
           </a>
         ) : (
           <a href="/login" class="mobile-app-bar__signin">Sign In</a>
@@ -329,13 +319,15 @@ interface AdaptiveNavProps {
   isReadingMode?: boolean;
 }
 
+// ── Shared signal for modal drawer open/close state ──
+const modalOpenSignal = signal(false);
+
 export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingMode }: AdaptiveNavProps) {
-  const [modalOpen, setModalOpen] = useState(false);
   const [bottomNavHidden, setBottomNavHidden] = useState(false);
   const lastScrollY = useRef(0);
 
-  const openModal = useCallback(() => setModalOpen(true), []);
-  const closeModal = useCallback(() => setModalOpen(false), []);
+  const openModal = useCallback(() => { modalOpenSignal.value = true; }, []);
+  const closeModal = useCallback(() => { modalOpenSignal.value = false; }, []);
 
   // Scroll-hide for mobile bottom nav (only in reading mode per acceptance criteria)
   useEffect(() => {
@@ -354,16 +346,18 @@ export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingM
     return () => window.removeEventListener('scroll', handleScroll);
   }, [isReadingMode]);
 
-  // Build primary nav items — include Bookmarks only if logged in
-  const primaryNav = userName
-    ? PRIMARY_NAV
-    : PRIMARY_NAV.filter((item) => item.href !== '/bookmarks');
+  // Build primary nav items — include Bookmarks and Profile only if logged in
+  // For mobile bottom nav, ensure at least 4 items for good layout
+  const guestPrimaryNav: NavItem[] = [
+    { label: 'Home', href: '/', icon: 'home' },
+    { label: 'Search', href: '/search', icon: 'manage_search' },
+    { label: 'Works', href: '/works', icon: 'search' },
+    { label: 'Authors', href: '/pseuds', icon: 'person' },
+  ];
+  const primaryNav = userName ? PRIMARY_NAV : guestPrimaryNav;
 
   // Build secondary nav for drawer/modal
   const secondaryNav = [...SECONDARY_NAV];
-  if (userName) {
-    secondaryNav.unshift(...STUDIO_NAV);
-  }
   if (isAdmin) {
     secondaryNav.push(...ADMIN_NAV);
   }
@@ -389,7 +383,7 @@ export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingM
 
       {/* Modal Drawer — overlay, activated by hamburger */}
       <ModalDrawer
-        isOpen={modalOpen}
+        isOpen={modalOpenSignal.value}
         onClose={closeModal}
         primaryItems={primaryNav}
         secondaryItems={secondaryNav}

--- a/src/components/AdaptiveNav.tsx
+++ b/src/components/AdaptiveNav.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'preact/hooks';
 import { signal } from '@preact/signals';
 
 // ── Navigation item definitions ──
@@ -97,7 +97,7 @@ function MobileBottomNav({ items, currentPath, hidden }: { items: NavItem[]; cur
 
 // ── Navigation Rail (600px – 839px) ──
 
-function NavigationRail({ items, currentPath, onMenuClick }: { items: NavItem[]; currentPath: string; onMenuClick: () => void }) {
+function NavigationRail({ items, currentPath, onMenuClick, userName }: { items: NavItem[]; currentPath: string; onMenuClick: () => void; userName?: string }) {
   return (
     <nav class="adaptive-nav navigation-rail" aria-label="Main navigation">
       <button class="navigation-rail__fab" onClick={onMenuClick} aria-label="Open menu">
@@ -119,9 +119,11 @@ function NavigationRail({ items, currentPath, onMenuClick }: { items: NavItem[];
         ))}
       </div>
       <div class="navigation-rail__spacer" />
-      <a href="/works/create" class="navigation-rail__create" aria-label="New Work" title="New Work">
-        <SvgIcon name="create" size={24} />
-      </a>
+      {userName && (
+        <a href="/works/create" class="navigation-rail__create" aria-label="New Work" title="New Work">
+          <SvgIcon name="create" size={24} />
+        </a>
+      )}
     </nav>
   );
 }
@@ -319,10 +321,9 @@ interface AdaptiveNavProps {
   isReadingMode?: boolean;
 }
 
-// ── Shared signal for modal drawer open/close state ──
-const modalOpenSignal = signal(false);
-
 export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingMode }: AdaptiveNavProps) {
+  // Scoped to this component instance to avoid cross-instance coupling
+  const modalOpenSignal = useMemo(() => signal(false), []);
   const [bottomNavHidden, setBottomNavHidden] = useState(false);
   const lastScrollY = useRef(0);
 
@@ -356,8 +357,10 @@ export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingM
   ];
   const primaryNav = userName ? PRIMARY_NAV : guestPrimaryNav;
 
-  // Build secondary nav for drawer/modal
-  const secondaryNav = [...SECONDARY_NAV];
+  // Build secondary nav for drawer/modal — filter out items already in primaryNav (avoids
+  // duplicate Works/Authors entries when guests have them in their primary nav)
+  const primaryHrefs = new Set(primaryNav.map((item) => item.href));
+  const secondaryNav = SECONDARY_NAV.filter((item) => !primaryHrefs.has(item.href));
   if (isAdmin) {
     secondaryNav.push(...ADMIN_NAV);
   }
@@ -371,7 +374,7 @@ export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingM
       <MobileBottomNav items={primaryNav.slice(0, 5)} currentPath={currentPath} hidden={bottomNavHidden} />
 
       {/* Navigation Rail — visible 600px – 839px */}
-      <NavigationRail items={primaryNav} currentPath={currentPath} onMenuClick={openModal} />
+      <NavigationRail items={primaryNav} currentPath={currentPath} onMenuClick={openModal} userName={userName} />
 
       {/* Navigation Drawer — visible 840px+ */}
       <NavigationDrawer


### PR DESCRIPTION
## M3 Adaptive Navigation Alignment (Issue #58)

The AdaptiveNav component was already built with three breakpoints (mobile bottom bar, tablet rail, desktop drawer). This PR aligns it with the #58 acceptance criteria and cleans up navigation structure.

### Changes

**Modal state → Preact signals:**
- Converted `useState` to `@preact/signals` for modal drawer open/close (per #58 acceptance criteria)

**Primary nav realigned with spec:**
- Mobile bottom nav now shows: Home, Search, Bookmarks, Profile (per #58 spec)
- Guests see: Home, Search, Works, Authors (4-item bottom nav, avoids sparse layout)
- Works and Authors moved to secondary/browse section

**Removed duplicate Studio links:**
- Studio is now a primary nav item ("Profile" → /studio), so removed from:
  - Navigation drawer footer
  - Modal drawer user section
  - Secondary nav injection

**Action buttons updated:**
- Mobile app bar: New Work (was Studio)
- Rail FAB: New Work (was Studio)  
- Drawer footer: New Work only

### Acceptance Criteria Checklist
- [x] Navigation adjusts across 3 M3 breakpoints (mobile <600px, tablet 600–839px, desktop 840px+)
- [x] Bottom nav hides on scroll-down in Reading Mode, reappears on scroll-up
- [x] Modal drawer open/close via Preact signals
- [x] All primary destinations accessible at each breakpoint
- [x] Secondary routes (New Work, Settings) reachable via hamburger menu on mobile

Closes #58