### PR TITLE
chore: disable Astro telemetry

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import preact from '@astrojs/preact';
 import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
+  telemetry: false,
   site: 'https://fanfiction.fyi',
   output: 'server',
   adapter: cloudflare({


### PR DESCRIPTION
Copilot's firewall blocks `telemetry.astro.build` during builds, causing failures.

Setting `telemetry: false` in astro.config prevents all outbound telemetry calls.

No functional changes — purely a build reliability fix.