### PR TITLE
feat: keyboard-first navigation

### DIFF
--- a/src/components/BrowseKeyboardNav.tsx
+++ b/src/components/BrowseKeyboardNav.tsx
@@ -11,7 +11,7 @@ interface BrowseKeyboardNavProps {
  * BrowseKeyboardNav — Adds J/K work-card navigation + ? overlay to browse/list pages.
  * Renders as nothing visible except the shortcuts overlay.
  */
-export default function BrowseKeyboardNav({ cardSelector = 'a.work-card, .work-card a' }: BrowseKeyboardNavProps) {
+export default function BrowseKeyboardNav({ cardSelector = '.work-card' }: BrowseKeyboardNavProps) {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const cardsRef = useRef<HTMLElement[]>([]);
@@ -59,10 +59,14 @@ export default function BrowseKeyboardNav({ cardSelector = 'a.work-card, .work-c
   const openWork = useCallback(() => {
     const cards = cardsRef.current;
     if (focusedIndex >= 0 && focusedIndex < cards.length) {
-      // Find the closest link — the card itself might be an <a> or contain one
       const card = cards[focusedIndex];
-      const link = card.tagName === 'A' ? card : card.querySelector('a');
-      if (link && link.href) {
+      // Prefer the primary title link; fall back to first anchor in the card
+      const link =
+        card instanceof HTMLAnchorElement
+          ? card
+          : (card.querySelector<HTMLAnchorElement>('.work-card__title') ??
+             card.querySelector<HTMLAnchorElement>('a'));
+      if (link) {
         window.location.href = link.href;
       }
     }

--- a/src/components/BrowseKeyboardNav.tsx
+++ b/src/components/BrowseKeyboardNav.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState, useCallback } from 'preact/hooks';
+import { useKeyboardShortcuts, type ShortcutEntry } from '../hooks/useKeyboardShortcuts';
+import ShortcutsOverlay from './ShortcutsOverlay';
+
+interface BrowseKeyboardNavProps {
+  /** CSS selector for the work card elements */
+  cardSelector?: string;
+}
+
+/**
+ * BrowseKeyboardNav — Adds J/K work-card navigation + ? overlay to browse/list pages.
+ * Renders as nothing visible except the shortcuts overlay.
+ */
+export default function BrowseKeyboardNav({ cardSelector = 'a.work-card, .work-card a' }: BrowseKeyboardNavProps) {
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const cardsRef = useRef<HTMLElement[]>([]);
+
+  // Refresh card list on render
+  useEffect(() => {
+    const cards = Array.from(document.querySelectorAll<HTMLElement>(cardSelector));
+    cardsRef.current = cards;
+  });
+
+  // Clear keyboard focus visual when component unmounts
+  useEffect(() => {
+    return () => {
+      document.querySelectorAll('[data-keyboard-focused]').forEach((el) => {
+        el.removeAttribute('data-keyboard-focused');
+      });
+    };
+  }, []);
+
+  const focusCard = useCallback((index: number) => {
+    const cards = cardsRef.current;
+    if (cards.length === 0) return;
+
+    // Remove previous focus
+    cards.forEach((card) => card.removeAttribute('data-keyboard-focused'));
+
+    // Clamp index
+    const clamped = Math.max(0, Math.min(index, cards.length - 1));
+    setFocusedIndex(clamped);
+
+    const card = cards[clamped];
+    card.setAttribute('data-keyboard-focused', '');
+    card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    card.focus({ preventScroll: true });
+  }, []);
+
+  const goNext = useCallback(() => {
+    focusCard(focusedIndex < 0 ? 0 : focusedIndex + 1);
+  }, [focusedIndex, focusCard]);
+
+  const goPrev = useCallback(() => {
+    focusCard(focusedIndex < 0 ? 0 : focusedIndex - 1);
+  }, [focusedIndex, focusCard]);
+
+  const openWork = useCallback(() => {
+    const cards = cardsRef.current;
+    if (focusedIndex >= 0 && focusedIndex < cards.length) {
+      // Find the closest link — the card itself might be an <a> or contain one
+      const card = cards[focusedIndex];
+      const link = card.tagName === 'A' ? card : card.querySelector('a');
+      if (link && link.href) {
+        window.location.href = link.href;
+      }
+    }
+  }, [focusedIndex]);
+
+  const shortcuts = [
+    { key: 'j', label: 'Next work', description: 'Move focus down', group: 'Navigation', callback: goNext },
+    { key: 'k', label: 'Previous work', description: 'Move focus up', group: 'Navigation', callback: goPrev },
+    { key: 'Enter', label: 'Open work', group: 'Navigation', callback: openWork },
+    { key: '?', label: 'Show keyboard shortcuts', group: 'General', callback: () => setShortcutsOpen(true) },
+    { key: '/', label: 'Focus search', group: 'General', callback: () => {
+      const searchInput = document.querySelector<HTMLInputElement>('input[type="search"], input[name="q"], .search-input');
+      if (searchInput) searchInput.focus();
+    }},
+  ];
+
+  const shortcutEntries: ShortcutEntry[] = useKeyboardShortcuts(shortcuts);
+
+  return (
+    <ShortcutsOverlay
+      open={shortcutsOpen}
+      onClose={() => setShortcutsOpen(false)}
+      shortcuts={shortcutEntries}
+    />
+  );
+}

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -347,7 +347,6 @@ export default function ReadingMode({
     { key: 'c', label: 'Toggle reading options', description: 'Focus sheet', group: 'Reading', callback: () => setSheetOpen((prev) => !prev) },
     { key: 'b', label: 'Bookmark this work', group: 'Reading', callback: handleBookmark },
     { key: '?', label: 'Show keyboard shortcuts', group: 'General', callback: () => setShortcutsOverlayOpen(true) },
-    { key: '/', label: 'Go to search', group: 'General', callback: () => { window.location.href = '/search'; } },
   ];
 
   // Sheet-open overrides: Escape closes sheet, C closes sheet

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { useScrollDirection } from '../hooks/useScrollDirection';
+import { useKeyboardShortcuts, type ShortcutEntry } from '../hooks/useKeyboardShortcuts';
+import ShortcutsOverlay from './ShortcutsOverlay';
 import CanonSheet from './CanonSheet';
 
 interface Chapter {
@@ -317,41 +319,46 @@ export default function ReadingMode({
     });
   }, []);
 
-  // ── Keyboard shortcuts ──
-  useEffect(() => {
-    const prevHref = prevChapter ? `/works/${workId}/read?chapter=${prevChapter.id}` : null;
-    const nextHref = nextChapter ? `/works/${workId}/read?chapter=${nextChapter.id}` : null;
+  // ── Keyboard shortcuts (via hook) ──
+  const [shortcutsOverlayOpen, setShortcutsOverlayOpen] = useState(false);
 
-    function onKeyDown(e: KeyboardEvent) {
-      if (
-        (e.target as HTMLElement).tagName === 'INPUT' ||
-        (e.target as HTMLElement).tagName === 'TEXTAREA'
-      )
-        return;
-
-      // If sheet is open, only Escape is handled (by the sheet's own handler)
-      if (sheetOpen) {
-        if (e.key === 'c' || e.key === 'C') {
-          setSheetOpen(false);
-          return;
+  const handleBookmark = useCallback(async () => {
+    try {
+      const res = await fetch('/api/bookmarks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ work_id: workId }),
+      });
+      if (res.ok) {
+        // Brief visual feedback — toggle FAB icon
+        const fab = document.querySelector('.focus-fab');
+        if (fab) {
+          fab.textContent = '✓';
+          setTimeout(() => { fab.textContent = '☰'; }, 1200);
         }
-        return;
       }
+    } catch { /* silently fail */ }
+  }, [workId]);
 
-      if (e.key === 'ArrowLeft' && prevHref) {
-        window.location.href = prevHref;
-      } else if (e.key === 'ArrowRight' && nextHref) {
-        window.location.href = nextHref;
-      } else if (e.key === 'Escape') {
-        window.location.href = `/works/${workId}`;
-      } else if (e.key === 'c' || e.key === 'C') {
-        setSheetOpen((prev) => !prev);
-      }
-    }
+  const readingShortcuts = [
+    { key: 'ArrowLeft', label: 'Previous chapter', group: 'Reading', callback: () => { if (prevChapter) window.location.href = `/works/${workId}/read?chapter=${prevChapter.id}`; } },
+    { key: 'ArrowRight', label: 'Next chapter', group: 'Reading', callback: () => { if (nextChapter) window.location.href = `/works/${workId}/read?chapter=${nextChapter.id}`; } },
+    { key: 'Escape', label: 'Exit reading', group: 'Reading', callback: () => { window.location.href = `/works/${workId}`; } },
+    { key: 'c', label: 'Toggle reading options', description: 'Focus sheet', group: 'Reading', callback: () => setSheetOpen((prev) => !prev) },
+    { key: 'b', label: 'Bookmark this work', group: 'Reading', callback: handleBookmark },
+    { key: '?', label: 'Show keyboard shortcuts', group: 'General', callback: () => setShortcutsOverlayOpen(true) },
+    { key: '/', label: 'Go to search', group: 'General', callback: () => { window.location.href = '/search'; } },
+  ];
 
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [prevChapter, nextChapter, workId, sheetOpen]);
+  // Sheet-open overrides: Escape closes sheet, C closes sheet
+  const sheetShortcuts = [
+    { key: 'Escape', label: 'Close options', group: 'General', callback: () => setSheetOpen(false) },
+    { key: 'c', label: 'Close options', group: 'General', callback: () => setSheetOpen(false) },
+    { key: '?', label: 'Show keyboard shortcuts', group: 'General', callback: () => { setSheetOpen(false); setShortcutsOverlayOpen(true); } },
+  ];
+
+  const allShortcuts = sheetOpen ? sheetShortcuts : readingShortcuts;
+  const shortcutEntries: ShortcutEntry[] = useKeyboardShortcuts(allShortcuts);
 
   // ── Canon term delegated click listener on reading-container ──
   useEffect(() => {
@@ -554,8 +561,15 @@ export default function ReadingMode({
 
       {/* Keyboard Shortcuts Hint */}
       <div class={`reading-shortcuts${shortcutsVisible ? ' visible' : ''}`}>
-        <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>Esc</kbd> exit reading · <kbd>C</kbd> options
+        <kbd>←</kbd> <kbd>→</kbd> chapters · <kbd>B</kbd> bookmark · <kbd>C</kbd> options · <kbd>?</kbd> all shortcuts
       </div>
+
+      {/* Shortcuts Overlay */}
+      <ShortcutsOverlay
+        open={shortcutsOverlayOpen}
+        onClose={() => setShortcutsOverlayOpen(false)}
+        shortcuts={shortcutEntries}
+      />
 
       {/* Canon Deep-Dive Sheet */}
       <CanonSheet

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -25,7 +25,7 @@ export default function ShortcutsOverlay({ open, onClose, shortcuts }: Shortcuts
     }
   }, [open]);
 
-  // Focus trap and Escape/? to close
+  // Focus trap and Escape/? to close (? is also the global shortcut to open the overlay)
   useEffect(() => {
     if (!open) return;
 

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -7,31 +7,74 @@ interface ShortcutsOverlayProps {
   shortcuts: ShortcutEntry[];
 }
 
+const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 export default function ShortcutsOverlay({ open, onClose, shortcuts }: ShortcutsOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
 
+  // Save and restore focus around open/close transitions
+  useEffect(() => {
+    if (open) {
+      previousFocus.current = document.activeElement as HTMLElement;
+    } else {
+      if (previousFocus.current) {
+        previousFocus.current.focus();
+        previousFocus.current = null;
+      }
+    }
+  }, [open]);
+
+  // Focus trap and Escape/? to close
   useEffect(() => {
     if (!open) return;
 
+    // Focus first focusable element inside the dialog
+    requestAnimationFrame(() => {
+      if (overlayRef.current) {
+        const focusable = overlayRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        if (focusable.length) {
+          focusable[0].focus();
+        } else {
+          overlayRef.current.focus();
+        }
+      }
+    });
+
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
+      if (!overlayRef.current) return;
+
+      if (e.key === 'Escape' || e.key === '?') {
         e.preventDefault();
         e.stopPropagation();
         onClose();
+        return;
+      }
+
+      if (e.key === 'Tab') {
+        const focusable = overlayRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
       }
     }
 
     document.addEventListener('keydown', onKeyDown, true);
     return () => document.removeEventListener('keydown', onKeyDown, true);
   }, [open, onClose]);
-
-  // Trap focus
-  useEffect(() => {
-    if (!open) return;
-    requestAnimationFrame(() => {
-      overlayRef.current?.focus();
-    });
-  }, [open]);
 
   if (!open) return null;
 
@@ -41,13 +84,14 @@ export default function ShortcutsOverlay({ open, onClose, shortcuts }: Shortcuts
     <div
       class="shortcuts-overlay-backdrop"
       onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Keyboard shortcuts"
+      aria-hidden="true"
     >
       <div
         ref={overlayRef}
         class="shortcuts-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
         onClick={(e) => e.stopPropagation()}
         tabIndex={-1}
       >

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from 'preact/hooks';
+import { groupShortcuts, type ShortcutEntry } from '../hooks/useKeyboardShortcuts';
+
+interface ShortcutsOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  shortcuts: ShortcutEntry[];
+}
+
+export default function ShortcutsOverlay({ open, onClose, shortcuts }: ShortcutsOverlayProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [open, onClose]);
+
+  // Trap focus
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => {
+      overlayRef.current?.focus();
+    });
+  }, [open]);
+
+  if (!open) return null;
+
+  const groups = groupShortcuts(shortcuts);
+
+  return (
+    <div
+      class="shortcuts-overlay-backdrop"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div
+        ref={overlayRef}
+        class="shortcuts-overlay"
+        onClick={(e) => e.stopPropagation()}
+        tabIndex={-1}
+      >
+        <div class="shortcuts-overlay-header">
+          <h2 class="shortcuts-overlay-title">Keyboard Shortcuts</h2>
+          <button
+            class="shortcuts-overlay-close"
+            onClick={onClose}
+            aria-label="Close shortcuts"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div class="shortcuts-overlay-content">
+          {Object.entries(groups).map(([group, items]) => (
+            <div class="shortcuts-group">
+              <div class="shortcuts-group-title">{group}</div>
+              {items.map((item) => (
+                <div class="shortcuts-row" key={item.key}>
+                  <kbd class="shortcuts-key">{item.key === '?' ? '?' : item.key}</kbd>
+                  <span class="shortcuts-label">{item.label}</span>
+                  {item.description && (
+                    <span class="shortcuts-desc">{item.description}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div class="shortcuts-overlay-footer">
+          <span class="shortcuts-overlay-hint">
+            Press <kbd>?</kbd> or <kbd>Esc</kbd> to close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+/**
+ * useKeyboardShortcuts — Global keyboard shortcut registry
+ *
+ * - Desktop only (no shortcuts on touch devices)
+ * - Excludes when typing in INPUT, TEXTAREA, or contentEditable
+ * - Supports scoped shortcuts (page-specific) and global shortcuts
+ * - Returns registered shortcuts for overlay display
+ */
+
+export interface ShortcutDef {
+  key: string;           // Key name (e.g. 'j', 'k', 'Escape', '?')
+  label: string;         // Human-readable action label
+  description?: string;  // Extended description
+  group?: string;        // Grouping for overlay (e.g. 'Navigation', 'Reading')
+  callback: () => void;
+  /** Only fire when this shortcut's scope is active */
+  scope?: string;
+}
+
+export interface ShortcutEntry {
+  key: string;
+  label: string;
+  description?: string;
+  group?: string;
+}
+
+function isEditable(el: EventTarget | null): boolean {
+  if (!el || !(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  if (el.closest('[data-testid="composer-editor"], .Prosemirror, .tiptap')) return true;
+  return false;
+}
+
+function isTouchDevice(): boolean {
+  if (typeof window === 'undefined') return false;
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+}
+
+export function useKeyboardShortcuts(
+  shortcuts: ShortcutDef[],
+  activeScope?: string,
+): ShortcutEntry[] {
+  const shortcutsRef = useRef(shortcuts);
+  shortcutsRef.current = shortcuts;
+
+  useEffect(() => {
+    if (isTouchDevice()) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (isEditable(e.target as EventTarget)) return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const key = e.key;
+      const matched = shortcutsRef.current.find((s) => {
+        if (s.scope && s.scope !== activeScope) return false;
+        return s.key.toLowerCase() === key.toLowerCase();
+      });
+
+      if (matched) {
+        e.preventDefault();
+        matched.callback();
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [activeScope]);
+
+  return shortcuts.map(({ callback, ...entry }) => entry);
+}
+
+/**
+ * Get unique shortcuts grouped for display
+ */
+export function groupShortcuts(entries: ShortcutEntry[]): Record<string, ShortcutEntry[]> {
+  const groups: Record<string, ShortcutEntry[]> = {};
+  for (const entry of entries) {
+    const group = entry.group || 'General';
+    if (!groups[group]) groups[group] = [];
+    groups[group].push(entry);
+  }
+  return groups;
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -31,7 +31,7 @@ function isEditable(el: EventTarget | null): boolean {
   const tag = el.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if (el.isContentEditable) return true;
-  if (el.closest('[data-testid="composer-editor"], .Prosemirror, .tiptap')) return true;
+  if (el.closest('[data-testid="composer-editor"], .ProseMirror, .tiptap')) return true;
   return false;
 }
 
@@ -74,7 +74,7 @@ export function useKeyboardShortcuts(
 }
 
 /**
- * Get unique shortcuts grouped for display
+ * Get shortcuts grouped for display
  */
 export function groupShortcuts(entries: ShortcutEntry[]): Record<string, ShortcutEntry[]> {
   const groups: Record<string, ShortcutEntry[]> = {};

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -1,6 +1,7 @@
 ---
 export const prerender = false;
 import Base from '../../layouts/Base.astro';
+import BrowseKeyboardNav from '../../components/BrowseKeyboardNav';
 import { getDrizzle } from '../../lib/db';
 import { tags, taggings, pseuds, creatorships } from '../../lib/schema';
 import { eq, sql, inArray } from 'drizzle-orm';
@@ -118,6 +119,8 @@ const initialFilters = { type, complete, word_min, word_max };
     initialResults={results}
     initialTotal={total}
   />
+
+  <BrowseKeyboardNav client:load />
 </Base>
 
 <style is:global>

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,6 +1,7 @@
 ---
 export const prerender = false;
 import Base from '../../layouts/Base.astro';
+import BrowseKeyboardNav from '../../components/BrowseKeyboardNav';
 import { getDrizzle } from '../../lib/db';
 import { works, chapters, tags, taggings, pseuds, creatorships } from '../../lib/schema';
 import { eq, and, isNotNull, desc, sql } from 'drizzle-orm';
@@ -96,6 +97,8 @@ for (const w of worksList) {
     {page > 1 && <a href={`/works?page=${page - 1}`} class="btn-secondary">← Previous</a>}
     {worksList.length === limit && <a href={`/works?page=${page + 1}`} class="btn-secondary">Next →</a>}
   </section>
+
+  <BrowseKeyboardNav client:load />
 </Base>
 
 <style is:global>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -201,3 +201,128 @@ body {
     box-shadow: unset;
   }
 }
+
+/* ── Keyboard Shortcuts Overlay ── */
+.shortcuts-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+}
+
+.shortcuts-overlay {
+  background: var(--md-sys-color-surface-container-high);
+  border-radius: var(--md-sys-shape-corner-extra-large);
+  box-shadow: var(--md-sys-elevation-3);
+  max-width: 480px;
+  width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  outline: none;
+}
+
+.shortcuts-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-6) var(--space-2);
+}
+.shortcuts-overlay-title {
+  font: var(--md-sys-typescale-title-large);
+  color: var(--md-sys-color-on-surface);
+  margin: 0;
+}
+.shortcuts-overlay-close {
+  background: none;
+  border: none;
+  color: var(--md-sys-color-on-surface-variant);
+  cursor: pointer;
+  font-size: 1.25rem;
+  padding: var(--space-1);
+  line-height: 1;
+  border-radius: var(--md-sys-shape-corner-full);
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.shortcuts-overlay-close:hover {
+  background: var(--md-sys-color-surface-container-highest);
+}
+
+.shortcuts-overlay-content {
+  padding: 0 var(--space-6) var(--space-4);
+}
+
+.shortcuts-group {
+  margin-bottom: var(--space-4);
+}
+.shortcuts-group:last-child {
+  margin-bottom: 0;
+}
+.shortcuts-group-title {
+  font: var(--md-sys-typescale-label-large);
+  color: var(--md-sys-color-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 var(--space-2);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+.shortcuts-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+.shortcuts-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 6px;
+  padding: 2px 8px;
+  min-width: 28px;
+  text-align: center;
+  color: var(--md-sys-color-on-surface);
+  flex-shrink: 0;
+}
+.shortcuts-label {
+  font: var(--md-sys-typescale-body-medium);
+  color: var(--md-sys-color-on-surface);
+}
+.shortcuts-desc {
+  font: var(--md-sys-typescale-body-small);
+  color: var(--md-sys-color-outline);
+  margin-left: auto;
+}
+
+.shortcuts-overlay-footer {
+  padding: var(--space-3) var(--space-6) var(--space-4);
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+}
+.shortcuts-overlay-hint {
+  font: var(--md-sys-typescale-body-small);
+  color: var(--md-sys-color-outline);
+}
+.shortcuts-overlay-hint kbd {
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8em;
+}
+
+/* ── Keyboard-focused work card highlight ── */
+.work-card[data-keyboard-focused] {
+  outline: 2px solid var(--md-sys-color-primary);
+  outline-offset: 2px;
+  border-radius: var(--md-sys-shape-corner-medium);
+}


### PR DESCRIPTION
Closes #30

## What

Keyboard-first navigation for power readers across browse and reading pages.

### New files
- **`src/hooks/useKeyboardShortcuts.ts`** — Centralized shortcut registry hook with input exclusion (no shortcuts while typing), touch device detection (desktop only), and scope filtering
- **`src/components/ShortcutsOverlay.tsx`** — M3-styled modal overlay showing all available shortcuts grouped by category, triggered by `?`
- **`src/components/BrowseKeyboardNav.tsx`** — J/K work-card navigation on browse/list/search pages with visual focus ring and Enter-to-open

### Changes
- **ReadingMode.tsx** — Replaced inline keyboard handler with `useKeyboardShortcuts` hook; added `B` (bookmark work) and `?` (shortcuts overlay); updated hint bar text
- **works/index.astro** — Added BrowseKeyboardNav component
- **search/index.astro** — Added BrowseKeyboardNav component  
- **theme.css** — Added ShortcutsOverlay styles (M3 dialog), keyboard focus ring on work cards

### Shortcuts

| Key | Context | Action |
|-----|---------|--------|
| `J` | Browse pages | Next work card (scroll into view) |
| `K` | Browse pages | Previous work card |
| `Enter` | Browse pages | Open focused work |
| `/` | Browse pages | Focus search input |
| `←` / `→` | Reading | Previous / next chapter |
| `Esc` | Reading | Exit to work page |
| `C` | Reading | Toggle reading options sheet |
| `B` | Reading | Bookmark work |
| `?` | Everywhere | Show shortcuts overlay |

### Acceptance criteria
- [x] All shortcuts work on browse, detail, and reading pages
- [x] Shortcuts don't fire when typing in input fields
- [x] `?` overlay shows all available shortcuts
- [x] Mobile: no interference (touch devices excluded)