### PR TITLE
feat: Phase 4 - Notifications, API Auth and Performance (#77)

### DIFF
--- a/drizzle/0002_notifications.sql
+++ b/drizzle/0002_notifications.sql
@@ -1,0 +1,19 @@
+CREATE TABLE notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  type TEXT NOT NULL CHECK(type IN ('comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system')),
+  title TEXT NOT NULL,
+  body TEXT,
+  link TEXT,
+  read INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX notifications_user_unread_idx ON notifications(user_id, read);
+
+CREATE TABLE notification_preferences (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  type TEXT NOT NULL CHECK(type IN ('comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system')),
+  enabled INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX notification_preferences_user_type_idx ON notification_preferences(user_id, type);

--- a/drizzle/0003_api_keys.sql
+++ b/drizzle/0003_api_keys.sql
@@ -1,0 +1,14 @@
+-- API Key Authentication (Issue #96)
+CREATE TABLE api_keys (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  name TEXT NOT NULL,
+  key_hash TEXT NOT NULL,
+  key_prefix TEXT NOT NULL,
+  rate_limit_tier TEXT NOT NULL DEFAULT 'free' CHECK(rate_limit_tier IN ('free', 'pro')),
+  last_used_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  revoked_at TEXT
+);
+CREATE INDEX api_keys_user_idx ON api_keys(user_id);
+CREATE INDEX api_keys_key_hash_idx ON api_keys(key_hash);

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+# Cloudflare Pages headers — immutable cache for hashed static assets
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Service worker must always revalidate
+/sw.js
+  Cache-Control: no-cache

--- a/src/components/AdaptiveNav.tsx
+++ b/src/components/AdaptiveNav.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'preact/hooks';
 import { signal } from '@preact/signals';
+import NotificationBell from './NotificationBell';
 
 // ── Navigation item definitions ──
 
@@ -121,6 +122,7 @@ function NavigationRail({ items, currentPath, onMenuClick, userName }: { items: 
         ))}
       </div>
       <div class="navigation-rail__spacer" />
+      {userName && <NotificationBell />}
       {userName && (
         <a href="/works/create" class="navigation-rail__create" aria-label="New Work" title="New Work">
           <SvgIcon name="create" size={24} />
@@ -169,6 +171,7 @@ function NavigationDrawer({ items, secondaryItems, currentPath, userName }: {
         ))}
       </div>
       <div class="navigation-drawer__spacer" />
+      {userName && <NotificationBell />}
       {userName && (
         <div class="navigation-drawer__footer">
           <a href="/works/create" class="navigation-drawer__create">
@@ -302,6 +305,7 @@ function MobileAppBar({ onMenuClick, userName }: { onMenuClick: () => void; user
       </button>
       <a href="/" class="mobile-app-bar__title">fanfiction.fyi</a>
       <div class="mobile-app-bar__actions">
+        {userName && <NotificationBell />}
         {userName ? (
           <a href="/works/create" class="mobile-app-bar__create" aria-label="New Work">
             <SvgIcon name="create" size={24} />

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+type NotificationType = 'comment_reply' | 'kudos' | 'new_chapter' | 'collection_invite' | 'work_featured' | 'system';
+
+interface Notification {
+  id: number;
+  user_id: number;
+  type: NotificationType;
+  title: string;
+  body: string | null;
+  link: string | null;
+  read: number | boolean;
+  created_at: string;
+}
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr + (dateStr.includes('Z') ? '' : 'Z')).getTime();
+  const diff = now - then;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+const TYPE_ICONS: Record<NotificationType, string> = {
+  comment_reply: '💬',
+  kudos: '❤️',
+  new_chapter: '📖',
+  collection_invite: '📁',
+  work_featured: '⭐',
+  system: '🔔',
+};
+
+function NotificationPanel({ notifications: notifs, unreadCount, onMarkAllRead, onDelete }: {
+  notifications: Notification[];
+  unreadCount: number;
+  onMarkAllRead: () => void;
+  onDelete: (id: number) => void;
+}) {
+  if (notifs.length === 0) {
+    return (
+      <div class="notif-panel__empty">
+        No notifications yet.
+      </div>
+    );
+  }
+
+  return (
+    <div class="notif-panel__list">
+      {notifs.map(n => (
+        <div key={n.id} class={`notif-panel__item ${n.read ? '' : 'notif-panel__item--unread'}`}>
+          <span class="notif-panel__icon">{TYPE_ICONS[n.type] || '🔔'}</span>
+          <div class="notif-panel__content">
+            {n.link ? (
+              <a href={n.link} class="notif-panel__link">{n.title}</a>
+            ) : (
+              <span class="notif-panel__title">{n.title}</span>
+            )}
+            {n.body && (
+              <p class="notif-panel__body">{n.body.length > 120 ? n.body.substring(0, 120) + '…' : n.body}</p>
+            )}
+            <span class="notif-panel__time">{timeAgo(n.created_at)}</span>
+          </div>
+          <button
+            class="notif-panel__delete"
+            onClick={(e: MouseEvent) => { e.stopPropagation(); onDelete(n.id); }}
+            aria-label="Dismiss notification"
+            title="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      {unreadCount > 0 && (
+        <button class="notif-panel__mark-all" onClick={onMarkAllRead}>
+          Mark All Read
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const [notifs, setNotifs] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const fetchUnreadCount = useCallback(async () => {
+    try {
+      const res = await fetch('/api/notifications?limit=1');
+      if (res.ok) {
+        const data = await res.json();
+        setUnreadCount(data.unreadCount ?? 0);
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  const fetchNotifications = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/notifications?limit=20');
+      if (res.ok) {
+        const data = await res.json();
+        setNotifs(data.notifications ?? []);
+        setUnreadCount(data.unreadCount ?? 0);
+      }
+    } catch { /* ignore */ }
+    setLoading(false);
+  }, []);
+
+  // Poll unread count every 30s
+  useEffect(() => {
+    fetchUnreadCount();
+    const interval = setInterval(fetchUnreadCount, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchUnreadCount]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [open]);
+
+  const toggleDropdown = () => {
+    if (!open) fetchNotifications();
+    setOpen(!open);
+  };
+
+  const markAllRead = async () => {
+    try {
+      await fetch('/api/notifications/read', { method: 'PUT', headers: { 'Content-Type': 'application/json' } });
+      setNotifs(prev => prev.map(n => ({ ...n, read: true })));
+      setUnreadCount(0);
+    } catch { /* ignore */ }
+  };
+
+  const deleteNotif = async (id: number) => {
+    try {
+      const res = await fetch(`/api/notifications/${id}`, { method: 'DELETE' });
+      if (res.ok) {
+        setNotifs(prev => prev.filter(n => n.id !== id));
+        setUnreadCount(prev => Math.max(0, prev - 1));
+      }
+    } catch { /* ignore */ }
+  };
+
+  return (
+    <div class="notif-bell" ref={panelRef}>
+      <button class="notif-bell__btn" onClick={toggleDropdown} aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2zm-2 1H8v-6c0-2.48 1.51-4.5 4-4.5s4 2.02 4 4.5v6z" />
+        </svg>
+        {unreadCount > 0 && (
+          <span class="notif-bell__badge">{unreadCount > 99 ? '99+' : unreadCount}</span>
+        )}
+      </button>
+      {open && (
+        <div class="notif-bell__dropdown">
+          <div class="notif-bell__header">
+            <span class="notif-bell__title">Notifications</span>
+          </div>
+          {loading ? (
+            <div class="notif-panel__empty">Loading…</div>
+          ) : (
+            <NotificationPanel
+              notifications={notifs}
+              unreadCount={unreadCount}
+              onMarkAllRead={markAllRead}
+              onDelete={deleteNotif}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -4,13 +4,13 @@ type NotificationType = 'comment_reply' | 'kudos' | 'new_chapter' | 'collection_
 
 interface Notification {
   id: number;
-  user_id: number;
+  userId: number;
   type: NotificationType;
   title: string;
   body: string | null;
   link: string | null;
   read: number | boolean;
-  created_at: string;
+  createdAt: string;
 }
 
 function timeAgo(dateStr: string): string {
@@ -66,7 +66,7 @@ function NotificationPanel({ notifications: notifs, unreadCount, onMarkAllRead, 
             {n.body && (
               <p class="notif-panel__body">{n.body.length > 120 ? n.body.substring(0, 120) + '…' : n.body}</p>
             )}
-            <span class="notif-panel__time">{timeAgo(n.created_at)}</span>
+            <span class="notif-panel__time">{timeAgo(n.createdAt)}</span>
           </div>
           <button
             class="notif-panel__delete"
@@ -153,8 +153,11 @@ export default function NotificationBell() {
     try {
       const res = await fetch(`/api/notifications/${id}`, { method: 'DELETE' });
       if (res.ok) {
+        const deleted = notifs.find(n => n.id === id);
         setNotifs(prev => prev.filter(n => n.id !== id));
-        setUnreadCount(prev => Math.max(0, prev - 1));
+        if (deleted && !deleted.read) {
+          setUnreadCount(prev => Math.max(0, prev - 1));
+        }
       }
     } catch { /* ignore */ }
   };

--- a/src/components/PseudPortfolio.tsx
+++ b/src/components/PseudPortfolio.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'preact/hooks';
 import ActivityHeatmap from './ActivityHeatmap';
 import Sparkline from './Sparkline';
 import GenrePie from './GenrePie';
+import { SkeletonProfile } from './Skeleton';
 
 interface PortfolioData {
   pseud: {
@@ -42,10 +43,8 @@ export default function PseudPortfolio({ pseudId }: { pseudId: number }) {
 
   if (loading) {
     return (
-      <div class="portfolio-loading">
-        <div class="portfolio-skeleton" />
-        <div class="portfolio-skeleton" style={{ height: '200px' }} />
-        <div class="portfolio-skeleton" style={{ height: '120px' }} />
+      <div role="status" aria-label="Loading profile">
+        <SkeletonProfile />
       </div>
     );
   }

--- a/src/components/SearchPage.tsx
+++ b/src/components/SearchPage.tsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
 import FilterChips from './FilterChips';
 import WorkCard from './WorkCard';
+import { SkeletonCard } from './Skeleton';
 
 type Filters = { type: string; complete: string; word_min: number; word_max: number };
 
@@ -175,7 +176,11 @@ export default function SearchPage({ initialQuery, initialFilters, initialPage, 
 
       <FilterChips filters={filters} onChange={handleFilterChange} />
 
-      {loading && <p class="search-loading">Searching…</p>}
+      {loading && (
+        <div class="results-list" role="status" aria-label="Loading search results">
+          {Array.from({ length: 5 }, (_, i) => <SkeletonCard key={i} />)}
+        </div>
+      )}
 
       {hasSearched && !loading && results.length === 0 && (
         <p class="no-results">
@@ -189,17 +194,19 @@ export default function SearchPage({ initialQuery, initialFilters, initialPage, 
         <p class="placeholder-text">Enter a search query or use filters to find works.</p>
       )}
 
-      {results.length > 0 && (
+      {!loading && results.length > 0 && (
         <div class="results-meta">
           <span>{total.toLocaleString()} result{total !== 1 ? 's' : ''}</span>
         </div>
       )}
 
-      <div class="results-list">
-        {results.map(w => (
-          <WorkCard key={w.id} {...w} />
-        ))}
-      </div>
+      {!loading && (
+        <div class="results-list">
+          {results.map(w => (
+            <WorkCard key={w.id} {...w} />
+          ))}
+        </div>
+      )}
 
       {totalPages > 1 && (
         <nav class="pagination">

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,136 @@
+import { h } from 'preact';
+
+/**
+ * Skeleton — M3-styled loading placeholder with shimmer animation.
+ *
+ * Variants:
+ *   - text:    multi-line text block (default)
+ *   - card:   card-sized rectangle (for work cards, browse items)
+ *   - avatar:  circular avatar placeholder
+ *   - circle:  generic circle (for icons, badges)
+ *
+ * Uses MD3 design tokens for colours and shape.
+ * Shimmer animation defined in theme.css via @keyframes shimmer.
+ */
+
+interface SkeletonProps {
+  variant?: 'text' | 'card' | 'avatar' | 'circle';
+  width?: string;
+  height?: string;
+  lines?: number; // for text variant
+  className?: string;
+}
+
+const VARIANT_STYLES: Record<string, { borderRadius: string; defaultWidth: string; defaultHeight: string }> = {
+  text:   { borderRadius: 'var(--md-sys-shape-corner-small)',  defaultWidth: '100%', defaultHeight: '1em' },
+  card:   { borderRadius: 'var(--md-sys-shape-corner-medium)', defaultWidth: '100%', defaultHeight: '200px' },
+  avatar: { borderRadius: '50%',                              defaultWidth: '48px', defaultHeight: '48px' },
+  circle: { borderRadius: '50%',                              defaultWidth: '40px', defaultHeight: '40px' },
+};
+
+export default function Skeleton({ variant = 'text', width, height, lines = 3, className }: SkeletonProps) {
+  const vs = VARIANT_STYLES[variant] || VARIANT_STYLES.text;
+  const w = width || vs.defaultWidth;
+  const h = height || vs.defaultHeight;
+
+  // For text variant, render multiple line blocks
+  if (variant === 'text') {
+    const lineElements = Array.from({ length: lines }, (_, i) => {
+      const isLast = i === lines - 1;
+      const lineWidth = isLast ? '60%' : '100%';
+      return (
+        <div
+          class={`skeleton skeleton-line ${className || ''}`}
+          style={{
+            width: lineWidth,
+            height: h,
+            borderRadius: vs.borderRadius,
+            marginBottom: '0.5em',
+          }}
+        />
+      );
+    });
+    return <div class="skeleton-text-block">{lineElements}</div>;
+  }
+
+  // For card/variant, render a single block
+  return (
+    <div
+      class={`skeleton ${className || ''}`}
+      style={{
+        width: w,
+        height: h,
+        borderRadius: vs.borderRadius,
+      }}
+      role="status"
+      aria-label="Loading…"
+    />
+  );
+}
+
+/**
+ * SkeletonCard — convenience wrapper that renders a work-card-shaped skeleton.
+ * Matches the layout of WorkCard for seamless swap-in during loading.
+ */
+export function SkeletonCard({ className }: { className?: string }) {
+  return (
+    <article class={`skeleton-card ${className || ''}`}>
+      <div class="skeleton skeleton-card-title" />
+      <div class="skeleton skeleton-card-author" />
+      <div class="skeleton skeleton-card-summary" style={{ width: '90%' }} />
+      <div class="skeleton skeleton-card-summary" style={{ width: '70%' }} />
+      <div class="skeleton skeleton-card-meta" />
+      <div class="skeleton skeleton-card-tags" />
+    </article>
+  );
+}
+
+/**
+ * SkeletonChapter — skeleton for chapter content during initial page paint.
+ * Matches the layout of the reading-chapter section.
+ */
+export function SkeletonChapter({ className }: { className?: string }) {
+  return (
+    <div class={`skeleton-chapter ${className || ''}`}>
+      <div class="skeleton skeleton-chapter-number" />
+      <div class="skeleton skeleton-chapter-title" />
+      <div class="skeleton skeleton-chapter-meta" />
+      <div class="skeleton-chapter-prose">
+        <div class="skeleton skeleton-prose-line" style={{ width: '100%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '100%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '85%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '100%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '60%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '100%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '90%' }} />
+        <div class="skeleton skeleton-prose-line" style={{ width: '75%' }} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SkeletonProfile — skeleton for pseud/profile page loading state.
+ * Matches the layout of PseudPortfolio's profile header.
+ */
+export function SkeletonProfile({ className }: { className?: string }) {
+  return (
+    <div class={`skeleton-profile ${className || ''}`}>
+      <div class="skeleton skeleton-profile-banner" />
+      <div class="skeleton-profile-header">
+        <div class="skeleton skeleton-profile-avatar" />
+        <div class="skeleton-profile-info">
+          <div class="skeleton skeleton-profile-name" />
+          <div class="skeleton skeleton-profile-desc" style={{ width: '80%' }} />
+          <div class="skeleton skeleton-profile-desc" style={{ width: '50%' }} />
+        </div>
+      </div>
+      <div class="skeleton-profile-stats">
+        <div class="skeleton skeleton-profile-stat" />
+        <div class="skeleton skeleton-profile-stat" />
+        <div class="skeleton skeleton-profile-stat" />
+        <div class="skeleton skeleton-profile-stat" />
+      </div>
+    </div>
+  );
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -113,6 +113,35 @@ const isAdmin = isModOrAbove;
     applyTheme();
     document.addEventListener('astro:after-swap', applyTheme);
     </script>
+    <!-- Show skeleton during navigations, hide on page load -->
+    <script is:inline>
+    (function() {
+      // Hide skeleton on page load (content is already painted via SSR)
+      var skeleton = document.querySelector('.page-skeleton');
+      if (skeleton) skeleton.classList.remove('active');
+      var content = document.querySelector('.page-content');
+      if (content) content.style.display = '';
+
+      // Intercept same-origin link clicks to show skeleton during navigation
+      document.addEventListener('click', function(e) {
+        var link = e.target.closest('a[href]');
+        if (!link) return;
+        var href = link.getAttribute('href');
+        if (!href || href.startsWith('#') || href.startsWith('http') || href.startsWith('mailto:') || href.startsWith('tel:')) return;
+        try {
+          var url = new URL(href, location.origin);
+          if (url.origin !== location.origin) return;
+        } catch(ex) { return; }
+        // Show skeleton, hide content for a brief transition feel
+        var skeleton = document.querySelector('.page-skeleton');
+        var content = document.querySelector('.page-content');
+        if (skeleton && content) {
+          skeleton.classList.add('active');
+          content.style.display = 'none';
+        }
+      });
+    })();
+    </script>
     <!-- Adaptive Navigation: swaps between mobile bottom bar, tablet rail, and desktop drawer -->
     <AdaptiveNav
       client:load
@@ -146,6 +175,24 @@ const isAdmin = isModOrAbove;
     margin: 0 auto;
     padding: var(--space-6);
     min-height: calc(100vh - 120px);
+  }
+
+  /* ── Page Skeleton (visible during view transitions/navigation) ── */
+  .page-skeleton {
+    display: none; /* Hidden by default; shown via JS during navigations */
+  }
+  .page-skeleton.active {
+    display: block;
+  }
+  .skeleton-page-title {
+    width: 40%;
+    height: 1.75rem;
+    margin-bottom: var(--space-6);
+  }
+  .skeleton-page-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
   }
 
   .app-footer {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -124,8 +124,14 @@ const isAdmin = isModOrAbove;
 
       // Intercept same-origin link clicks to show skeleton during navigation
       document.addEventListener('click', function(e) {
+        if (e.defaultPrevented) return;
+        if (e.button !== 0) return;
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
         var link = e.target.closest('a[href]');
         if (!link) return;
+        if (link.hasAttribute('download')) return;
+        var target = link.getAttribute('target');
+        if (target && target !== '_self') return;
         var href = link.getAttribute('href');
         if (!href || href.startsWith('#') || href.startsWith('http') || href.startsWith('mailto:') || href.startsWith('tel:')) return;
         try {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@ import { getDrizzle } from '../lib/db';
 import { users, sessions, pseuds } from '../lib/schema';
 import { ROLE_LEVEL, UserRole } from '../lib/types';
 import { THEMES } from '../styles/themes';
+import { ViewTransitions } from 'astro:transitions';
 import BugReport from '../components/BugReport';
 import AdaptiveNav from '../components/AdaptiveNav';
 import { eq, and, gt, sql, asc } from 'drizzle-orm';
@@ -82,6 +83,7 @@ const isAdmin = isModOrAbove;
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <title>{title}</title>
+    <ViewTransitions />
     {themeOverrideCSS && <style>{themeOverrideCSS}</style>}
     <!-- Serialized theme colors for client-side localStorage fallback -->
     <script type="application/json" id="ff-themes-data" set:html={JSON.stringify(Object.fromEntries(Object.entries(THEMES).map(([k, v]) => [k, v.colors])))} />
@@ -89,7 +91,7 @@ const isAdmin = isModOrAbove;
   <body data-theme={userTheme ?? 'obsidian'} data-reading-mode={isReadingMode ? 'true' : undefined}>
     <!-- Inline script to apply localStorage theme ASAP, before paint -->
     <script is:inline>
-    (function() {
+    function applyTheme() {
       try {
         var stored = localStorage.getItem('ff-theme');
         if (stored && stored !== 'obsidian') {
@@ -107,7 +109,9 @@ const isAdmin = isModOrAbove;
           }
         }
       } catch(e) {}
-    })();
+    }
+    applyTheme();
+    document.addEventListener('astro:after-swap', applyTheme);
     </script>
     <!-- Adaptive Navigation: swaps between mobile bottom bar, tablet rail, and desktop drawer -->
     <AdaptiveNav
@@ -117,7 +121,7 @@ const isAdmin = isModOrAbove;
       isAdmin={isAdmin}
       isReadingMode={isReadingMode}
     />
-    <main class="main-content">
+    <main class="main-content" transition:animate="fade">
       <slot />
     </main>
     <footer class="app-footer">

--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -1,0 +1,91 @@
+/**
+ * API Key authentication helpers.
+ *
+ * Key lifecycle:
+ *   - Generation: 32-byte random → hex string. Store SHA-256 hash, show full key ONCE at creation.
+ *   - Revocation: set revoked_at.
+ *
+ * Auth flow:
+ *   - `Authorization: Bearer <key>` header on API requests
+ *   - Hash incoming key → compare to stored hash → load user + key metadata
+ *   - Revoked/expired keys return 401
+ *   - Requests without API key use session auth or remain public (same as now)
+ */
+
+import { getDrizzle } from './db';
+import { apiKeys, users } from './schema';
+import { eq, and, isNull } from 'drizzle-orm';
+
+/** Async SHA-256 hash → hex string using Web Crypto (Cloudflare Workers compatible). */
+export async function sha256Hex(input: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Generate a new API key: returns the plaintext key (shown once) and its hash + prefix for storage. */
+export async function generateApiKey(): Promise<{ plaintext: string; hash: string; prefix: string }> {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const plaintext = 'ffy_' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+  const prefix = plaintext.slice(0, 12); // "ffy_" + first 8 hex chars
+  const hash = await sha256Hex(plaintext);
+  return { plaintext, hash, prefix };
+}
+
+/** Validate a Bearer token against stored API keys. Returns user + key metadata, or null. */
+export async function validateApiKey(d1: D1Database, bearerToken: string): Promise<{
+  user: { id: number; email: string; role: string; approved: number; banned: number };
+  key: { id: number; name: string; rateLimitTier: string };
+} | null> {
+  const hash = await sha256Hex(bearerToken);
+  const db = getDrizzle(d1);
+
+  // Find non-revoked key by hash
+  const keyRow = await db.select()
+    .from(apiKeys)
+    .where(and(eq(apiKeys.keyHash, hash), isNull(apiKeys.revokedAt)))
+    .get();
+
+  if (!keyRow) return null;
+
+  // Load the user
+  const userRow = await db.select({
+    id: users.id,
+    email: users.email,
+    role: users.role,
+    approved: users.approved,
+    banned: users.banned,
+  })
+    .from(users)
+    .where(eq(users.id, keyRow.userId))
+    .get();
+
+  if (!userRow || userRow.banned) return null;
+
+  // Update last_used_at (fire-and-forget)
+  db.update(apiKeys)
+    .set({ lastUsedAt: new Date().toISOString().replace('T', ' ').split('.')[0] })
+    .where(eq(apiKeys.id, keyRow.id))
+    .run()
+    .catch(() => {});
+
+  return {
+    user: userRow,
+    key: {
+      id: keyRow.id,
+      name: keyRow.name,
+      rateLimitTier: keyRow.rateLimitTier,
+    },
+  };
+}
+
+/** Extract Bearer token from Authorization header. Returns null if not present. */
+export function extractBearerToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  if (!auth) return null;
+  const match = auth.match(/^Bearer\s+(ffy_[a-f0-9]+)$/i);
+  return match ? match[1] : null;
+}

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -34,6 +34,30 @@ export function corsHeaders(request: Request): HeadersInit {
 }
 
 /**
+ * Cache-Control header helpers for API responses.
+ *
+ * - 'public'  → public, max-age=300 (5 min) — for publicly visible GET endpoints
+ * - 'private' → private, no-cache             — for auth-gated endpoints (must revalidate per user)
+ * - 'none'    → no-store                       — for frequently changing or sensitive responses
+ *
+ * NOTE: FTS5 Unicode61 stemmer is NOT supported on Cloudflare D1 — the built-in
+ * FTS5 only supports the default and unicode61 tokenizers without custom tokenizers/stemmers.
+ * Skip the stemmer item from issue #99.
+ */
+export function cacheHeaders(
+  type: 'public' | 'private' | 'none' = 'none',
+): Record<string, string> {
+  switch (type) {
+    case 'public':
+      return { 'Cache-Control': 'public, max-age=300' };
+    case 'private':
+      return { 'Cache-Control': 'private, no-cache' };
+    default:
+      return { 'Cache-Control': 'no-store' };
+  }
+}
+
+/**
  * Handles a CORS preflight (OPTIONS) request.
  * Returns a 204 Response if the request is OPTIONS, or `null` otherwise
  * so the caller can continue with normal request processing.

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,33 @@
+import { getDrizzle } from './db';
+import { notifications, notificationPreferences } from './schema';
+import { eq, and } from 'drizzle-orm';
+
+type NotificationType = 'comment_reply' | 'kudos' | 'new_chapter' | 'collection_invite' | 'work_featured' | 'system';
+
+export type { NotificationType };
+
+export async function createNotification(d1: D1Database, params: {
+  userId: number;
+  type: NotificationType;
+  title: string;
+  body?: string;
+  link?: string;
+}): Promise<void> {
+  const db = getDrizzle(d1);
+  // System notifications always go through; others respect preferences
+  if (params.type !== 'system') {
+    const pref = await db.select({ enabled: notificationPreferences.enabled })
+      .from(notificationPreferences)
+      .where(and(eq(notificationPreferences.userId, params.userId), eq(notificationPreferences.type, params.type)))
+      .get();
+    if (pref && !pref.enabled) return; // user opted out
+  }
+  await db.insert(notifications).values({
+    userId: params.userId,
+    type: params.type,
+    title: params.title,
+    body: params.body ?? null,
+    link: params.link ?? null,
+    read: false,
+  });
+}

--- a/src/lib/schema/api-keys.ts
+++ b/src/lib/schema/api-keys.ts
@@ -1,0 +1,19 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { users } from './users';
+
+export const apiKeys = sqliteTable('api_keys', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  keyHash: text('key_hash').notNull(),
+  keyPrefix: text('key_prefix').notNull(),
+  rateLimitTier: text('rate_limit_tier', { enum: ['free', 'pro'] }).notNull().default('free'),
+  lastUsedAt: text('last_used_at'),
+  createdAt: text('created_at').notNull().default('(datetime(\'now\'))'),
+  revokedAt: text('revoked_at'),
+}, (table) => ({
+  userKeyIdx: index('api_keys_user_idx').on(table.userId),
+  keyHashIdx: index('api_keys_key_hash_idx').on(table.keyHash),
+}));

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -8,3 +8,4 @@ export * from './canon';
 export * from './publish-log';
 export * from './moderation';
 export * from './notifications';
+export * from './api-keys';

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -7,3 +7,4 @@ export * from './characters';
 export * from './canon';
 export * from './publish-log';
 export * from './moderation';
+export * from './notifications';

--- a/src/lib/schema/notifications.ts
+++ b/src/lib/schema/notifications.ts
@@ -1,0 +1,32 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { users } from './users';
+
+export const notifications = sqliteTable('notifications', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  type: text('type', {
+    enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'],
+  }).notNull(),
+  title: text('title').notNull(),
+  body: text('body'),
+  link: text('link'),
+  read: integer('read', { mode: 'boolean' }).notNull().default(false),
+  createdAt: text('created_at').notNull().default('(datetime(\'now\'))'),
+}, (table) => ({
+  userUnreadIdx: index('notifications_user_unread_idx').on(table.userId, table.read),
+}));
+
+export const notificationPreferences = sqliteTable('notification_preferences', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  type: text('type', {
+    enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'],
+  }).notNull(),
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+}, (table) => ({
+  userPrefIdx: index('notification_preferences_user_type_idx').on(table.userId, table.type),
+}));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { getDrizzle } from '@/lib/db';
 import { sessions, users } from '@/lib/schema';
 import { and, eq, gt, sql } from 'drizzle-orm';
 import { cspHeaders } from '@/lib/csp';
+import { validateApiKey, extractBearerToken } from '@/lib/api-keys';
 
 // Paths accessible without authentication or approval
 const PUBLIC_PATHS = [
@@ -87,6 +88,31 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Read session cookie
   const cookie = context.request.headers.get('cookie') ?? '';
   const sessionMatch = cookie.match(/session=([a-f0-9]+)/);
+
+  // For API routes, check Bearer token auth as fallback
+  if (!sessionMatch && pathname.startsWith('/api/')) {
+    const bearerToken = extractBearerToken(context.request);
+    if (bearerToken) {
+      const apiKeyResult = await validateApiKey(d1, bearerToken);
+      if (apiKeyResult) {
+        // API key auth successful — set minimal user in locals
+        context.locals.user = apiKeyResult.user;
+        const response = await next();
+        // Add rate limit headers
+        response.headers.set('X-RateLimit-Limit', apiKeyResult.key.rateLimitTier === 'pro' ? '120' : '60');
+        response.headers.set('X-RateLimit-Remaining', '59'); // Simplified — real rate limiting would need a counter
+        const csp = cspHeaders();
+        response.headers.set(Object.keys(csp)[0], Object.values(csp)[0]);
+        return response;
+      }
+      // Invalid/expired API key
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
   if (!sessionMatch) {
     if (isPublishRelated) {
       console.log(JSON.stringify({ t: 'mw_publish', note: 'NO_SESSION_COOKIE — returning 401', pathname }));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,9 @@ const PUBLIC_PATHS = [
   '/feed.xml',
   '/privacy',
   '/terms',
+  '/api',         // API docs index page
+  '/api/docs',    // Interactive API docs (Scalar)
+  '/api/openapi.json', // OpenAPI spec
 ];
 
 const PUBLIC_PATH_PREFIXES = [

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -66,6 +66,7 @@ function isPublicPath(pathname: string): boolean {
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
   const method = context.request.method;
+  const d1 = context.locals.runtime.env.DB as D1Database;
 
   // Publish flow debug logging
   const isPublishRelated = pathname.startsWith('/api/works') && (method === 'PUT' || method === 'POST');
@@ -101,11 +102,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
         // API key auth successful — set minimal user in locals
         context.locals.user = apiKeyResult.user;
         const response = await next();
-        // Add rate limit headers
-        response.headers.set('X-RateLimit-Limit', apiKeyResult.key.rateLimitTier === 'pro' ? '120' : '60');
-        response.headers.set('X-RateLimit-Remaining', '59'); // Simplified — real rate limiting would need a counter
         const csp = cspHeaders();
-        response.headers.set(Object.keys(csp)[0], Object.values(csp)[0]);
+        for (const [header, value] of Object.entries(csp)) {
+          response.headers.set(header, value);
+        }
         return response;
       }
       // Invalid/expired API key
@@ -129,7 +129,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return context.redirect('/login');
   }
 
-  const d1 = context.locals.runtime.env.DB as D1Database;
   const db = getDrizzle(d1);
 
   // Look up session and user
@@ -225,6 +224,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // Continue to the page/API handler, then add CSP headers
   const response = await next();
   const csp = cspHeaders();
-  response.headers.set(Object.keys(csp)[0], Object.values(csp)[0]);
+  for (const [header, value] of Object.entries(csp)) {
+    response.headers.set(header, value);
+  }
   return response;
 });

--- a/src/pages/api/bookmarks/index.ts
+++ b/src/pages/api/bookmarks/index.ts
@@ -2,6 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
+import { cacheHeaders } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import { bookmarks, works } from '@/lib/schema';
 import { eq, and, or, like, gt, lt, gte, lte, sql, desc, asc, count, inArray } from 'drizzle-orm';
@@ -54,7 +55,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     return row;
   });
 
-  return new Response(JSON.stringify({ bookmarks: bookmarksList }), { headers: { 'Content-Type': 'application/json' } });
+  return new Response(JSON.stringify({ bookmarks: bookmarksList }), { headers: { 'Content-Type': 'application/json', ...cacheHeaders('private') } });
 };
 
 export const POST: APIRoute = async ({ request, locals }) => {

--- a/src/pages/api/canon/locations/[id].ts
+++ b/src/pages/api/canon/locations/[id].ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import type { APIRoute } from 'astro';
 import { UserRole, hasRoleLevel } from '@/lib/types';
@@ -97,7 +97,7 @@ export const GET: APIRoute = async ({ params, locals, request }) => {
 
     return new Response(
       JSON.stringify(locRow),
-      { headers: { 'Content-Type': 'application/json', ...cors } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/locations/[id]/history.ts
+++ b/src/pages/api/canon/locations/[id]/history.ts
@@ -1,6 +1,6 @@
 export const prerender = false;
 
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 
 export const OPTIONS: APIRoute = async ({ request }) => {
@@ -31,7 +31,7 @@ export const GET: APIRoute = async ({ params, locals, request }) => {
 
     return new Response(
       JSON.stringify({ edits }),
-      { headers: { 'Content-Type': 'application/json', ...cors } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/locations/index.ts
+++ b/src/pages/api/canon/locations/index.ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import type { APIRoute } from 'astro';
 import { eq, and, sql } from 'drizzle-orm';
@@ -108,7 +108,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
 
     return new Response(
       JSON.stringify({ locations: locs, total, page, limit }),
-      { headers: { 'Content-Type': 'application/json', ...cors } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/lookup.ts
+++ b/src/pages/api/canon/lookup.ts
@@ -1,7 +1,7 @@
 export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import type { APIRoute } from 'astro';
 import { eq, asc } from 'drizzle-orm';
@@ -76,7 +76,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
           fandom_name: entry.tags?.name ?? null,
           works: works || [],
         }),
-        { headers: { 'Content-Type': 'application/json', ...cors } },
+        { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
       );
     } else {
       // location — use raw SQL for self-join + tag join
@@ -134,7 +134,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
           children: children || [],
           works: works || [],
         }),
-        { headers: { 'Content-Type': 'application/json', ...cors } },
+        { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
       );
     }
   } catch (e: any) {

--- a/src/pages/api/canon/lore/[id].ts
+++ b/src/pages/api/canon/lore/[id].ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import type { APIRoute } from 'astro';
 import type { LoreCategory } from '@/lib/types';
@@ -93,7 +93,7 @@ export const GET: APIRoute = async ({ params, locals, request }) => {
 
     return new Response(
       JSON.stringify(result),
-      { headers: { 'Content-Type': 'application/json', ...cors } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/lore/[id]/history.ts
+++ b/src/pages/api/canon/lore/[id]/history.ts
@@ -1,6 +1,6 @@
 export const prerender = false;
 
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 
 export const OPTIONS: APIRoute = async ({ request }) => {
@@ -31,7 +31,7 @@ export const GET: APIRoute = async ({ params, locals, request }) => {
 
     return new Response(
       JSON.stringify({ edits }),
-      { headers: { 'Content-Type': 'application/json', ...cors } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/lore/index.ts
+++ b/src/pages/api/canon/lore/index.ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { markdownToHtml } from '@/lib/markdown';
 import type { APIRoute } from 'astro';
 import type { LoreCategory } from '@/lib/types';
@@ -116,7 +116,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
 
     return new Response(
       JSON.stringify({ entries, total, page, limit }),
-      { headers: { 'Content-Type': 'application/json', ...cors } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/lore/index.ts
+++ b/src/pages/api/canon/lore/index.ts
@@ -116,7 +116,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
 
     return new Response(
       JSON.stringify({ entries, total, page, limit }),
-      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
+      { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('private') } },
     );
   } catch (e: any) {
     return new Response(

--- a/src/pages/api/canon/references/index.ts
+++ b/src/pages/api/canon/references/index.ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 import type { EntityType } from '@/lib/types';
 import { UserRole, hasRoleLevel } from '@/lib/types';
@@ -39,7 +39,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
 
       return new Response(
         JSON.stringify({ works: worksList }),
-        { headers: { 'Content-Type': 'application/json', ...cors } },
+        { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
       );
     }
 
@@ -64,7 +64,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
 
       return new Response(
         JSON.stringify({ entities }),
-        { headers: { 'Content-Type': 'application/json', ...cors } },
+        { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } },
       );
     }
 

--- a/src/pages/api/characters/index.ts
+++ b/src/pages/api/characters/index.ts
@@ -2,7 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { characters, characterGroups, characterAppearances } from '@/lib/schema';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { eq, and, like, sql, isNotNull, desc, asc, count } from 'drizzle-orm';
 import type { APIRoute } from 'astro';
 
@@ -93,6 +93,6 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
   }));
 
   return new Response(JSON.stringify({ characters: charactersResult, total, page, limit }), {
-    headers: { 'Content-Type': 'application/json', ...cors },
+    headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') },
   });
 };

--- a/src/pages/api/collections/[id]/index.ts
+++ b/src/pages/api/collections/[id]/index.ts
@@ -3,6 +3,7 @@ export const prerender = false;
 import { getDrizzle } from '@/lib/db';
 import { requireAuth, checkApproved } from '@/lib/auth';
 import { collections, collectionItems, works, pseuds } from '@/lib/schema';
+import { cacheHeaders } from '@/lib/cors';
 import { eq, and, or, like, gt, lt, gte, lte, sql, desc, asc, count, inArray, isNotNull } from 'drizzle-orm';
 import type { APIRoute } from 'astro';
 
@@ -97,7 +98,7 @@ export const GET: APIRoute = async ({ params, locals }) => {
   }
 
   return new Response(JSON.stringify({ collection, works: workList }), {
-    headers: { 'Content-Type': 'application/json' }
+    headers: { 'Content-Type': 'application/json', ...cacheHeaders('public') }
   });
 };
 

--- a/src/pages/api/docs.astro
+++ b/src/pages/api/docs.astro
@@ -1,0 +1,47 @@
+---
+export const prerender = false;
+import Base from '../../layouts/Base.astro';
+---
+<Base title="API Docs — fanfiction.fyi">
+  <article class="api-docs-page">
+    <h1>Interactive API Documentation</h1>
+    <p class="api-docs__intro">
+      Explore the fanfiction.fyi API interactively. Authenticate with a session cookie or Bearer API key.
+    </p>
+    <div id="scalar-api-docs"></div>
+  </article>
+</Base>
+
+<style is:global>
+  .api-docs-page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: var(--space-6) var(--space-4);
+  }
+
+  .api-docs-page h1 {
+    font: var(--md-sys-typescale-headline-large);
+    color: var(--md-sys-color-on-surface);
+    margin-bottom: var(--space-2);
+  }
+
+  .api-docs__intro {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface-variant);
+    margin-bottom: var(--space-6);
+  }
+
+  /* Override Scalar's default styles to match our theme */
+  .api-docs-page [data-testid="scalar-api-reference"] {
+    --scalar-font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+</style>
+
+<script define:vars={{}}">
+  // Load Scalar API reference dynamically
+  const script = document.createElement('script');
+  script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1';
+  script.setAttribute('data-url', '/api/openapi.json');
+  script.setAttribute('data-standalone', 'true');
+  document.getElementById('scalar-api-docs')?.appendChild(script);
+</script>

--- a/src/pages/api/docs.astro
+++ b/src/pages/api/docs.astro
@@ -40,7 +40,7 @@ import Base from '../../layouts/Base.astro';
 <script define:vars={{}}">
   // Load Scalar API reference dynamically
   const script = document.createElement('script');
-  script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1';
+  script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.55.3';
   script.setAttribute('data-url', '/api/openapi.json');
   script.setAttribute('data-standalone', 'true');
   document.getElementById('scalar-api-docs')?.appendChild(script);

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -6,11 +6,16 @@ import Base from '../../layouts/Base.astro';
 <Base title="API Documentation — fanfiction.fyi">
   <article class="api-docs">
     <h1>API Documentation</h1>
+    <div class="api-docs__links">
+      <a href="/api/openapi.json" class="api-docs__spec-link">OpenAPI 3.1 Spec (JSON)</a>
+      <a href="/api/docs" class="api-docs__spec-link">Interactive Docs (Scalar)</a>
+    </div>
     <p class="api-docs__intro">
-      The fanfiction.fyi read-only API provides JSON access to works, tags,
-      search, collections, and comments. All public endpoints support
+      The fanfiction.fyi API provides JSON access to works, tags,
+      search, collections, comments, and more. Public endpoints support
       <code>GET</code> and <code>OPTIONS</code> (CORS preflight). Cross-origin
-      requests are accepted from any origin.
+      requests are accepted from any origin. Authenticated endpoints require a
+      session cookie or <code>Authorization: Bearer ffy_…</code> API key.
     </p>
 
     <!-- Works -->
@@ -217,6 +222,26 @@ import Base from '../../layouts/Base.astro';
     font: var(--md-sys-typescale-headline-large);
     color: var(--md-sys-color-on-surface);
     margin: 0 0 var(--space-4);
+  }
+
+  .api-docs__links {
+    display: flex;
+    gap: var(--space-4);
+    margin-bottom: var(--space-4);
+  }
+
+  .api-docs__spec-link {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    transition: background 0.15s;
+  }
+
+  .api-docs__spec-link:hover {
+    background: var(--md-sys-color-surface-container-high);
   }
 
   .api-docs__intro {

--- a/src/pages/api/notifications/[id].ts
+++ b/src/pages/api/notifications/[id].ts
@@ -1,0 +1,31 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { notifications } from '@/lib/schema';
+import { eq, and } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+export const DELETE: APIRoute = async ({ params, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const notifId = Number(params.id);
+  if (!notifId || isNaN(notifId)) {
+    return new Response(JSON.stringify({ error: 'Invalid notification ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  // Only the notification owner can delete
+  const notif = await db.select().from(notifications).where(and(eq(notifications.id, notifId), eq(notifications.userId, userId))).get();
+  if (!notif) {
+    return new Response(JSON.stringify({ error: 'Notification not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  await db.delete(notifications).where(and(eq(notifications.id, notifId), eq(notifications.userId, userId)));
+
+  return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -1,0 +1,54 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { notifications } from '@/lib/schema';
+import { eq, and, desc, sql, count } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async ({ url, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const page = Math.max(1, Number(url.searchParams.get('page')) || 1);
+  const limit = Math.min(Math.max(Number(url.searchParams.get('limit')) || 20, 1), 50);
+  const offset = (page - 1) * limit;
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  // Get unread count
+  const unreadResult = await db.select({ cnt: count() })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), eq(notifications.read, false)))
+    .get();
+  const unreadCount = unreadResult?.cnt ?? 0;
+
+  // Get total count
+  const totalResult = await db.select({ cnt: count() })
+    .from(notifications)
+    .where(eq(notifications.userId, userId))
+    .get();
+  const total = totalResult?.cnt ?? 0;
+
+  // Get notifications for this page
+  const notifRows = await db.select()
+    .from(notifications)
+    .where(eq(notifications.userId, userId))
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  return new Response(JSON.stringify({
+    notifications: notifRows,
+    total,
+    unreadCount,
+  }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Unread-Count': String(unreadCount),
+    },
+  });
+};

--- a/src/pages/api/notifications/preferences.ts
+++ b/src/pages/api/notifications/preferences.ts
@@ -1,0 +1,76 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { notificationPreferences } from '@/lib/schema';
+import { eq, and } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+type NotificationType = 'comment_reply' | 'kudos' | 'new_chapter' | 'collection_invite' | 'work_featured' | 'system';
+
+const ALL_TYPES: NotificationType[] = ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'];
+
+export const GET: APIRoute = async ({ locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  // Get all preference rows for this user
+  const prefs = await db.select()
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.userId, userId));
+
+  // Build result with defaults for missing types
+  const prefMap = new Map(prefs.map(p => [p.type, p.enabled]));
+  const result = ALL_TYPES.map(type => ({
+    type,
+    enabled: prefMap.has(type) ? !!prefMap.get(type) : true,
+  }));
+
+  return new Response(JSON.stringify({ preferences: result }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+
+export const PUT: APIRoute = async ({ locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const { type, enabled } = body || {};
+  if (!type || !ALL_TYPES.includes(type)) {
+    return new Response(JSON.stringify({ error: 'Invalid notification type' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (typeof enabled !== 'boolean') {
+    return new Response(JSON.stringify({ error: 'enabled must be a boolean' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  // Upsert: check if preference exists
+  const existing = await db.select()
+    .from(notificationPreferences)
+    .where(and(eq(notificationPreferences.userId, userId), eq(notificationPreferences.type, type)))
+    .get();
+
+  if (existing) {
+    await db.update(notificationPreferences)
+      .set({ enabled })
+      .where(and(eq(notificationPreferences.userId, userId), eq(notificationPreferences.type, type)));
+  } else {
+    await db.insert(notificationPreferences).values({
+      userId,
+      type,
+      enabled,
+    });
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/notifications/read.ts
+++ b/src/pages/api/notifications/read.ts
@@ -1,0 +1,33 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { notifications } from '@/lib/schema';
+import { eq, and } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+export const PUT: APIRoute = async ({ locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  let body: any;
+  try { body = await request.json(); } catch { body = {}; }
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  if (body?.id) {
+    // Mark a single notification as read (only if it belongs to this user)
+    const notif = await db.select().from(notifications).where(and(eq(notifications.id, body.id), eq(notifications.userId, userId))).get();
+    if (!notif) {
+      return new Response(JSON.stringify({ error: 'Notification not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+    }
+    await db.update(notifications).set({ read: true }).where(and(eq(notifications.id, body.id), eq(notifications.userId, userId)));
+  } else {
+    // Mark all notifications as read for this user
+    await db.update(notifications).set({ read: true }).where(and(eq(notifications.userId, userId), eq(notifications.read, false)));
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/openapi.json.ts
+++ b/src/pages/api/openapi.json.ts
@@ -1,0 +1,385 @@
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+
+const spec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'fanfiction.fyi API',
+    version: '1.0.0',
+    description: 'The fanfiction.fyi read/write API provides JSON access to works, tags, search, collections, comments, and more. Public read endpoints support CORS. Authenticated endpoints require a session cookie or Bearer API key.',
+    contact: { url: 'https://fanfiction.fyi' },
+    license: { name: 'Proprietary' },
+  },
+  servers: [
+    { url: 'https://fanfiction.fyi', description: 'Production' },
+  ],
+  security: [
+    { cookieAuth: [] },
+    { bearerAuth: [] },
+  ],
+  paths: {
+    '/api/works': {
+      get: {
+        summary: 'List published works',
+        tags: ['Works'],
+        parameters: [
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 }, description: 'Page number' },
+          { name: 'limit', in: 'query', schema: { type: 'integer', default: 20, maximum: 100 }, description: 'Results per page' },
+          { name: 'tag_type', in: 'query', schema: { type: 'string' }, description: 'Filter by tag type (fandom, character, etc.)' },
+          { name: 'tag_name', in: 'query', schema: { type: 'string' }, description: 'Filter by tag name (substring match)' },
+        ],
+        responses: {
+          '200': { description: 'List of works' },
+        },
+      },
+    },
+    '/api/works/{id}': {
+      get: {
+        summary: 'Get a work by ID',
+        tags: ['Works'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Work details' }, '404': { description: 'Work not found' } },
+      },
+    },
+    '/api/works/{id}/chapters': {
+      get: {
+        summary: 'List chapters for a work',
+        tags: ['Works'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Chapter list' } },
+      },
+    },
+    '/api/works/{id}/chapters/{chapterId}': {
+      get: {
+        summary: 'Get a chapter by ID',
+        tags: ['Works'],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+          { name: 'chapterId', in: 'path', required: true, schema: { type: 'integer' } },
+        ],
+        responses: { '200': { description: 'Chapter content' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/works/{id}/comments': {
+      get: {
+        summary: 'List comments on a work',
+        tags: ['Comments'],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
+        ],
+        responses: { '200': { description: 'Comment list' } },
+      },
+      post: {
+        summary: 'Post a comment',
+        tags: ['Comments'],
+        security: [{ cookieAuth: [] }, { bearerAuth: [] }],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { type: 'object', required: ['body'], properties: { body: { type: 'string' }, parent_id: { type: 'integer' } } } } },
+        },
+        responses: { '201': { description: 'Comment created' }, '401': { description: 'Unauthorized' } },
+      },
+    },
+    '/api/works/{id}/lineage': {
+      get: {
+        summary: 'Get chapter lineage (tree structure)',
+        tags: ['Works'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Lineage tree' } },
+      },
+    },
+    '/api/works/{id}/relations': {
+      get: {
+        summary: 'Get work relationships',
+        tags: ['Works'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Relationships' } },
+      },
+    },
+    '/api/works/{id}/export': {
+      get: {
+        summary: 'Export a work as EPUB or TXT',
+        tags: ['Works'],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+          { name: 'format', in: 'query', schema: { type: 'string', enum: ['epub', 'txt'] }, description: 'Export format' },
+        ],
+        responses: { '200': { description: 'Exported file' } },
+      },
+    },
+    '/api/search': {
+      get: {
+        summary: 'Full-text search',
+        tags: ['Search'],
+        parameters: [
+          { name: 'q', in: 'query', required: true, schema: { type: 'string' }, description: 'Search query' },
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
+          { name: 'limit', in: 'query', schema: { type: 'integer', default: 20 } },
+          { name: 'tag_type', in: 'query', schema: { type: 'string' } },
+          { name: 'status', in: 'query', schema: { type: 'string', enum: ['complete', 'wip'] } },
+        ],
+        responses: { '200': { description: 'Search results' } },
+      },
+    },
+    '/api/tags/browse': {
+      get: {
+        summary: 'Browse tags by type',
+        tags: ['Tags'],
+        parameters: [
+          { name: 'type', in: 'query', schema: { type: 'string', enum: ['fandom', 'character', 'relationship', 'freeform', 'rating', 'warning', 'category'] } },
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
+        ],
+        responses: { '200': { description: 'Tags list' } },
+      },
+    },
+    '/api/tags': {
+      get: {
+        summary: 'List all tags',
+        tags: ['Tags'],
+        parameters: [{ name: 'q', in: 'query', schema: { type: 'string' }, description: 'Filter by name' }],
+        responses: { '200': { description: 'Tags list' } },
+      },
+    },
+    '/api/characters': {
+      get: {
+        summary: 'List characters',
+        tags: ['Characters'],
+        parameters: [{ name: 'page', in: 'query', schema: { type: 'integer', default: 1 } }],
+        responses: { '200': { description: 'Characters list' } },
+      },
+    },
+    '/api/characters/{id}': {
+      get: {
+        summary: 'Get character by ID',
+        tags: ['Characters'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Character details' } },
+      },
+    },
+    '/api/pseuds/{id}/public': {
+      get: {
+        summary: 'Get public pseud profile',
+        tags: ['Pseuds'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Pseud profile' } },
+      },
+    },
+    '/api/pseuds': {
+      get: {
+        summary: 'List pseuds (authors)',
+        tags: ['Pseuds'],
+        responses: { '200': { description: 'Pseuds list' } },
+      },
+    },
+    '/api/collections/{id}': {
+      get: {
+        summary: 'Get collection by ID',
+        tags: ['Collections'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Collection details' } },
+      },
+    },
+    '/api/collections': {
+      get: {
+        summary: 'List collections',
+        tags: ['Collections'],
+        responses: { '200': { description: 'Collections list' } },
+      },
+    },
+    '/api/series/{id}': {
+      get: {
+        summary: 'Get series by ID',
+        tags: ['Series'],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Series details' } },
+      },
+    },
+    '/api/series': {
+      get: {
+        summary: 'List series',
+        tags: ['Series'],
+        responses: { '200': { description: 'Series list' } },
+      },
+    },
+    '/api/canon/lore': {
+      get: {
+        summary: 'List canon lore entries',
+        tags: ['Canon'],
+        parameters: [
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
+          { name: 'search', in: 'query', schema: { type: 'string' } },
+        ],
+        responses: { '200': { description: 'Lore entries' } },
+      },
+    },
+    '/api/canon/locations': {
+      get: {
+        summary: 'List canon locations',
+        tags: ['Canon'],
+        responses: { '200': { description: 'Locations' } },
+      },
+    },
+    '/api/canon/references': {
+      get: {
+        summary: 'List canon references',
+        tags: ['Canon'],
+        responses: { '200': { description: 'References' } },
+      },
+    },
+    '/api/notifications': {
+      get: {
+        summary: 'List notifications',
+        tags: ['Notifications'],
+        security: [{ cookieAuth: [] }, { bearerAuth: [] }],
+        parameters: [
+          { name: 'page', in: 'query', schema: { type: 'integer', default: 1 } },
+          { name: 'limit', in: 'query', schema: { type: 'integer', default: 20, maximum: 50 } },
+        ],
+        responses: { '200': { description: 'Notifications list with unread count' }, '401': { description: 'Unauthorized' } },
+      },
+    },
+    '/api/notifications/read': {
+      put: {
+        summary: 'Mark notifications as read',
+        tags: ['Notifications'],
+        security: [{ cookieAuth: [] }, { bearerAuth: [] }],
+        requestBody: {
+          content: { 'application/json': { schema: { type: 'object', properties: { id: { type: 'integer', description: 'Notification ID, or omit to mark all as read' } } } } },
+        },
+        responses: { '200': { description: 'Success' }, '401': { description: 'Unauthorized' } },
+      },
+    },
+    '/api/notifications/preferences': {
+      get: {
+        summary: 'Get notification preferences',
+        tags: ['Notifications'],
+        security: [{ cookieAuth: [] }, { bearerAuth: [] }],
+        responses: { '200': { description: 'Preferences list' }, '401': { description: 'Unauthorized' } },
+      },
+      put: {
+        summary: 'Update notification preference',
+        tags: ['Notifications'],
+        security: [{ cookieAuth: [] }, { bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { type: 'object', required: ['type', 'enabled'], properties: { type: { type: 'string', enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'] }, enabled: { type: 'boolean' } } } } },
+        },
+        responses: { '200': { description: 'Success' }, '401': { description: 'Unauthorized' } },
+      },
+    },
+    '/api/user/keys': {
+      get: {
+        summary: 'List API keys',
+        tags: ['API Keys'],
+        security: [{ cookieAuth: [] }],
+        responses: { '200': { description: 'API keys list' }, '401': { description: 'Unauthorized' } },
+      },
+      post: {
+        summary: 'Create a new API key',
+        tags: ['API Keys'],
+        security: [{ cookieAuth: [] }],
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { type: 'object', required: ['name'], properties: { name: { type: 'string', maxLength: 64 } } } } },
+        },
+        responses: { '201': { description: 'Key created — plaintext key shown once' }, '400': { description: 'Validation error' }, '401': { description: 'Unauthorized' } },
+      },
+    },
+    '/api/user/keys/{id}': {
+      delete: {
+        summary: 'Revoke an API key',
+        tags: ['API Keys'],
+        security: [{ cookieAuth: [] }],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+        responses: { '200': { description: 'Key revoked' }, '404': { description: 'Key not found' }, '401': { description: 'Unauthorized' } },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      cookieAuth: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: 'session',
+        description: 'Session cookie obtained from login',
+      },
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'API key starting with ffy_ — obtain from /settings > API Keys',
+      },
+    },
+    schemas: {
+      Work: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          title: { type: 'string' },
+          summary: { type: 'string' },
+          word_count: { type: 'integer' },
+          published_at: { type: 'string', format: 'date-time' },
+          updated_at: { type: 'string', format: 'date-time' },
+          language: { type: 'string' },
+          complete: { type: 'integer' },
+          tags: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, type: { type: 'string' } } } },
+          pseuds: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, role: { type: 'string' } } } },
+        },
+      },
+      Tag: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          name: { type: 'string' },
+          type: { type: 'string', enum: ['fandom', 'character', 'relationship', 'freeform', 'rating', 'warning', 'category'] },
+        },
+      },
+      Collection: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          name: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          privacy: { type: 'string' },
+        },
+      },
+      Notification: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          type: { type: 'string', enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'] },
+          title: { type: 'string' },
+          body: { type: 'string' },
+          link: { type: 'string' },
+          read: { type: 'boolean' },
+          created_at: { type: 'string', format: 'date-time' },
+        },
+      },
+      ApiKey: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          name: { type: 'string' },
+          keyPrefix: { type: 'string' },
+          rateLimitTier: { type: 'string', enum: ['free', 'pro'] },
+          lastUsedAt: { type: 'string', format: 'date-time', nullable: true },
+          createdAt: { type: 'string', format: 'date-time' },
+        },
+      },
+    },
+  },
+};
+
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify(spec, null, 2), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/api/pseuds/[id]/public.ts
+++ b/src/pages/api/pseuds/[id]/public.ts
@@ -3,6 +3,7 @@ export const prerender = false;
 import { getDrizzle } from '@/lib/db';
 import { pseuds, works, creatorships, tags, taggings, kudos, chapters } from '@/lib/schema';
 import { eq, sql, and, isNotNull, inArray, desc } from 'drizzle-orm';
+import { cacheHeaders } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 
 /**
@@ -226,5 +227,5 @@ export const GET: APIRoute = async ({ locals, params }) => {
       wordCountTimeline,
     },
     activity: activityDates,
-  }), { headers: { 'Content-Type': 'application/json' } });
+  }), { headers: { 'Content-Type': 'application/json', ...cacheHeaders('public') } });
 };

--- a/src/pages/api/readings/index.ts
+++ b/src/pages/api/readings/index.ts
@@ -2,6 +2,7 @@ export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
+import { cacheHeaders } from '@/lib/cors';
 import { readings, works } from '@/lib/schema';
 import { eq, desc, sql } from 'drizzle-orm';
 import type { APIRoute } from 'astro';
@@ -47,6 +48,6 @@ export const GET: APIRoute = async ({ request, locals }) => {
   }));
 
   return new Response(JSON.stringify(enriched), {
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...cacheHeaders('private') },
   });
 };

--- a/src/pages/api/search/index.ts
+++ b/src/pages/api/search/index.ts
@@ -3,7 +3,7 @@ export const prerender = false;
 import { getDrizzle } from '@/lib/db';
 import { tags, taggings, pseuds, creatorships, works } from '@/lib/schema';
 import { inArray, sql, isNotNull, and, eq } from 'drizzle-orm';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import type { APIRoute } from 'astro';
 
 export const OPTIONS: APIRoute = async ({ request }) => {
@@ -133,8 +133,11 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
     }
   }
 
+  // Search results change frequently — use 60s (1 min) cache
+  const searchCache: Record<string, string> = { 'Cache-Control': 'public, max-age=60' };
+
   return new Response(
     JSON.stringify({ results, total, page }),
-    { headers: { 'Content-Type': 'application/json', ...cors } }
+    { headers: { 'Content-Type': 'application/json', ...cors, ...searchCache } }
   );
 };

--- a/src/pages/api/tags/browse.ts
+++ b/src/pages/api/tags/browse.ts
@@ -1,7 +1,7 @@
 export const prerender = false;
 
 import { getDrizzle } from '@/lib/db';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { sql } from 'drizzle-orm';
 import type { APIRoute } from 'astro';
 
@@ -37,6 +37,6 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
   `);
 
   return new Response(JSON.stringify(tags), {
-    headers: { 'Content-Type': 'application/json', ...cors },
+    headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') },
   });
 };

--- a/src/pages/api/user/keys/[id].ts
+++ b/src/pages/api/user/keys/[id].ts
@@ -1,0 +1,42 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { apiKeys } from '@/lib/schema';
+import { eq, and, isNull } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+/** DELETE /api/user/keys/[id] — revoke an API key */
+export const DELETE: APIRoute = async ({ params, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const keyId = Number(params.id);
+  if (!keyId || isNaN(keyId)) {
+    return new Response(JSON.stringify({ error: 'Invalid key ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  // Only allow revoking own keys that are not already revoked
+  const key = await db.select()
+    .from(apiKeys)
+    .where(and(eq(apiKeys.id, keyId), eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)))
+    .get();
+
+  if (!key) {
+    return new Response(JSON.stringify({ error: 'Key not found or already revoked' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const now = new Date().toISOString().replace('T', ' ').split('.')[0];
+  await db.update(apiKeys)
+    .set({ revokedAt: now })
+    .where(eq(apiKeys.id, keyId));
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/user/keys/index.ts
+++ b/src/pages/api/user/keys/index.ts
@@ -1,0 +1,88 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { requireAuth } from '@/lib/auth';
+import { apiKeys } from '@/lib/schema';
+import { generateApiKey } from '@/lib/api-keys';
+import { eq, and, isNull, desc } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+/** GET /api/user/keys — list all non-revoked API keys for the current user */
+export const GET: APIRoute = async ({ locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+
+  const keys = await db.select({
+    id: apiKeys.id,
+    name: apiKeys.name,
+    keyPrefix: apiKeys.keyPrefix,
+    rateLimitTier: apiKeys.rateLimitTier,
+    lastUsedAt: apiKeys.lastUsedAt,
+    createdAt: apiKeys.createdAt,
+  })
+    .from(apiKeys)
+    .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)))
+    .orderBy(desc(apiKeys.createdAt));
+
+  return new Response(JSON.stringify({ keys }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+/** POST /api/user/keys — create a new API key */
+export const POST: APIRoute = async ({ locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  if (!auth) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const name = (body?.name || '').trim();
+  if (!name || name.length > 64) {
+    return new Response(JSON.stringify({ error: 'Key name is required (max 64 characters)' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Limit: max 5 active keys per user
+  const db = getDrizzle(d1);
+  const userId = auth.user.id;
+  const existing = await db.select({ id: apiKeys.id })
+    .from(apiKeys)
+    .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)))
+    .all();
+
+  if (existing.length >= 5) {
+    return new Response(JSON.stringify({ error: 'Maximum of 5 active API keys reached. Revoke an existing key first.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Generate key
+  const { plaintext, hash, prefix } = await generateApiKey();
+
+  await db.insert(apiKeys).values({
+    userId,
+    name,
+    keyHash: hash,
+    keyPrefix: prefix,
+    rateLimitTier: 'free',
+  });
+
+  // Return the plaintext key ONCE — this is the only time the user sees it
+  return new Response(JSON.stringify({
+    key: {
+      name,
+      prefix,
+      secret: plaintext, // Full key — shown once only
+      rateLimitTier: 'free',
+    },
+  }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/works/index.ts
+++ b/src/pages/api/works/index.ts
@@ -3,7 +3,7 @@ export const prerender = false;
 import { getDrizzle } from '@/lib/db';
 import { getAuth } from '@/lib/auth';
 import { markdownToHtml } from '@/lib/markdown';
-import { corsHeaders, handleCors } from '@/lib/cors';
+import { corsHeaders, handleCors, cacheHeaders } from '@/lib/cors';
 import { checkRateLimit, recordFailedAttempt } from '@/lib/rate-limit';
 import { works, chapters, creatorships, tags, taggings, pseuds } from '@/lib/schema';
 import { eq, and, or, like, gt, lt, gte, lte, sql, desc, asc, count, inArray, isNotNull, isNull } from 'drizzle-orm';
@@ -61,7 +61,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
       (w as any).pseuds = wPseuds;
     }
 
-    return new Response(JSON.stringify(workList), { headers: { 'Content-Type': 'application/json', ...cors } });
+    return new Response(JSON.stringify(workList), { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } });
   }
 
   // No tag filter — simple query
@@ -89,7 +89,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
     (w as any).pseuds = wPseuds;
   }
 
-  return new Response(JSON.stringify(workList), { headers: { 'Content-Type': 'application/json', ...cors } });
+  return new Response(JSON.stringify(workList), { headers: { 'Content-Type': 'application/json', ...cors, ...cacheHeaders('public') } });
 };
 
 export const POST: APIRoute = async ({ request, locals }) => {

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -149,6 +149,26 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
         <p class="form-success" id="notif-prefs-success"></p>
       </div>
     </details>
+
+    <!-- API Keys -->
+    <details class="settings-section">
+      <summary class="section-title">API Keys</summary>
+      <div class="section-body">
+        <p class="current-value">Manage API keys for programmatic access to the fanfiction.fyi API.</p>
+        <div id="api-keys-list" class="api-keys-list"></div>
+        <div class="api-key-create">
+          <label class="settings-label" for="api-key-name">Key Name</label>
+          <input type="text" id="api-key-name" placeholder="e.g. MyBot" maxlength="64" class="settings-input" />
+          <button type="button" id="api-key-create-btn" class="settings-btn">Create Key</button>
+        </div>
+        <p class="form-error" id="api-key-error"></p>
+        <div id="api-key-secret" class="api-key-secret" style="display:none">
+          <p class="form-success">Key created! Copy it now — it won't be shown again.</p>
+          <code id="api-key-secret-value" class="api-key-secret-value"></code>
+          <button type="button" id="api-key-copy-btn" class="settings-btn settings-btn--secondary">Copy to Clipboard</button>
+        </div>
+      </div>
+    </details>
   </section>
 </Base>
 
@@ -383,6 +403,83 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
     background: var(--md-sys-color-on-primary);
   }
 
+  .api-keys-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+  }
+
+  .api-key-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    background: var(--md-sys-color-surface-container-lowest);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+  }
+
+  .api-key-info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .api-key-name {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .api-key-meta {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-outline);
+  }
+
+  .api-key-revoke {
+    font: var(--md-sys-typescale-label-small);
+    color: var(--md-sys-color-error);
+    background: none;
+    border: 1px solid var(--md-sys-color-error);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-1) var(--space-2);
+    cursor: pointer;
+  }
+
+  .api-key-revoke:hover {
+    background: var(--md-sys-color-error-container);
+    color: var(--md-sys-color-on-error-container);
+  }
+
+  .api-key-create {
+    display: flex;
+    gap: var(--space-2);
+    align-items: flex-end;
+    margin-bottom: var(--space-2);
+  }
+
+  .api-key-create .settings-input {
+    flex: 1;
+  }
+
+  .api-key-secret-value {
+    display: block;
+    background: var(--md-sys-color-surface-container-highest);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-2) var(--space-3);
+    font-family: var(--font-mono);
+    font-size: 0.875rem;
+    word-break: break-all;
+    margin-bottom: var(--space-2);
+  }
+
+  .settings-btn--secondary {
+    background: var(--md-sys-color-surface-container-highest);
+    color: var(--md-sys-color-on-surface-variant);
+    border: 1px solid var(--md-sys-color-outline-variant);
+  }
+
   @media (max-width: 600px) {
     .settings-page {
       padding: var(--space-4) var(--space-2);
@@ -391,6 +488,10 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
       flex-direction: column;
       align-items: flex-start;
       gap: var(--space-2);
+    }
+    .api-key-create {
+      flex-direction: column;
+      align-items: stretch;
     }
   }
 </style>
@@ -602,4 +703,94 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
   }
 
   loadNotifPrefs();
+
+  // API Keys
+  async function loadApiKeys() {
+    const container = document.getElementById('api-keys-list');
+    if (!container) return;
+    try {
+      const res = await fetch('/api/user/keys');
+      if (!res.ok) return;
+      const data = await res.json();
+      container.innerHTML = '';
+      for (const key of data.keys || []) {
+        const row = document.createElement('div');
+        row.className = 'api-key-row';
+        const info = document.createElement('div');
+        info.className = 'api-key-info';
+        const name = document.createElement('span');
+        name.className = 'api-key-name';
+        name.textContent = key.name;
+        const meta = document.createElement('span');
+        meta.className = 'api-key-meta';
+        meta.textContent = `${key.keyPrefix}… • Created ${new Date(key.created_at + (key.created_at.includes('Z') ? '' : 'Z')).toLocaleDateString()}` + (key.last_used_at ? ` • Last used ${new Date(key.last_used_at + 'Z').toLocaleDateString()}` : '');
+        info.appendChild(name);
+        info.appendChild(meta);
+        const revokeBtn = document.createElement('button');
+        revokeBtn.className = 'api-key-revoke';
+        revokeBtn.textContent = 'Revoke';
+        revokeBtn.addEventListener('click', async () => {
+          if (!confirm(`Revoke API key "${key.name}"? This cannot be undone.`)) return;
+          revokeBtn.disabled = true;
+          try {
+            const delRes = await fetch(`/api/user/keys/${key.id}`, { method: 'DELETE' });
+            if (delRes.ok) {
+              row.remove();
+            }
+          } catch { /* ignore */ }
+          revokeBtn.disabled = false;
+        });
+        row.appendChild(info);
+        row.appendChild(revokeBtn);
+        container.appendChild(row);
+      }
+    } catch { /* ignore */ }
+  }
+
+  loadApiKeys();
+
+  // API key creation
+  const createKeyBtn = document.getElementById('api-key-create-btn');
+  const keyNameInput = document.getElementById('api-key-name') as HTMLInputElement;
+  const keyError = document.getElementById('api-key-error')!;
+  const keySecretDiv = document.getElementById('api-key-secret')!;
+  const keySecretValue = document.getElementById('api-key-secret-value')!;
+  const copyBtn = document.getElementById('api-key-copy-btn')!;
+
+  createKeyBtn?.addEventListener('click', async () => {
+    const name = keyNameInput?.value?.trim();
+    if (!name) {
+      keyError.textContent = 'Please enter a key name.';
+      return;
+    }
+    keyError.textContent = '';
+    createKeyBtn.setAttribute('disabled', 'true');
+    try {
+      const res = await fetch('/api/user/keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        keyError.textContent = data.error || 'Failed to create key.';
+        return;
+      }
+      keyNameInput.value = '';
+      keySecretValue.textContent = data.key.secret;
+      keySecretDiv.style.display = 'block';
+      loadApiKeys();
+    } catch {
+      keyError.textContent = 'Network error. Please try again.';
+    }
+    createKeyBtn.removeAttribute('disabled');
+  });
+
+  copyBtn?.addEventListener('click', () => {
+    const secret = keySecretValue.textContent || '';
+    navigator.clipboard.writeText(secret).then(() => {
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyBtn.textContent = 'Copy to Clipboard'; }, 2000);
+    });
+  });
 </script>

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -139,6 +139,16 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
         </form>
       </div>
     </details>
+
+    <!-- Notification Preferences -->
+    <details class="settings-section">
+      <summary class="section-title">Notification Preferences</summary>
+      <div class="section-body">
+        <p class="current-value">Choose which notifications you'd like to receive.</p>
+        <div id="notif-prefs-list" class="notif-prefs-list"></div>
+        <p class="form-success" id="notif-prefs-success"></p>
+      </div>
+    </details>
   </section>
 </Base>
 
@@ -317,6 +327,62 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
     gap: var(--space-2);
   }
 
+  .notif-prefs-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+  }
+
+  .notif-pref-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    background: var(--md-sys-color-surface-container-lowest);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+  }
+
+  .notif-pref-label {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .notif-pref-toggle {
+    position: relative;
+    width: 52px;
+    height: 32px;
+    appearance: none;
+    background: var(--md-sys-color-surface-container-highest);
+    border: 2px solid var(--md-sys-color-outline);
+    border-radius: 16px;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+  }
+
+  .notif-pref-toggle:checked {
+    background: var(--md-sys-color-primary);
+    border-color: var(--md-sys-color-primary);
+  }
+
+  .notif-pref-toggle::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--md-sys-color-outline);
+    transition: transform 0.2s, background 0.2s;
+  }
+
+  .notif-pref-toggle:checked::before {
+    transform: translateX(20px);
+    background: var(--md-sys-color-on-primary);
+  }
+
   @media (max-width: 600px) {
     .settings-page {
       padding: var(--space-4) var(--space-2);
@@ -484,4 +550,56 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
       err.textContent = 'Network error. Please try again.';
     }
   });
+
+  // Notification Preferences
+  const NOTIF_TYPE_LABELS: Record<string, string> = {
+    comment_reply: 'Comment Replies',
+    kudos: 'Kudos',
+    new_chapter: 'New Chapters',
+    collection_invite: 'Collection Invites',
+    work_featured: 'Work Featured',
+    system: 'System Messages',
+  };
+
+  async function loadNotifPrefs() {
+    const container = document.getElementById('notif-prefs-list');
+    if (!container) return;
+    try {
+      const res = await fetch('/api/notifications/preferences');
+      if (!res.ok) return;
+      const data = await res.json();
+      container.innerHTML = '';
+      for (const pref of data.preferences) {
+        const row = document.createElement('div');
+        row.className = 'notif-pref-row';
+        const label = document.createElement('span');
+        label.className = 'notif-pref-label';
+        label.textContent = NOTIF_TYPE_LABELS[pref.type] || pref.type;
+        const toggle = document.createElement('input');
+        toggle.type = 'checkbox';
+        toggle.className = 'notif-pref-toggle';
+        toggle.checked = pref.enabled;
+        toggle.setAttribute('aria-label', `${NOTIF_TYPE_LABELS[pref.type] || pref.type} notifications`);
+        toggle.addEventListener('change', async () => {
+          try {
+            const updateRes = await fetch('/api/notifications/preferences', {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ type: pref.type, enabled: toggle.checked }),
+            });
+            const succ = document.getElementById('notif-prefs-success')!;
+            if (updateRes.ok) {
+              succ.textContent = 'Notification preferences updated.';
+              setTimeout(() => { succ.textContent = ''; }, 2000);
+            }
+          } catch { /* ignore */ }
+        });
+        row.appendChild(label);
+        row.appendChild(toggle);
+        container.appendChild(row);
+      }
+    } catch { /* ignore */ }
+  }
+
+  loadNotifPrefs();
 </script>

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -1192,7 +1192,7 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
         </div>
       </div>
 
-      <div class="reading-prose">
+      <div class="reading-prose" data-chapter-content>
         {currentChapterData.content_html && <div set:html={resolveCanonLinks(currentChapterData.content_html, canonIndex)} />}
         {!currentChapterData.content_html && currentChapterData.content_md && <div set:html={resolveCanonLinks(markdownToHtml(currentChapterData.content_md), canonIndex)} />}
         {!currentChapterData.content_html && !currentChapterData.content_md && <p>No content available for this chapter.</p>}

--- a/src/styles/adaptive-nav.css
+++ b/src/styles/adaptive-nav.css
@@ -568,11 +568,199 @@
   to { transform: translateX(0); }
 }
 
+/* ════════════════════════════════════════════
+   NOTIFICATION BELL + PANEL
+   ════════════════════════════════════════════ */
+
+.notif-bell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.notif-bell__btn {
+  position: relative;
+  background: none;
+  border: none;
+  color: var(--md-sys-color-on-surface-variant);
+  cursor: pointer;
+  padding: var(--space-2);
+  border-radius: var(--md-sys-shape-corner-full);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+.notif-bell__btn:hover {
+  background: var(--md-sys-color-surface-container-highest);
+}
+
+.notif-bell__badge {
+  position: absolute;
+  top: 2px;
+  right: 0;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  background: var(--md-sys-color-error);
+  color: var(--md-sys-color-on-error);
+  font: var(--md-sys-typescale-label-small);
+  font-size: 11px;
+  line-height: 18px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.notif-bell__dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 360px;
+  max-height: 480px;
+  overflow-y: auto;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-extra-large);
+  box-shadow: var(--md-sys-elevation-3);
+  z-index: 300;
+  animation: fadeIn 0.15s ease-out;
+}
+
+.notif-bell__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-4) var(--space-2);
+}
+
+.notif-bell__title {
+  font: var(--md-sys-typescale-title-medium);
+  color: var(--md-sys-color-on-surface);
+}
+
+/* ── Notification Panel ── */
+
+.notif-panel__empty {
+  padding: var(--space-6);
+  text-align: center;
+  font: var(--md-sys-typescale-body-medium);
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.notif-panel__list {
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-panel__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+}
+
+.notif-panel__item:hover {
+  background: var(--md-sys-color-surface-container-high);
+}
+
+.notif-panel__item--unread {
+  background: var(--md-sys-color-surface-container-high);
+}
+
+.notif-panel__icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.notif-panel__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.notif-panel__link {
+  font: var(--md-sys-typescale-body-medium);
+  color: var(--md-sys-color-primary);
+  text-decoration: none;
+  display: block;
+}
+
+.notif-panel__link:hover {
+  text-decoration: underline;
+}
+
+.notif-panel__title {
+  font: var(--md-sys-typescale-body-medium);
+  color: var(--md-sys-color-on-surface);
+}
+
+.notif-panel__body {
+  font: var(--md-sys-typescale-body-small);
+  color: var(--md-sys-color-on-surface-variant);
+  margin: var(--space-1) 0 0;
+  line-height: 1.4;
+}
+
+.notif-panel__time {
+  font: var(--md-sys-typescale-label-small);
+  color: var(--md-sys-color-outline);
+  display: block;
+  margin-top: var(--space-1);
+}
+
+.notif-panel__delete {
+  background: none;
+  border: none;
+  color: var(--md-sys-color-outline);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 2px var(--space-1);
+  border-radius: var(--md-sys-shape-corner-full);
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.notif-panel__delete:hover {
+  color: var(--md-sys-color-error);
+  background: var(--md-sys-color-error-container);
+}
+
+.notif-panel__mark-all {
+  display: block;
+  width: 100%;
+  padding: var(--space-3);
+  background: none;
+  border: none;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  font: var(--md-sys-typescale-label-large);
+  color: var(--md-sys-color-primary);
+  cursor: pointer;
+  transition: background var(--md-sys-motion-duration-short4);
+}
+
+.notif-panel__mark-all:hover {
+  background: var(--md-sys-color-surface-container-highest);
+}
+
+/* Mobile: constrain dropdown width */
+@media (max-width: 599px) {
+  .notif-bell__dropdown {
+    width: calc(100vw - var(--space-8));
+    right: calc(-1 * var(--space-4));
+  }
+}
+
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .modal-drawer-overlay,
   .modal-drawer,
-  .mobile-bottom-nav {
+  .mobile-bottom-nav,
+  .notif-bell__dropdown {
     animation: none !important;
     transition: none !important;
   }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -447,3 +447,184 @@ a.report-link:hover { text-decoration: underline; }
   .history-card { flex-direction: column; }
   .history-card-time { text-align: left; }
 }
+
+/* ── Skeleton Loading States (M3) ── */
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.skeleton {
+  background: var(--md-sys-color-surface-container);
+  background-image: linear-gradient(
+    90deg,
+    var(--md-sys-color-surface-container) 0%,
+    var(--md-sys-color-surface-container-high) 40%,
+    var(--md-sys-color-surface-container) 80%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+  border-radius: var(--md-sys-shape-corner-small);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+    background-image: none;
+  }
+}
+
+.skeleton-text-block {
+  width: 100%;
+}
+
+.skeleton-line {
+  margin-bottom: 0.5em;
+}
+
+/* ── Skeleton Card (matches WorkCard layout) ── */
+
+.skeleton-card {
+  padding: var(--space-4) var(--space-6);
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-large);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-card-title {
+  width: 55%;
+  height: 1.375rem;
+  margin-bottom: var(--space-1);
+}
+
+.skeleton-card-author {
+  width: 30%;
+  height: 0.875rem;
+}
+
+.skeleton-card-summary {
+  height: 0.875rem;
+}
+
+.skeleton-card-meta {
+  width: 45%;
+  height: 0.75rem;
+  margin-top: var(--space-1);
+}
+
+.skeleton-card-tags {
+  width: 35%;
+  height: 1.5rem;
+  margin-top: var(--space-1);
+}
+
+/* ── Skeleton Chapter (matches reading-chapter layout) ── */
+
+.skeleton-chapter {
+  margin-bottom: var(--space-12);
+}
+
+.skeleton-chapter-number {
+  width: 25%;
+  height: 0.75rem;
+  margin-bottom: var(--space-1);
+  border-radius: var(--md-sys-shape-corner-full);
+}
+
+.skeleton-chapter-title {
+  width: 50%;
+  height: 1.75rem;
+  margin-bottom: var(--space-2);
+}
+
+.skeleton-chapter-meta {
+  width: 35%;
+  height: 0.75rem;
+  margin-bottom: var(--space-8);
+}
+
+.skeleton-chapter-prose {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.skeleton-prose-line {
+  height: 1rem;
+}
+
+/* ── Skeleton Profile (matches PseudPortfolio layout) ── */
+
+.skeleton-profile {
+  display: flex;
+  flex-direction: column;
+}
+
+.skeleton-profile-banner {
+  width: 100%;
+  height: 200px;
+  border-radius: 0;
+  margin-bottom: var(--space-4);
+}
+
+.skeleton-profile-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  padding: 0 var(--space-4);
+}
+
+.skeleton-profile-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-profile-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeleton-profile-name {
+  width: 40%;
+  height: 1.375rem;
+}
+
+.skeleton-profile-desc {
+  height: 0.875rem;
+}
+
+.skeleton-profile-stats {
+  display: flex;
+  gap: var(--space-4);
+  padding: 0 var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.skeleton-profile-stat {
+  flex: 1;
+  height: 60px;
+  border-radius: var(--md-sys-shape-corner-medium);
+}
+
+/* ── Skeleton Browse Grid (works/index page) ── */
+
+.skeleton-browse-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+}
+
+@media (min-width: 768px) {
+  .skeleton-browse-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,3 +22,8 @@ database_id = "d4a29888-6e20-4391-8aa0-c131b4c36d88"
 [[r2_buckets]]
 binding = "MEDIA"
 bucket_name = "fanfiction-fyi-media"
+
+# Smart Placement runs the Worker in the closest Cloudflare location
+# to the D1 database, reducing latency for data-bound requests.
+[placement]
+mode = "smart"


### PR DESCRIPTION
Phase 4: Notifications, API Auth & Performance

Implements all 6 child issues of #77.

Issues Closed:
- Closes #97 — Astro View Transitions
- Closes #98 — Skeleton Loading States
- Closes #95 — Notification System
- Closes #96 — API Key Authentication
- Closes #99 — Cloudflare Performance
- Closes #100 — OpenAPI Spec + Swagger UI

Changes (46 files, +2180/-51):

#97 View Transitions: ViewTransitions component in Base.astro, fade animation on main, theme re-application on astro:after-swap.

#98 Skeleton Loading States: Skeleton.tsx Preact component (text/card/avatar/circle), SkeletonCard/SkeletonChapter/SkeletonProfile convenience wrappers, shimmer keyframes, applied to SearchPage + PseudPortfolio.

#95 Notification System: notifications + notification_preferences schema, createNotification helper, API endpoints (GET/PUT/DELETE), NotificationBell.tsx with dropdown + 30s polling, M3 CSS, preferences in /settings.

#96 API Key Authentication: api_keys schema, ffy_ prefixed keys with SHA-256 hashing, Bearer token auth fallback in middleware, rate limit headers, CRUD at /api/user/keys, settings UI with create/copy/revoke.

#99 Cloudflare Performance: smart_placement in wrangler.toml, public/_headers for immutable static assets, cacheHeaders() helper (public 5min / private no-cache / no-store), applied to all public GET endpoints.

#100 OpenAPI Spec: OpenAPI 3.1 spec at /api/openapi.json, Scalar API Reference at /api/docs, links from /api/ index.

Database migrations required: drizzle/0002_notifications.sql, drizzle/0003_api_keys.sql