### PR TITLE
fix: Copilot review fixes for Phase 4

### DIFF
--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -3,7 +3,7 @@ export const prerender = false;
 import { getDrizzle } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
 import { notifications } from '@/lib/schema';
-import { eq, and, desc, sql, count } from 'drizzle-orm';
+import { eq, and, desc, count } from 'drizzle-orm';
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = async ({ url, locals, request }) => {

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -723,7 +723,7 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
         name.textContent = key.name;
         const meta = document.createElement('span');
         meta.className = 'api-key-meta';
-        meta.textContent = `${key.keyPrefix}… • Created ${new Date(key.created_at + (key.created_at.includes('Z') ? '' : 'Z')).toLocaleDateString()}` + (key.last_used_at ? ` • Last used ${new Date(key.last_used_at + 'Z').toLocaleDateString()}` : '');
+        meta.textContent = `${key.keyPrefix}… • Created ${new Date(key.createdAt + (key.createdAt.includes('Z') ? '' : 'Z')).toLocaleDateString()}` + (key.lastUsedAt ? ` • Last used ${new Date(key.lastUsedAt + (key.lastUsedAt.includes('Z') ? '' : 'Z')).toLocaleDateString()}` : '');
         info.appendChild(name);
         info.appendChild(meta);
         const revokeBtn = document.createElement('button');
@@ -782,8 +782,9 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
       loadApiKeys();
     } catch {
       keyError.textContent = 'Network error. Please try again.';
+    } finally {
+      createKeyBtn.removeAttribute('disabled');
     }
-    createKeyBtn.removeAttribute('disabled');
   });
 
   copyBtn?.addEventListener('click', () => {


### PR DESCRIPTION
Fixes 3 issues flagged by Copilot on PR #102:

1. Remove unused `sql` import from `notifications/index.ts`
2. Fix API keys settings UI using snake_case (`created_at`) instead of camelCase (`createdAt`) — the API returns camelCase
3. Use `finally` block to ensure create-key button is re-enabled on all error paths

All verified with clean build.