### PR TITLE
fix: guest login button + corrupted search icon

### DIFF
--- a/src/components/AdaptiveNav.tsx
+++ b/src/components/AdaptiveNav.tsx
@@ -19,14 +19,14 @@ export interface NavGroup {
 // Shared nav items — the same set used across all breakpoints
 const PRIMARY_NAV: NavItem[] = [
   { label: 'Home', href: '/', icon: 'home' },
-  { label: 'Search', href: '/search', icon: 'manage_search' },
+  { label: 'Search', href: '/search', icon: 'search' },
   { label: 'Bookmarks', href: '/bookmarks', icon: 'bookmark' },
   { label: 'History', href: '/history', icon: 'history' },
   { label: 'Profile', href: '/studio', icon: 'studio' },
 ];
 
 const SECONDARY_NAV: NavItem[] = [
-  { label: 'Works', href: '/works', icon: 'search' },
+  { label: 'Works', href: '/works', icon: 'auto_stories' },
   { label: 'Authors', href: '/pseuds', icon: 'person' },
   { label: 'Characters', href: '/characters', icon: 'groups' },
   { label: 'Tags', href: '/tags', icon: 'label' },
@@ -60,6 +60,7 @@ const ICONS: Record<string, string> = {
   settings: 'M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.61 3.61 0 0112 15.6z',
   close: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
   logout: 'M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z',
+  login: 'M11 7L9.6 8.4l2.6 2.6H2v2h10.2l-2.6 2.6L11 17l5-5-5-5zm9 12h-8v2h8c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-8v2h8v14z',
 };
 
 function SvgIcon({ name, size = 24 }: { name: string; size?: number }) {
@@ -123,9 +124,13 @@ function NavigationRail({ items, currentPath, onMenuClick, userName }: { items: 
       </div>
       <div class="navigation-rail__spacer" />
       {userName && <NotificationBell />}
-      {userName && (
+      {userName ? (
         <a href="/works/create" class="navigation-rail__create" aria-label="New Work" title="New Work">
           <SvgIcon name="create" size={24} />
+        </a>
+      ) : (
+        <a href="/login" class="navigation-rail__create" aria-label="Sign In" title="Sign In">
+          <SvgIcon name="login" size={24} />
         </a>
       )}
     </nav>
@@ -172,7 +177,7 @@ function NavigationDrawer({ items, secondaryItems, currentPath, userName }: {
       </div>
       <div class="navigation-drawer__spacer" />
       {userName && <NotificationBell />}
-      {userName && (
+      {userName ? (
         <div class="navigation-drawer__footer">
           <a href="/works/create" class="navigation-drawer__create">
             <SvgIcon name="create" size={20} />
@@ -192,6 +197,13 @@ function NavigationDrawer({ items, secondaryItems, currentPath, userName }: {
               <span>Sign Out</span>
             </button>
           </form>
+        </div>
+      ) : (
+        <div class="navigation-drawer__footer">
+          <a href="/login" class="navigation-drawer__create">
+            <SvgIcon name="login" size={20} />
+            <span>Sign In</span>
+          </a>
         </div>
       )}
     </nav>
@@ -263,7 +275,7 @@ function ModalDrawer({ isOpen, onClose, primaryItems, secondaryItems, currentPat
             </a>
           ))}
         </div>
-        {userName && (
+        {userName ? (
           <>
             <div class="modal-drawer__divider" />
             <div class="modal-drawer__section">
@@ -287,6 +299,16 @@ function ModalDrawer({ isOpen, onClose, primaryItems, secondaryItems, currentPat
                   <span>Sign Out</span>
                 </button>
               </form>
+            </div>
+          </>
+        ) : (
+          <>
+            <div class="modal-drawer__divider" />
+            <div class="modal-drawer__section">
+              <a href="/login" class="modal-drawer__item modal-drawer__item--create" onClick={onClose}>
+                <SvgIcon name="login" size={24} />
+                <span>Sign In</span>
+              </a>
             </div>
           </>
         )}
@@ -357,8 +379,8 @@ export default function AdaptiveNav({ currentPath, userName, isAdmin, isReadingM
   // For mobile bottom nav, ensure at least 4 items for good layout
   const guestPrimaryNav: NavItem[] = [
     { label: 'Home', href: '/', icon: 'home' },
-    { label: 'Search', href: '/search', icon: 'manage_search' },
-    { label: 'Works', href: '/works', icon: 'search' },
+    { label: 'Search', href: '/search', icon: 'search' },
+    { label: 'Works', href: '/works', icon: 'auto_stories' },
     { label: 'Authors', href: '/pseuds', icon: 'person' },
   ];
   const primaryNav = userName ? PRIMARY_NAV : guestPrimaryNav;


### PR DESCRIPTION
## Problems
1. **No login button for guests on desktop/tablet**: The NavigationDrawer (840px+) and NavigationRail (600-839px) only showed auth UI when the user was logged in. Guest users on larger screens had no visible way to sign in — the entire footer/sidebar section was hidden.
2. **Corrupted search icon**: The Search nav item used the Material `manage_search` icon which renders as a complex filter-list + magnifying glass composite. At small sizes this looks garbled/broken.

## Changes
- **AdaptiveNav.tsx**: Added `login` Material Design icon path to ICONS dictionary
- **NavigationDrawer**: Guest users now see a prominent "Sign In" CTA button (styled like the "New Work" button) in the drawer footer
- **NavigationRail**: Guest users now see a "Sign In" FAB circle (where logged-in users see "New Work")  
- **ModalDrawer**: Guest users see a "Sign In" link in the modal menu
- **MobileAppBar**: Already had "Sign In" text link (unchanged)
- **Search icon**: Replaced `manage_search` with clean `search` magnifying glass
- **Works icon**: Changed from duplicate `search` to `auto_stories` (open book) to distinguish from Search

## Testing
- Build passes ✅
- All three breakpoints (mobile, tablet, desktop) now show login for guests
- Icons render as proper Material Design SVGs