### PR TITLE
fix: parameterized SQL in datetime() modifiers breaks OAuth (and D1 queries)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -95,7 +95,7 @@ export async function createSession(db: D1Database, userId: number): Promise<str
     userId,
     token,
     createdAt: sql`(datetime('now'))`,
-    expiresAt: sql`(datetime('now', '+${SESSION_DAYS} days'))`,
+    expiresAt: sql`(datetime('now', '+30 days'))`,
   });
   return token;
 }

--- a/src/pages/api/admin/users/[id]/suspend.ts
+++ b/src/pages/api/admin/users/[id]/suspend.ts
@@ -45,7 +45,7 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   }
 
   await db.update(users)
-    .set({ suspendedUntil: sql`(datetime('now', '+${duration} hours'))`, updatedAt: sql`(datetime('now'))` })
+    .set({ suspendedUntil: sql.raw(`datetime('now', '+${Number(duration)} hours')`), updatedAt: sql`(datetime('now'))` })
     .where(eq(users.id, userId));
 
   const updatedUser = await db


### PR DESCRIPTION
## Bug
Google OAuth sign-in fails with `oauth_callback_failed` — the catch-all error from the callback handler's try/catch.

## Root Cause
Drizzle's `sql\`\``` tagged template interpolates JS values as parameterized SQL bindings (`?`). When used inside a SQLite `datetime()` modifier string:

```ts
sql\`(datetime('now', '+${SESSION_DAYS} days'))\`
// Produces: datetime('now', '+? days') with binding [30]
// SQLite expects: datetime('now', '+30 days') as a single modifier string
```

This makes `createSession()` throw an invalid SQL error, which cascades up to the OAuth callback's catch block.

## Fix
- **`src/lib/auth.ts`**: Hardcode `'+30 days'` instead of interpolating `${SESSION_DAYS}`. The value is a fixed constant and doesn't need parameterization.
- **`src/pages/api/admin/users/[id]/suspend.ts`**: Use `sql.raw(\`datetime('now', '+\${Number(duration)} hours')\\ `)` since `duration` is dynamic and already validated as a number. `sql.raw()` embeds the value directly in the SQL string (safe because `Number()` coerces to a numeric literal).
- **`wrangler.toml`**: Already fixed in previous commit — removed empty `FOUNDER_EMAIL = ""` from `[vars]`.

## Testing
- Build passes locally
- Fake code callback correctly returns `oauth_token_failed` (env vars are working)
- Deployment triggered after merge