### PR TITLE
debug: add error detail to OAuth callback for 500 debugging

### DIFF
--- a/src/pages/api/auth/google/callback.ts
+++ b/src/pages/api/auth/google/callback.ts
@@ -263,6 +263,7 @@ export const GET: APIRoute = async ({ url, locals, request }) => {
     });
   } catch (err) {
     console.error('Google OAuth callback error (standard flow):', err);
-    return Response.redirect(`${url.origin}/login?error=oauth_callback_failed`, 302);
+    const errDetail = err instanceof Error ? `${err.message}|${err.stack?.slice(0, 200)}` : String(err);
+    return Response.redirect(`${url.origin}/login?error=oauth_callback_failed&detail=${encodeURIComponent(errDetail.slice(0, 300))}`, 302);
   }
 };

--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -216,6 +216,11 @@ import Base from '../../layouts/Base.astro';
       suspended: 'This account is temporarily suspended',
     };
     errorEl.textContent = messages[oauthError] || 'Google sign-in failed';
+    // Show detail param for debugging OAuth errors
+    const detail = urlParams.get('detail');
+    if (detail) {
+      errorEl.textContent += ' (' + detail + ')';
+    }
     // If suspended with until date, append it
     if (oauthError === 'suspended') {
       const until = urlParams.get('until');


### PR DESCRIPTION
Temporary debug PR — adds error message and stack trace to the OAuth callback redirect URL so we can see what's actually failing. Will revert after diagnosis.