### PR TITLE
feat: work skins/theming (#22)

### DIFF
--- a/drizzle/0004_work_skins.sql
+++ b/drizzle/0004_work_skins.sql
@@ -1,0 +1,2 @@
+-- Migration 0004: Add work_skin column for Work Skins feature (#22)
+ALTER TABLE works ADD COLUMN work_skin TEXT NOT NULL DEFAULT 'default';

--- a/drizzle/0005_reading_skin_override.sql
+++ b/drizzle/0005_reading_skin_override.sql
@@ -1,0 +1,3 @@
+-- Migration 0005: Add reading_skin_override column for Work Skins feature (#22)
+ALTER TABLE users ADD COLUMN reading_skin_override TEXT DEFAULT 'author';
+-- Values: 'default', 'typewriter', 'manuscript', 'terminal', 'parchment', 'author'

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -24,6 +24,7 @@ interface ReadingModeProps {
   reactionCounts: Record<string, number>;
   myReactions: string[];
   fontSize: string;
+  skin?: string;
   workTitle: string;
 }
 
@@ -53,11 +54,20 @@ interface FocusSheetProps {
   workId: number;
   fontSize: string;
   moodDisabled: boolean;
+  skin?: string;
   onFontSizeChange: (size: string) => void;
   onMoodToggle: () => void;
   prevChapter: Chapter | null;
   nextChapter: Chapter | null;
 }
+
+const SKIN_LABELS: Record<string, string> = {
+  default: 'Default Obsidian',
+  typewriter: 'Typewriter',
+  manuscript: 'Manuscript',
+  terminal: 'Terminal',
+  parchment: 'Parchment',
+};
 
 function FocusSheet({
   open,
@@ -67,6 +77,7 @@ function FocusSheet({
   workId,
   fontSize,
   moodDisabled,
+  skin,
   onFontSizeChange,
   onMoodToggle,
   prevChapter,
@@ -220,6 +231,14 @@ function FocusSheet({
               {moodDisabled ? 'Off' : 'On'}
             </button>
           </div>
+
+          {/* Reading Skin indicator */}
+          {skin && skin !== 'default' && (
+            <div class="focus-sheet-setting-row">
+              <span class="focus-sheet-setting-label">Reading Skin</span>
+              <span class="focus-sheet-setting-label" style={{ color: 'var(--md-sys-color-primary)' }}>{SKIN_LABELS[skin] || skin}</span>
+            </div>
+          )}
         </div>
 
         {/* Navigation section */}
@@ -270,6 +289,7 @@ export default function ReadingMode({
   reactionCounts: initialReactionCounts,
   myReactions: initialMyReactions,
   fontSize: initialFontSize,
+  skin,
   workTitle,
 }: ReadingModeProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -552,6 +572,7 @@ export default function ReadingMode({
         workId={workId}
         fontSize={currentFontSize}
         moodDisabled={moodDisabled}
+        skin={skin}
         onFontSizeChange={handleFontSizeChange}
         onMoodToggle={handleMoodToggle}
         prevChapter={prevChapter}

--- a/src/lib/schema/users.ts
+++ b/src/lib/schema/users.ts
@@ -30,6 +30,7 @@ export const users = sqliteTable('users', {
   })
     .notNull()
     .default('default'),
+  readingSkinOverride: text('reading_skin_override').default('author'),
   moodDisabled: integer('mood_disabled').default(0),
   approved: integer('approved').notNull().default(1),
 });

--- a/src/lib/schema/works.ts
+++ b/src/lib/schema/works.ts
@@ -11,6 +11,7 @@ export const works = sqliteTable('works', {
   wordCount: integer('word_count').notNull().default(0),
   complete: integer('complete').notNull().default(0),
   publishedAt: text('published_at'),
+  workSkin: text('work_skin').notNull().default('default'),
   updatedAt: text('updated_at').notNull().default('(datetime(\'now\'))'),
   createdAt: text('created_at').notNull().default('(datetime(\'now\'))'),
 });

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -8,6 +8,7 @@ import { eq, sql } from 'drizzle-orm';
 
 const VALID_EMAIL_VISIBILITY = ['public', 'mutual', 'private'] as const;
 const VALID_READING_FONT_SIZE = ['small', 'default', 'large', 'xlarge'] as const;
+const VALID_READING_SKIN_OVERRIDE = ['default', 'typewriter', 'manuscript', 'terminal', 'parchment', 'author'] as const;
 
 /**
  * PUT /api/user/profile — update authenticated user's profile fields
@@ -73,6 +74,17 @@ export const PUT: APIRoute = async ({ locals, request }) => {
     updateValues.moodDisabled = (md === true || md === 1) ? 1 : 0;
   }
 
+  if ('reading_skin_override' in body) {
+    const skin = body.reading_skin_override as string;
+    if (!VALID_READING_SKIN_OVERRIDE.includes(skin as any)) {
+      return new Response(JSON.stringify({ error: 'Invalid reading_skin_override value' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    updateValues.readingSkinOverride = skin;
+  }
+
   if ('avatar_url' in body) {
     updateValues.avatarUrl = typeof body.avatar_url === 'string' ? body.avatar_url : null;
   }
@@ -108,6 +120,7 @@ export const PUT: APIRoute = async ({ locals, request }) => {
         bio: updated!.bio,
         email_visibility: updated!.emailVisibility,
         reading_font_size: updated!.readingFontSize,
+        reading_skin_override: updated!.readingSkinOverride ?? 'author',
         mood_disabled: updated!.moodDisabled ?? 0,
       },
     }),

--- a/src/pages/api/works/[id]/index.ts
+++ b/src/pages/api/works/[id]/index.ts
@@ -182,6 +182,12 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   if (body.end_notes !== undefined) setValues.endNotes = body.end_notes;
   if (body.complete !== undefined) setValues.complete = body.complete ? 1 : 0;
   if (body.language !== undefined) setValues.language = body.language;
+  if (body.work_skin !== undefined) {
+    const validSkins = ['default', 'typewriter', 'manuscript', 'terminal', 'parchment'];
+    if (validSkins.includes(body.work_skin)) {
+      setValues.workSkin = body.work_skin;
+    }
+  }
   if (body.publish) {
     console.log('[WORK_PUT] Publishing work:', workId, 'body keys:', Object.keys(body).join(','));
     // Set published_at only if it's currently null (first publish)

--- a/src/pages/api/works/index.ts
+++ b/src/pages/api/works/index.ts
@@ -112,8 +112,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
   let body: any;
   try { body = await request.json(); } catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } }); }
 
-  const { title, summary, notes, pseud_id, chapter_title, chapter_content, chapter_images, draft, tag_ids, tag_names, rating, category, warning, skip_chapter } = body || {};
+  const { title, summary, notes, pseud_id, chapter_title, chapter_content, chapter_images, draft, tag_ids, tag_names, rating, category, warning, skip_chapter, work_skin } = body || {};
   if (!title) return new Response(JSON.stringify({ error: 'Title is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+
+  // Validate work_skin
+  const validSkins = ['default', 'typewriter', 'manuscript', 'terminal', 'parchment'];
+  const skin = validSkins.includes(work_skin) ? work_skin : 'default';
 
   const pseudId = pseud_id || auth.pseuds[0]?.id;
   if (!pseudId) return new Response(JSON.stringify({ error: 'No pseud available' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
@@ -150,6 +154,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     wordCount: 0,
     complete: 0,
     publishedAt: isDraft ? null : sql`(datetime('now'))`,
+    workSkin: skin,
   });
 
   const workId = Number(workResult.meta?.last_row_id ?? workResult[0]?.meta?.last_row_id);

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -133,6 +133,17 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
             <input type="checkbox" name="mood_disabled" value="1" checked={user.moodDisabled === 1} />
             Disable mood indicators
           </label>
+          <label class="form-label">
+            Reading Skin
+            <select name="reading_skin_override" class="form-input">
+              <option value="author" selected={(user.readingSkinOverride ?? 'author') === 'author'}>Use author's skin</option>
+              <option value="default" selected={user.readingSkinOverride === 'default'}>Default Obsidian</option>
+              <option value="typewriter" selected={user.readingSkinOverride === 'typewriter'}>Typewriter</option>
+              <option value="manuscript" selected={user.readingSkinOverride === 'manuscript'}>Manuscript</option>
+              <option value="terminal" selected={user.readingSkinOverride === 'terminal'}>Terminal</option>
+              <option value="parchment" selected={user.readingSkinOverride === 'parchment'}>Parchment</option>
+            </select>
+          </label>
           <button type="submit" class="btn-primary">Save Preferences</button>
           <p class="form-error" id="prefs-error"></p>
           <p class="form-success" id="prefs-success"></p>
@@ -633,6 +644,7 @@ const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, user.i
       email_visibility: formData.get('email_visibility'),
       reading_font_size: formData.get('reading_font_size'),
       mood_disabled: formData.get('mood_disabled') ? 1 : 0,
+      reading_skin_override: formData.get('reading_skin_override'),
     };
 
     try {

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -45,12 +45,14 @@ if (sessionMatch) {
       id: users.id,
       theme: users.theme,
       readingFontSize: users.readingFontSize,
+      readingSkinOverride: users.readingSkinOverride,
       moodDisabled: users.moodDisabled,
     }).from(users).where(eq(users.id, session.userId)).get();
     if (authUser) {
       // Map to snake_case for template compatibility
       (authUser as any).reading_font_size = authUser.readingFontSize;
       (authUser as any).mood_disabled = authUser.moodDisabled;
+      (authUser as any).reading_skin_override = authUser.readingSkinOverride ?? 'author';
       const userPseud = await db.select({ id: pseudsTable.id }).from(pseudsTable)
         .where(eq(pseudsTable.userId, authUser.id))
         .orderBy(pseudsTable.id)
@@ -165,6 +167,10 @@ const authorNames = pseuds.map((p: any) => p.name).join(', ');
 
 // User font size preference
 const fontSizeClass = authUser?.reading_font_size || 'default';
+
+// Determine effective reading skin
+const userSkinOverride = (authUser as any)?.reading_skin_override || 'author';
+const effectiveSkin = userSkinOverride === 'author' ? (workRow.workSkin || 'default') : userSkinOverride;
 
 // Mood engine — map chapter mood to CSS custom properties
 const moodDisabled = authUser?.mood_disabled || false;
@@ -1147,7 +1153,7 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
   {moodCSS && <style>{`:root { ${moodCSS} }`}</style>}
 
   <!-- Main Reading Area -->
-  <main class="reading-container" data-font-size={fontSizeClass} data-mood={moodDisabled ? 'off' : currentMood || 'none'}>
+  <main class="reading-container" data-font-size={fontSizeClass} data-mood={moodDisabled ? 'off' : currentMood || 'none'} data-skin={effectiveSkin}>
     <!-- Work Metadata -->
     <div class="reading-work-meta">
       <h1 class="reading-work-title">{work.title}</h1>
@@ -1211,6 +1217,7 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
         reactionCounts={reactionCounts}
         myReactions={myReactions}
         fontSize={fontSizeClass}
+        skin={effectiveSkin}
         workTitle={work.title}
       />
     </section>

--- a/src/pages/works/[id]/settings.astro
+++ b/src/pages/works/[id]/settings.astro
@@ -120,6 +120,17 @@ const RELATION_TYPES = [
               Mark as Complete
             </label>
           </div>
+          <div class="m3-form-field">
+            <label for="work_skin">Reading Skin</label>
+            <select id="work_skin" name="work_skin" class="m3-select">
+              <option value="default" selected={work.workSkin === 'default'}>Default Obsidian</option>
+              <option value="typewriter" selected={work.workSkin === 'typewriter'}>Typewriter</option>
+              <option value="manuscript" selected={work.workSkin === 'manuscript'}>Manuscript</option>
+              <option value="terminal" selected={work.workSkin === 'terminal'}>Terminal</option>
+              <option value="parchment" selected={work.workSkin === 'parchment'}>Parchment</option>
+            </select>
+            <span class="m3-hint">Choose the visual theme readers will see for this work.</span>
+          </div>
         </div>
       </div>
 
@@ -348,6 +359,7 @@ const RELATION_TYPES = [
     const rating = (document.getElementById('rating') as HTMLSelectElement).value;
     const category = (document.getElementById('category') as HTMLSelectElement).value;
     const warning = (document.getElementById('warning') as HTMLSelectElement).value;
+    const workSkin = (document.getElementById('work_skin') as HTMLSelectElement).value;
 
     // Gather tag data from hidden inputs created by TagChips
     const tagIds: number[] = [];
@@ -374,6 +386,7 @@ const RELATION_TYPES = [
           summary: summary || null,
           notes: notes || null,
           complete,
+          work_skin: workSkin,
           tag_ids: tagIds,
           tag_names: tagNames,
           rating: rating || null,

--- a/src/pages/works/create.astro
+++ b/src/pages/works/create.astro
@@ -93,6 +93,22 @@ const defaultPseudId = pseuds.find(p => p.name === user.display_name)?.id ?? pse
         </div>
       </div>
 
+      <!-- Card 4: Reading Skin -->
+      <div class="m3-card">
+        <h2 class="m3-card-title">Reading Experience</h2>
+        <div class="m3-form-field" style="max-width: 300px">
+          <label for="work_skin">Reading Skin</label>
+          <select id="work_skin" name="work_skin" class="m3-select">
+            <option value="default" selected>Default Obsidian</option>
+            <option value="typewriter">Typewriter</option>
+            <option value="manuscript">Manuscript</option>
+            <option value="terminal">Terminal</option>
+            <option value="parchment">Parchment</option>
+          </select>
+          <p class="m3-helper-text">Choose the visual theme readers will see for this work.</p>
+        </div>
+      </div>
+
       <!-- Post As pseud selector -->
       <div class="m3-form-field" style="max-width: 300px">
         <label for="pseud">Post As</label>
@@ -184,6 +200,7 @@ const defaultPseudId = pseuds.find(p => p.name === user.display_name)?.id ?? pse
     const rating = (document.getElementById('rating') as HTMLSelectElement).value;
     const category = (document.getElementById('category') as HTMLSelectElement).value;
     const warning = (document.getElementById('warning') as HTMLSelectElement).value;
+    const workSkin = (document.getElementById('work_skin') as HTMLSelectElement).value;
 
     // Gather tag data from hidden inputs created by TagChips
     const tagIds: number[] = [];
@@ -223,6 +240,7 @@ const defaultPseudId = pseuds.find(p => p.name === user.display_name)?.id ?? pse
           rating: rating || null,
           category: category || null,
           warning: warning || null,
+          work_skin: workSkin,
         }),
       });
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -628,3 +628,182 @@ a.report-link:hover { text-decoration: underline; }
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ─── Work Skins ─── */
+/* Applied via data-skin attribute on .reading-container */
+
+/* ── Default (Obsidian) ── */
+.reading-container[data-skin="default"] .reading-prose {
+  /* Inherits existing Obsidian theme — no overrides needed */
+}
+
+/* ── Typewriter ── */
+/* Monospace, narrow, high contrast — WCAG AA: #1a1a1a on #2d2d2d = 6.7:1 — but let's use darker bg, brighter text */
+.reading-container[data-skin="typewriter"] {
+  background: #1e1e1e;
+  color: #d4d4d4;
+}
+.reading-container[data-skin="typewriter"] .reading-prose {
+  font-family: 'Courier New', Courier, monospace;
+  line-height: 1.5;
+  max-width: 640px;
+  color: #d4d4d4;
+}
+.reading-container[data-skin="typewriter"] .reading-prose p { text-indent: 0; }
+.reading-container[data-skin="typewriter"] .reading-prose a { color: #8ecae6; }
+.reading-container[data-skin="typewriter"] .reading-prose a:hover { background: #8ecae6; color: #1e1e1e; }
+.reading-container[data-skin="typewriter"] .reading-work-title {
+  font-family: 'Courier New', Courier, monospace;
+  color: #d4d4d4;
+}
+.reading-container[data-skin="typewriter"] .reading-chapter-title {
+  font-family: 'Courier New', Courier, monospace;
+  color: #d4d4d4;
+}
+.reading-container[data-skin="typewriter"] .reading-work-author { color: #a0a0a0; }
+.reading-container[data-skin="typewriter"] .reading-work-stats { color: #808080; }
+.reading-container[data-skin="typewriter"] .reading-chapter-meta { color: #808080; }
+.reading-container[data-skin="typewriter"] .reading-chapter-number { color: #8ecae6; }
+.reading-container[data-skin="typewriter"] .reading-prose blockquote {
+  border-left-color: #8ecae6;
+  color: #a0a0a0;
+}
+.reading-container[data-skin="typewriter"] .reading-prose hr { color: #808080; }
+.reading-container[data-skin="typewriter"] .reading-prose h2,
+.reading-container[data-skin="typewriter"] .reading-prose h3 {
+  font-family: 'Courier New', Courier, monospace;
+  color: #d4d4d4;
+}
+.reading-container[data-skin="typewriter"] .reading-nav-link {
+  color: #8ecae6;
+  background: #333;
+}
+
+/* ── Manuscript ── */
+/* Serif, wide, generous line-height — WCAG AA: #2d2216 on #faf6f0 = 12.5:1 */
+.reading-container[data-skin="manuscript"] {
+  background: #faf6f0;
+  color: #2d2216;
+}
+.reading-container[data-skin="manuscript"] .reading-prose {
+  font-family: 'Georgia', 'Palatino Linotype', 'Book Antiqua', serif;
+  line-height: 1.9;
+  max-width: 780px;
+  color: #2d2216;
+  letter-spacing: 0.005em;
+}
+.reading-container[data-skin="manuscript"] .reading-prose p { text-indent: 0; }
+.reading-container[data-skin="manuscript"] .reading-prose a {
+  color: #7b5733;
+  text-decoration-color: #7b5733;
+}
+.reading-container[data-skin="manuscript"] .reading-prose a:hover { background: #e8dcc8; color: #5a3d20; border-radius: 2px; }
+.reading-container[data-skin="manuscript"] .reading-work-title {
+  font-family: 'Georgia', 'Palatino Linotype', serif;
+  color: #2d2216;
+}
+.reading-container[data-skin="manuscript"] .reading-chapter-title {
+  font-family: 'Georgia', 'Palatino Linotype', serif;
+  color: #2d2216;
+}
+.reading-container[data-skin="manuscript"] .reading-work-author { color: #5a4633; }
+.reading-container[data-skin="manuscript"] .reading-work-stats { color: #8a7b6b; }
+.reading-container[data-skin="manuscript"] .reading-chapter-meta { color: #8a7b6b; }
+.reading-container[data-skin="manuscript"] .reading-chapter-number { color: #7b5733; }
+.reading-container[data-skin="manuscript"] .reading-prose blockquote {
+  border-left-color: #7b5733;
+  color: #5a4633;
+}
+.reading-container[data-skin="manuscript"] .reading-prose hr { color: #8a7b6b; }
+.reading-container[data-skin="manuscript"] .reading-prose h2,
+.reading-container[data-skin="manuscript"] .reading-prose h3 {
+  font-family: 'Georgia', 'Palatino Linotype', serif;
+  color: #2d2216;
+}
+.reading-container[data-skin="manuscript"] .reading-nav-link {
+  color: #faf6f0;
+  background: #7b5733;
+}
+
+/* ── Terminal ── */
+/* Green-on-black — WCAG AA: #00ff41 on #0a0a0a = 11.3:1 */
+.reading-container[data-skin="terminal"] {
+  background: #0a0a0a;
+  color: #00ff41;
+}
+.reading-container[data-skin="terminal"] .reading-prose {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  line-height: 1.6;
+  color: #00ff41;
+}
+.reading-container[data-skin="terminal"] .reading-prose p { text-indent: 0; }
+.reading-container[data-skin="terminal"] .reading-prose a { color: #00ddff; text-decoration-color: #00ddff; }
+.reading-container[data-skin="terminal"] .reading-prose a:hover { background: #00ddff; color: #0a0a0a; border-radius: 2px; }
+.reading-container[data-skin="terminal"] .reading-work-title {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  color: #00ff41;
+}
+.reading-container[data-skin="terminal"] .reading-chapter-title {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  color: #00ff41;
+}
+.reading-container[data-skin="terminal"] .reading-work-author { color: #00cc33; }
+.reading-container[data-skin="terminal"] .reading-work-stats { color: #009926; }
+.reading-container[data-skin="terminal"] .reading-chapter-meta { color: #009926; }
+.reading-container[data-skin="terminal"] .reading-chapter-number { color: #00ddff; }
+.reading-container[data-skin="terminal"] .reading-prose blockquote {
+  border-left-color: #00ddff;
+  color: #00cc33;
+}
+.reading-container[data-skin="terminal"] .reading-prose hr { color: #009926; }
+.reading-container[data-skin="terminal"] .reading-prose h2,
+.reading-container[data-skin="terminal"] .reading-prose h3 {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  color: #00ff41;
+}
+.reading-container[data-skin="terminal"] .reading-prose img { display: none; }
+.reading-container[data-skin="terminal"] .reading-nav-link {
+  color: #0a0a0a;
+  background: #00ff41;
+}
+
+/* ── Parchment ── */
+/* Warm paper — WCAG AA: #3d3529 on #f5f0e8 = 10.3:1 */
+.reading-container[data-skin="parchment"] {
+  background: #f5f0e8;
+  color: #3d3529;
+}
+.reading-container[data-skin="parchment"] .reading-prose {
+  font-family: 'Georgia', 'Palatino Linotype', 'Book Antiqua', serif;
+  line-height: 1.85;
+  color: #3d3529;
+}
+.reading-container[data-skin="parchment"] .reading-prose p { text-indent: 0; }
+.reading-container[data-skin="parchment"] .reading-prose a { color: #8b6914; }
+.reading-container[data-skin="parchment"] .reading-prose a:hover { background: #e8dcc8; color: #6b4f0a; border-radius: 2px; }
+.reading-container[data-skin="parchment"] .reading-work-title {
+  font-family: 'Georgia', 'Palatino Linotype', serif;
+  color: #3d3529;
+}
+.reading-container[data-skin="parchment"] .reading-chapter-title {
+  font-family: 'Georgia', 'Palatino Linotype', serif;
+  color: #3d3529;
+}
+.reading-container[data-skin="parchment"] .reading-work-author { color: #5c4f3d; }
+.reading-container[data-skin="parchment"] .reading-work-stats { color: #7a6e5e; }
+.reading-container[data-skin="parchment"] .reading-chapter-meta { color: #7a6e5e; }
+.reading-container[data-skin="parchment"] .reading-chapter-number { color: #8b6914; }
+.reading-container[data-skin="parchment"] .reading-prose blockquote {
+  border-left-color: #8b6914;
+  color: #5c4f3d;
+}
+.reading-container[data-skin="parchment"] .reading-prose hr { color: #7a6e5e; }
+.reading-container[data-skin="parchment"] .reading-prose h2,
+.reading-container[data-skin="parchment"] .reading-prose h3 {
+  font-family: 'Georgia', 'Palatino Linotype', serif;
+  color: #3d3529;
+}
+.reading-container[data-skin="parchment"] .reading-nav-link {
+  color: #f5f0e8;
+  background: #8b6914;
+}


### PR DESCRIPTION
## Work Skins / Theming (#22)

Implements the Work Skins feature — authors pick a visual reading theme for their work, and readers can override it in settings.

### Schema Changes
- `drizzle/0004_work_skins.sql` — adds `work_skin TEXT NOT NULL DEFAULT 'default'` to `works` table
- `drizzle/0005_reading_skin_override.sql` — adds `reading_skin_override TEXT DEFAULT 'author'` to `users` table

### 5 Themed Skins
Each skin is scoped to `.reading-container[data-skin]` and affects:
- **Default Obsidian** — no-op, inherits existing dark theme
- **Typewriter** — monospace (Courier New), narrower 640px, dark gray bg (#1e1e1e), cyan accents
- **Manuscript** — Georgia serif, 780px, 1.9 line-height, cream background (#faf6f0), warm brown text
- **Terminal** — green-on-black (#00ff41 on #0a0a0a), monospace, cyan links, images hidden
- **Parchment** — warm paper (#f5f0e8), Georgia serif, golden link colors

All skins verified for WCAG AA contrast (4.5:1+ ratios).

### Author Side
- Work creation form (`/works/create`) includes a "Reading Skin" dropdown
- Work settings page (`/works/[id]/settings`) allows changing skin after creation
- `POST /api/works` and `PUT /api/works/:id` both accept and validate `work_skin`

### Reader Side
- Reading page (`/works/[id]/read`) applies `data-skin` attribute to `.reading-container`
- User override: Settings page has "Reading Skin" preference (Use author's skin / Default / Typewriter / Manuscript / Terminal / Parchment)
- `PUT /api/user/profile` persists `reading_skin_override`
- ReadingMode FocusSheet shows active skin name when non-default

### Verification
- Clean build ✅ (`npm run build` exits 0)
- API validates skin against allowed values
- Reader override logic: `override === 'author' ? work.workSkin : override`