### PR TITLE
feat: inline reader annotations (#23)

### DIFF
--- a/drizzle/0006_annotations.sql
+++ b/drizzle/0006_annotations.sql
@@ -1,0 +1,16 @@
+-- Migration 0006: Add annotations table for Inline Reader Annotations (#23)
+CREATE TABLE IF NOT EXISTS annotations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  chapter_id INTEGER NOT NULL REFERENCES chapters(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  start_offset INTEGER NOT NULL,
+  end_offset INTEGER NOT NULL,
+  note_text TEXT NOT NULL DEFAULT '',
+  color TEXT NOT NULL DEFAULT 'yellow',
+  shared_with_author INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_annotations_chapter_user ON annotations(chapter_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_annotations_user ON annotations(user_id);

--- a/src/components/AnnotationsLayer.tsx
+++ b/src/components/AnnotationsLayer.tsx
@@ -1,0 +1,338 @@
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+
+interface AnnotationData {
+  id: number;
+  chapterId: number;
+  userId: number;
+  startOffset: number;
+  endOffset: number;
+  noteText: string;
+  color: string;
+  sharedWithAuthor: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AnnotationsLayerProps {
+  workId: number;
+  chapterId: number;
+  userId: number | null;
+}
+
+const COLORS = [
+  { key: 'yellow', bg: 'rgba(255, 235, 59, 0.2)', marker: '#FDD835' },
+  { key: 'green', bg: 'rgba(76, 175, 80, 0.2)', marker: '#66BB6A' },
+  { key: 'blue', bg: 'rgba(33, 150, 243, 0.2)', marker: '#42A5F5' },
+  { key: 'pink', bg: 'rgba(233, 30, 99, 0.2)', marker: '#EC407A' },
+  { key: 'orange', bg: 'rgba(255, 152, 0, 0.2)', marker: '#FFA726' },
+] as const;
+
+export default function AnnotationsLayer({ workId, chapterId, userId }: AnnotationsLayerProps) {
+  const [annotations, setAnnotations] = useState<AnnotationData[]>([]);
+  const [showCreate, setShowCreate] = useState(false);
+  const [selectionRange, setSelectionRange] = useState<{ start: number; end: number } | null>(null);
+  const [noteText, setNoteText] = useState('');
+  const [selectedColor, setSelectedColor] = useState<string>('yellow');
+  const [shareWithAuthor, setShareWithAuthor] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editNote, setEditNote] = useState('');
+  const [editColor, setEditColor] = useState('yellow');
+  const [editShared, setEditShared] = useState(false);
+  const [visible, setVisible] = useState(true);
+  const [activeAnnotation, setActiveAnnotation] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const proseRef = useRef<HTMLDivElement | null>(null);
+
+  // Load annotations
+  useEffect(() => {
+    if (!userId) return;
+    fetch(`/api/works/${workId}/chapters/${chapterId}/annotations`)
+      .then(r => r.json())
+      .then(data => setAnnotations(data.annotations || data || []))
+      .catch(() => {});
+  }, [workId, chapterId, userId]);
+
+  // Load visibility from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem('ffy_annotations_visible');
+    if (stored !== null) setVisible(stored === 'true');
+  }, []);
+
+  // Toggle visibility
+  const toggleVisible = useCallback(() => {
+    setVisible(prev => {
+      const next = !prev;
+      localStorage.setItem('ffy_annotations_visible', String(next));
+      return next;
+    });
+  }, []);
+
+  // Handle text selection
+  useEffect(() => {
+    const prose = proseRef.current || document.querySelector('[data-chapter-content]');
+    if (!prose || !userId) return;
+
+    const handleSelection = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || !sel.rangeCount) {
+        // Don't hide create popup immediately — user may be clicking inside it
+        return;
+      }
+      const range = sel.getRangeAt(0);
+      // Check if selection is within the prose element
+      if (!prose.contains(range.startContainer) || !prose.contains(range.endContainer)) return;
+
+      const textContent = prose.textContent || '';
+      const preRange = document.createRange();
+      preRange.setStart(prose, 0);
+      preRange.setEnd(range.startContainer, range.startOffset);
+      const start = preRange.toString().length;
+      const end = start + range.toString().length;
+
+      if (end > start && end <= textContent.length) {
+        setSelectionRange({ start, end });
+        setShowCreate(true);
+      }
+    };
+
+    document.addEventListener('mouseup', handleSelection);
+    return () => document.removeEventListener('mouseup', handleSelection);
+  }, [userId]);
+
+  // Create annotation
+  const handleCreate = async () => {
+    if (!selectionRange || !noteText.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/annotations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          start_offset: selectionRange.start,
+          end_offset: selectionRange.end,
+          note_text: noteText.trim(),
+          color: selectedColor,
+          shared_with_author: shareWithAuthor ? 1 : 0,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setAnnotations(prev => [...prev, data.annotation || data]);
+        setNoteText('');
+        setSelectedColor('yellow');
+        setShareWithAuthor(false);
+        setShowCreate(false);
+        setSelectionRange(null);
+        window.getSelection()?.removeAllRanges();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Delete annotation
+  const handleDelete = async (id: number) => {
+    const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/annotations/${id}`, {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    });
+    if (res.ok) {
+      setAnnotations(prev => prev.filter(a => a.id !== id));
+      if (activeAnnotation === id) setActiveAnnotation(null);
+    }
+  };
+
+  // Update annotation
+  const handleUpdate = async () => {
+    if (!editingId) return;
+    const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/annotations/${editingId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ note_text: editNote.trim(), color: editColor, shared_with_author: editShared ? 1 : 0 }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setAnnotations(prev => prev.map(a => a.id === editingId ? (data.annotation || data) : a));
+      setEditingId(null);
+    }
+  };
+
+  // Toggle share with author
+  const handleToggleShare = async (id: number, current: boolean) => {
+    const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/annotations/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ shared_with_author: current ? 0 : 1 }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setAnnotations(prev => prev.map(a => a.id === id ? (data.annotation || data) : a));
+    }
+  };
+
+  // Render highlights
+  const renderHighlights = () => {
+    if (!visible || annotations.length === 0) return null;
+    const prose = proseRef.current || document.querySelector('[data-chapter-content]');
+    if (!prose) return null;
+
+    // We use a position: relative container for overlay highlights
+    return (
+      <div class="annotations-highlights">
+        {annotations.map(ann => {
+          const colorDef = COLORS.find(c => c.key === ann.color) || COLORS[0];
+          return (
+            <div
+              key={ann.id}
+              class="annotation-highlight"
+              data-annotation-id={ann.id}
+              style={{
+                '--ann-color': colorDef.bg,
+                '--ann-marker': colorDef.marker,
+              }}
+              onClick={() => setActiveAnnotation(activeAnnotation === ann.id ? null : ann.id)}
+            />
+          );
+        })}
+      </div>
+    );
+  };
+
+  // Annotation detail popup
+  const renderAnnotationDetail = () => {
+    if (!activeAnnotation) return null;
+    const ann = annotations.find(a => a.id === activeAnnotation);
+    if (!ann) return null;
+    const colorDef = COLORS.find(c => c.key === ann.color) || COLORS[0];
+    const isOwner = ann.userId === userId;
+
+    return (
+      <div class="annotation-tooltip">
+        {editingId === ann.id ? (
+          <div class="annotation-edit-form">
+            <textarea value={editNote} onInput={e => setEditNote((e.target as HTMLTextAreaElement).value)} rows={3} class="annotation-note-input" />
+            <div class="annotation-color-picker">
+              {COLORS.map(c => (
+                <button
+                  key={c.key}
+                  class={`annotation-color-swatch${editColor === c.key ? ' active' : ''}`}
+                  style={{ '--swatch-color': c.marker }}
+                  onClick={() => setEditColor(c.key)}
+                  aria-label={c.key}
+                />
+              ))}
+            </div>
+            <div class="annotation-actions">
+              <button class="annotation-btn-save" onClick={handleUpdate}>Save</button>
+              <button class="annotation-btn-cancel" onClick={() => setEditingId(null)}>Cancel</button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div class="annotation-tooltip-header">
+              <span class="annotation-tooltip-color" style={{ backgroundColor: colorDef.marker }} />
+              <span class="annotation-tooltip-time">{new Date(ann.createdAt).toLocaleDateString()}</span>
+            </div>
+            <p class="annotation-tooltip-text">{ann.noteText}</p>
+            {isOwner && (
+              <div class="annotation-actions">
+                <button class="annotation-btn-edit" onClick={() => { setEditingId(ann.id); setEditNote(ann.noteText); setEditColor(ann.color); setEditShared(!!ann.sharedWithAuthor); }}>Edit</button>
+                <button class="annotation-btn-delete" onClick={() => handleDelete(ann.id)}>Delete</button>
+                <label class="annotation-share-toggle">
+                  <input type="checkbox" checked={!!ann.sharedWithAuthor} onChange={() => handleToggleShare(ann.id, !!ann.sharedWithAuthor)} />
+                  Share with author
+                </label>
+              </div>
+            )}
+            {!isOwner && ann.sharedWithAuthor && (
+              <span class="annotation-shared-badge">Shared by author</span>
+            )}
+          </>
+        )}
+      </div>
+    );
+  };
+
+  if (!userId) return null; // Guests can't annotate
+
+  return (
+    <>
+      {/* Fragment root — no wrapper div to avoid layout issues */}
+      {/* Visibility toggle - renders in ReadingMode's focus sheet or as a floating button */}
+      <button
+        class={`annotation-toggle-btn${visible ? ' active' : ''}`}
+        onClick={toggleVisible}
+        aria-label={visible ? 'Hide annotations' : 'Show annotations'}
+        title={visible ? 'Hide annotations' : 'Show annotations'}
+      >
+        📝
+      </button>
+
+      {/* Annotation highlights overlay */}
+      {renderHighlights()}
+
+      {/* Create popup */}
+      {showCreate && selectionRange && (
+        <div class="annotation-create-popup">
+          <h4>Add Annotation</h4>
+          <textarea
+            value={noteText}
+            onInput={e => setNoteText((e.target as HTMLTextAreaElement).value)}
+            placeholder="Write a note..."
+            rows={3}
+            class="annotation-note-input"
+            autoFocus
+          />
+          <div class="annotation-color-picker">
+            {COLORS.map(c => (
+              <button
+                key={c.key}
+                class={`annotation-color-swatch${selectedColor === c.key ? ' active' : ''}`}
+                style={{ '--swatch-color': c.marker }}
+                onClick={() => setSelectedColor(c.key)}
+                aria-label={c.key}
+              />
+            ))}
+          </div>
+          <label class="annotation-share-toggle">
+            <input type="checkbox" checked={shareWithAuthor} onChange={() => setShareWithAuthor(!shareWithAuthor)} />
+            Share with author
+          </label>
+          <div class="annotation-actions">
+            <button class="annotation-btn-save" onClick={handleCreate} disabled={saving || !noteText.trim()}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button class="annotation-btn-cancel" onClick={() => { setShowCreate(false); setSelectionRange(null); window.getSelection()?.removeAllRanges(); }}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {/* Annotation detail popup */}
+      {renderAnnotationDetail()}
+
+      {/* Annotation list sidebar (visible toggle) */}
+      {visible && annotations.length > 0 && (
+        <div class="annotation-sidebar">
+          <h4>Your Annotations ({annotations.length})</h4>
+          {annotations.map(ann => {
+            const colorDef = COLORS.find(c => c.key === ann.color) || COLORS[0];
+            return (
+              <div
+                key={ann.id}
+                class={`annotation-sidebar-item${activeAnnotation === ann.id ? ' active' : ''}`}
+                onClick={() => setActiveAnnotation(ann.id)}
+              >
+                <span class="annotation-sidebar-color" style={{ backgroundColor: colorDef.marker }} />
+                <span class="annotation-sidebar-text">{ann.noteText || '(no text)'}</span>
+                {ann.sharedWithAuthor && <span class="annotation-shared-badge-mini">Shared</span>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -2,7 +2,7 @@ import { getDrizzle } from './db';
 import { notifications, notificationPreferences } from './schema';
 import { eq, and } from 'drizzle-orm';
 
-type NotificationType = 'comment_reply' | 'kudos' | 'new_chapter' | 'collection_invite' | 'work_featured' | 'system';
+type NotificationType = 'comment_reply' | 'kudos' | 'new_chapter' | 'collection_invite' | 'work_featured' | 'system' | 'annotation_shared';
 
 export type { NotificationType };
 

--- a/src/lib/schema/annotations.ts
+++ b/src/lib/schema/annotations.ts
@@ -1,0 +1,25 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { chapters } from './works';
+import { users } from './users';
+
+export const annotations = sqliteTable('annotations', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  chapterId: integer('chapter_id')
+    .notNull()
+    .references(() => chapters.id, { onDelete: 'cascade' }),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  startOffset: integer('start_offset').notNull(),
+  endOffset: integer('end_offset').notNull(),
+  noteText: text('note_text').notNull().default(''),
+  color: text('color', {
+    enum: ['yellow', 'green', 'blue', 'pink', 'orange'],
+  }).notNull().default('yellow'),
+  sharedWithAuthor: integer('shared_with_author').notNull().default(0),
+  createdAt: text('created_at').notNull().default("(datetime('now'))"),
+  updatedAt: text('updated_at').notNull().default("(datetime('now'))"),
+});
+
+export const idxAnnotationsChapterUser = index('idx_annotations_chapter_user').on(annotations.chapterId, annotations.userId);
+export const idxAnnotationsUser = index('idx_annotations_user').on(annotations.userId);

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -9,3 +9,4 @@ export * from './publish-log';
 export * from './moderation';
 export * from './notifications';
 export * from './api-keys';
+export * from './annotations';

--- a/src/lib/schema/notifications.ts
+++ b/src/lib/schema/notifications.ts
@@ -7,7 +7,7 @@ export const notifications = sqliteTable('notifications', {
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
   type: text('type', {
-    enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'],
+    enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system', 'annotation_shared'],
   }).notNull(),
   title: text('title').notNull(),
   body: text('body'),
@@ -24,7 +24,7 @@ export const notificationPreferences = sqliteTable('notification_preferences', {
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
   type: text('type', {
-    enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system'],
+    enum: ['comment_reply', 'kudos', 'new_chapter', 'collection_invite', 'work_featured', 'system', 'annotation_shared'],
   }).notNull(),
   enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
 }, (table) => ({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,9 +33,9 @@ function isPublicPath(pathname: string): boolean {
   if (pathname.startsWith('/api/bugs/')) return true;
   // Public read-only API endpoints
   // /api/works: read endpoints (GET) are public, write endpoints use requireAuth internally
-  // Only auth-gated sub-routes needing middleware protection: /progress, /mine
+  // Only auth-gated sub-routes needing middleware protection: /progress, /mine, /annotations
   if (pathname.startsWith('/api/works')) {
-    if (pathname.includes('/progress') || pathname.includes('/mine')) return false;
+    if (pathname.includes('/progress') || pathname.includes('/mine') || pathname.includes('/annotations')) return false;
     return true;
   }
   if (pathname.startsWith('/api/pseuds')) return true;

--- a/src/pages/api/works/[id]/chapters/[chapterId]/annotations/[annotationId].ts
+++ b/src/pages/api/works/[id]/chapters/[chapterId]/annotations/[annotationId].ts
@@ -1,0 +1,197 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { getAuth, checkApproved } from '@/lib/auth';
+import { annotations, chapters, creatorships, pseuds } from '@/lib/schema';
+import { createNotification } from '@/lib/notifications';
+import { eq, and, sql } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+const VALID_COLORS = ['yellow', 'green', 'blue', 'pink', 'orange'] as const;
+
+// GET — not needed (index covers listing). Return 405.
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { 'Content-Type': 'application/json' } });
+};
+
+// PUT /api/works/[id]/chapters/[chapterId]/annotations/[annotationId]
+// Update annotation. Auth + must be owner.
+export const PUT: APIRoute = async ({ params, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDrizzle(d1);
+  const auth = await getAuth(d1, request);
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const annotationId = Number(params.annotationId);
+  if (!annotationId) {
+    return new Response(JSON.stringify({ error: 'Invalid annotation ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Check ownership
+  const existing = await db.select().from(annotations)
+    .where(eq(annotations.id, annotationId))
+    .get();
+  if (!existing) {
+    return new Response(JSON.stringify({ error: 'Annotation not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (existing.userId !== auth.user.id) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const updates: Record<string, any> = {};
+  updates.updatedAt = sql`datetime('now')`;
+
+  if (body.note_text !== undefined) {
+    updates.noteText = String(body.note_text);
+  }
+  if (body.color !== undefined) {
+    if (!VALID_COLORS.includes(body.color)) {
+      return new Response(JSON.stringify({ error: `Invalid color. Must be one of: ${VALID_COLORS.join(', ')}` }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    updates.color = body.color;
+  }
+  if (body.shared_with_author !== undefined) {
+    updates.sharedWithAuthor = body.shared_with_author ? 1 : 0;
+  }
+
+  await db.update(annotations).set(updates).where(eq(annotations.id, annotationId));
+
+  const updated = await db.select().from(annotations)
+    .where(eq(annotations.id, annotationId))
+    .get();
+
+  return new Response(JSON.stringify({
+    id: updated!.id,
+    chapterId: updated!.chapterId,
+    userId: updated!.userId,
+    startOffset: updated!.startOffset,
+    endOffset: updated!.endOffset,
+    noteText: updated!.noteText,
+    color: updated!.color,
+    sharedWithAuthor: Boolean(updated!.sharedWithAuthor),
+    createdAt: updated!.createdAt,
+    updatedAt: updated!.updatedAt,
+  }), { headers: { 'Content-Type': 'application/json' } });
+};
+
+// PATCH /api/works/[id]/chapters/[chapterId]/annotations/[annotationId]
+// Toggle shared_with_author. Auth + must be owner.
+export const PATCH: APIRoute = async ({ params, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDrizzle(d1);
+  const auth = await getAuth(d1, request);
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const annotationId = Number(params.annotationId);
+  const workId = Number(params.id);
+  const chapterId = Number(params.chapterId);
+  if (!annotationId || !workId || !chapterId) {
+    return new Response(JSON.stringify({ error: 'Invalid parameters' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Check ownership
+  const existing = await db.select().from(annotations)
+    .where(eq(annotations.id, annotationId))
+    .get();
+  if (!existing) {
+    return new Response(JSON.stringify({ error: 'Annotation not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (existing.userId !== auth.user.id) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  if (body.shared_with_author === undefined || typeof body.shared_with_author !== 'boolean') {
+    return new Response(JSON.stringify({ error: 'shared_with_author (boolean) is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const newSharedValue = body.shared_with_author ? 1 : 0;
+
+  await db.update(annotations).set({
+    sharedWithAuthor: newSharedValue,
+    updatedAt: sql`datetime('now')`,
+  }).where(eq(annotations.id, annotationId));
+
+  // If sharing with author for the first time, notify the work author
+  if (newSharedValue === 1) {
+    // Find the work author's user ID
+    const authorRow = await db.select({ userId: pseuds.userId })
+      .from(creatorships)
+      .innerJoin(pseuds, eq(creatorships.pseudId, pseuds.id))
+      .where(eq(creatorships.workId, workId))
+      .limit(1)
+      .get();
+
+    if (authorRow && authorRow.userId !== auth.user.id) {
+      const displayName = auth.user.displayName || 'A reader';
+      await createNotification(d1, {
+        userId: authorRow.userId,
+        type: 'annotation_shared',
+        title: 'New annotation shared',
+        body: `${displayName} shared an annotation on your work`,
+        link: `/works/${workId}/read?chapter=${chapterId}`,
+      });
+    }
+  }
+
+  const updated = await db.select().from(annotations)
+    .where(eq(annotations.id, annotationId))
+    .get();
+
+  return new Response(JSON.stringify({
+    id: updated!.id,
+    chapterId: updated!.chapterId,
+    userId: updated!.userId,
+    startOffset: updated!.startOffset,
+    endOffset: updated!.endOffset,
+    noteText: updated!.noteText,
+    color: updated!.color,
+    sharedWithAuthor: Boolean(updated!.sharedWithAuthor),
+    createdAt: updated!.createdAt,
+    updatedAt: updated!.updatedAt,
+  }), { headers: { 'Content-Type': 'application/json' } });
+};
+
+// DELETE /api/works/[id]/chapters/[chapterId]/annotations/[annotationId]
+// Delete annotation. Auth + must be owner.
+export const DELETE: APIRoute = async ({ params, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDrizzle(d1);
+  const auth = await getAuth(d1, request);
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const annotationId = Number(params.annotationId);
+  if (!annotationId) {
+    return new Response(JSON.stringify({ error: 'Invalid annotation ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Check ownership
+  const existing = await db.select().from(annotations)
+    .where(eq(annotations.id, annotationId))
+    .get();
+  if (!existing) {
+    return new Response(JSON.stringify({ error: 'Annotation not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (existing.userId !== auth.user.id) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  await db.delete(annotations).where(eq(annotations.id, annotationId));
+
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/api/works/[id]/chapters/[chapterId]/annotations/index.ts
+++ b/src/pages/api/works/[id]/chapters/[chapterId]/annotations/index.ts
@@ -1,0 +1,145 @@
+export const prerender = false;
+
+import { getDrizzle } from '@/lib/db';
+import { getAuth, checkApproved } from '@/lib/auth';
+import { annotations, chapters } from '@/lib/schema';
+import { eq, and } from 'drizzle-orm';
+import type { APIRoute } from 'astro';
+
+const VALID_COLORS = ['yellow', 'green', 'blue', 'pink', 'orange'] as const;
+
+function formatAnnotation(a: any) {
+  return {
+    id: a.id,
+    chapterId: a.chapterId,
+    userId: a.userId,
+    startOffset: a.startOffset,
+    endOffset: a.endOffset,
+    noteText: a.noteText,
+    color: a.color,
+    sharedWithAuthor: Boolean(a.sharedWithAuthor),
+    createdAt: a.createdAt,
+    updatedAt: a.updatedAt,
+  };
+}
+
+// GET /api/works/[id]/chapters/[chapterId]/annotations
+// List annotations for a chapter. Requires auth.
+// Query params: ?shared=1 to also include annotations shared with author.
+export const GET: APIRoute = async ({ params, locals, request, url }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDrizzle(d1);
+  const auth = await getAuth(d1, request);
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+  const approved = checkApproved(auth);
+  if ('forbidden' in approved) {
+    return new Response(JSON.stringify({ error: approved.forbidden }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const workId = Number(params.id);
+  const chapterId = Number(params.chapterId);
+  if (!workId || !chapterId) {
+    return new Response(JSON.stringify({ error: 'Invalid parameters' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Verify chapter belongs to work
+  const chapter = await db.select({ id: chapters.id }).from(chapters)
+    .where(and(eq(chapters.id, chapterId), eq(chapters.workId, workId)))
+    .get();
+  if (!chapter) {
+    return new Response(JSON.stringify({ error: 'Chapter not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const includeShared = url.searchParams.get('shared') === '1';
+
+  // Fetch user's own annotations
+  const ownAnnotations = await db.select().from(annotations)
+    .where(and(eq(annotations.chapterId, chapterId), eq(annotations.userId, auth.user.id)));
+
+  let allAnnotations = [...ownAnnotations];
+
+  if (includeShared) {
+    // Include shared annotations from other users
+    const sharedAnnotations = await db.select().from(annotations)
+      .where(and(
+        eq(annotations.chapterId, chapterId),
+        eq(annotations.sharedWithAuthor, 1),
+      ));
+    // Add only those not already in the list (not owned by current user)
+    const ownIds = new Set(ownAnnotations.map(a => a.id));
+    for (const a of sharedAnnotations) {
+      if (!ownIds.has(a.id)) {
+        allAnnotations.push(a);
+      }
+    }
+  }
+
+  return new Response(JSON.stringify(allAnnotations.map(formatAnnotation)), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+// POST /api/works/[id]/chapters/[chapterId]/annotations
+// Create a new annotation. Requires auth + approved.
+export const POST: APIRoute = async ({ params, locals, request }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDrizzle(d1);
+  const auth = await getAuth(d1, request);
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  }
+  const approved = checkApproved(auth);
+  if ('forbidden' in approved) {
+    return new Response(JSON.stringify({ error: approved.forbidden }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const workId = Number(params.id);
+  const chapterId = Number(params.chapterId);
+  if (!workId || !chapterId) {
+    return new Response(JSON.stringify({ error: 'Invalid parameters' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  let body: any;
+  try { body = await request.json(); } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const { start_offset, end_offset, note_text, color, shared_with_author } = body || {};
+
+  // Validate offsets
+  if (typeof start_offset !== 'number' || typeof end_offset !== 'number' ||
+      !Number.isInteger(start_offset) || !Number.isInteger(end_offset) ||
+      start_offset < 0 || end_offset < 0 || start_offset >= end_offset) {
+    return new Response(JSON.stringify({ error: 'Invalid offsets. start_offset and end_offset must be non-negative integers with start < end.' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Validate color
+  if (!color || !VALID_COLORS.includes(color)) {
+    return new Response(JSON.stringify({ error: `Invalid color. Must be one of: ${VALID_COLORS.join(', ')}` }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Verify chapter belongs to work
+  const chapter = await db.select({ id: chapters.id }).from(chapters)
+    .where(and(eq(chapters.id, chapterId), eq(chapters.workId, workId)))
+    .get();
+  if (!chapter) {
+    return new Response(JSON.stringify({ error: 'Chapter not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const sharedInt = shared_with_author ? 1 : 0;
+
+  const result = await db.insert(annotations).values({
+    chapterId,
+    userId: auth.user.id,
+    startOffset: start_offset,
+    endOffset: end_offset,
+    noteText: note_text || '',
+    color,
+    sharedWithAuthor: sharedInt,
+  }).returning();
+
+  const a = result[0];
+  return new Response(JSON.stringify(formatAnnotation(a)), { status: 201, headers: { 'Content-Type': 'application/json' } });
+};

--- a/src/pages/works/[id]/read.astro
+++ b/src/pages/works/[id]/read.astro
@@ -6,6 +6,7 @@ import { eq, and, isNotNull, sql } from 'drizzle-orm';
 import { markdownToHtml } from '../../../lib/markdown';
 import { THEMES } from '../../../styles/themes';
 import ReadingMode from '../../../components/ReadingMode';
+import AnnotationsLayer from '../../../components/AnnotationsLayer';
 import TagCluster from '../../../components/TagCluster.tsx';
 import { buildCanonIndex, resolveCanonLinks } from '../../../lib/canon-resolver';
 
@@ -1212,6 +1213,11 @@ const moodCSS = (!moodDisabled && currentMood && MOOD_PALETTES[currentMood])
         myReactions={myReactions}
         fontSize={fontSizeClass}
         workTitle={work.title}
+      />
+      <AnnotationsLayer client:load
+        workId={workId}
+        chapterId={currentChapter.id}
+        userId={authUser?.id ?? null}
       />
     </section>
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -628,3 +628,273 @@ a.report-link:hover { text-decoration: underline; }
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ── Annotations ── */
+.annotation-toggle-btn {
+  position: fixed;
+  bottom: 80px;
+  right: 16px;
+  z-index: 50;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  font-size: 18px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  transition: background-color 0.2s, border-color 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.annotation-toggle-btn.active {
+  background: var(--md-sys-color-primary-container);
+  border-color: var(--md-sys-color-primary);
+}
+
+.annotation-highlight {
+  position: relative;
+  display: inline;
+  background: var(--ann-color, rgba(255, 235, 59, 0.2));
+  border-bottom: 2px solid var(--ann-marker, #FDD835);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+.annotation-highlight:hover {
+  background: var(--ann-color, rgba(255, 235, 59, 0.35));
+}
+
+.annotation-tooltip {
+  position: absolute;
+  z-index: 60;
+  min-width: 240px;
+  max-width: 340px;
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 12px;
+  padding: var(--space-3);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+  font: var(--md-sys-typescale-body-small);
+  color: var(--md-sys-color-on-surface);
+}
+.annotation-tooltip-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+.annotation-tooltip-color {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.annotation-tooltip-time {
+  font: var(--md-sys-typescale-label-small);
+  color: var(--md-sys-color-on-surface-variant);
+}
+.annotation-tooltip-text {
+  margin: var(--space-1) 0;
+  font: var(--md-sys-typescale-body-medium);
+  word-break: break-word;
+}
+.annotation-shared-badge {
+  display: inline-block;
+  font: var(--md-sys-typescale-label-small);
+  color: var(--md-sys-color-primary);
+  margin-top: var(--space-1);
+}
+.annotation-shared-badge-mini {
+  font: var(--md-sys-typescale-label-small);
+  color: var(--md-sys-color-primary);
+  margin-left: var(--space-1);
+}
+
+.annotation-create-popup,
+.annotation-edit-form {
+  position: fixed;
+  z-index: 70;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(90vw, 400px);
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 16px;
+  padding: var(--space-4);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  font: var(--md-sys-typescale-body-medium);
+  color: var(--md-sys-color-on-surface);
+}
+.annotation-create-popup h4 {
+  font: var(--md-sys-typescale-title-small);
+  margin: 0 0 var(--space-2) 0;
+  color: var(--md-sys-color-on-surface);
+}
+.annotation-note-input {
+  width: 100%;
+  min-height: 72px;
+  padding: var(--space-2);
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 8px;
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  font: var(--md-sys-typescale-body-medium);
+  resize: vertical;
+  margin-bottom: var(--space-2);
+}
+.annotation-note-input:focus {
+  outline: none;
+  border-color: var(--md-sys-color-primary);
+}
+.annotation-color-picker {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+.annotation-color-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: var(--swatch-color);
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.annotation-color-swatch.active {
+  border-color: var(--md-sys-color-on-surface);
+  transform: scale(1.15);
+}
+.annotation-color-swatch:hover {
+  transform: scale(1.1);
+}
+
+.annotation-share-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font: var(--md-sys-typescale-label-medium);
+  color: var(--md-sys-color-on-surface-variant);
+  margin-bottom: var(--space-2);
+  cursor: pointer;
+}
+.annotation-share-toggle input[type="checkbox"] {
+  accent-color: var(--md-sys-color-primary);
+}
+
+.annotation-actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.annotation-btn-save {
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: none;
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  font: var(--md-sys-typescale-label-large);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.annotation-btn-save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.annotation-btn-cancel {
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: transparent;
+  color: var(--md-sys-color-on-surface);
+  font: var(--md-sys-typescale-label-large);
+  cursor: pointer;
+}
+.annotation-btn-edit {
+  padding: 4px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: transparent;
+  color: var(--md-sys-color-on-surface);
+  font: var(--md-sys-typescale-label-small);
+  cursor: pointer;
+}
+.annotation-btn-delete {
+  padding: 4px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--md-sys-color-error);
+  background: transparent;
+  color: var(--md-sys-color-error);
+  font: var(--md-sys-typescale-label-small);
+  cursor: pointer;
+}
+
+.annotation-sidebar {
+  position: fixed;
+  right: 16px;
+  top: 80px;
+  width: 220px;
+  max-height: calc(100vh - 160px);
+  overflow-y: auto;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 12px;
+  padding: var(--space-3);
+  z-index: 40;
+  font: var(--md-sys-typescale-body-small);
+  color: var(--md-sys-color-on-surface);
+}
+.annotation-sidebar h4 {
+  font: var(--md-sys-typescaletitle-small);
+  margin: 0 0 var(--space-2) 0;
+  color: var(--md-sys-color-on-surface);
+}
+.annotation-sidebar-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  margin-bottom: var(--space-1);
+}
+.annotation-sidebar-item:hover {
+  background: var(--md-sys-color-surface-container-high);
+}
+.annotation-sidebar-item.active {
+  background: var(--md-sys-color-secondary-container);
+}
+.annotation-sidebar-color {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+.annotation-sidebar-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: var(--md-sys-typescale-body-small);
+}
+
+/* Mobile adjustments */
+@media (max-width: 839px) {
+  .annotation-sidebar {
+    display: none;
+  }
+  .annotation-create-popup,
+  .annotation-edit-form {
+    width: 95vw;
+    top: 50%;
+  }
+  .annotation-toggle-btn {
+    bottom: 72px;
+    right: 12px;
+  }
+}


### PR DESCRIPTION
## Inline Reader Annotations

Implements #23 — private reader annotations on chapter content.

### What's included

- **Schema**: `annotations` table with `start_offset`/`end_offset` (text-position-based), 5 color options, share-with-author flag, cascade deletes on chapter/user
- **API endpoints**:
  - `GET /api/works/:id/chapters/:cid/annotations` — list own annotations (opt-in `?shared=1` for author-shared)
  - `POST` — create annotation with text selection
  - `PUT /:annotationId` — full update
  - `PATCH /:annotationId` — toggle share-with-author
  - `DELETE /:annotationId` — delete (owner only)
- **Preact component** (`AnnotationsLayer`): text selection → create popup, color picker (5 colors), sidebar list, tooltip detail view, edit/delete actions, share-with-author toggle
- **CSS**: Full M3-themed annotation styles — highlights, tooltips, sidebar, create popup, mobile responsive
- **Reading page**: wired `AnnotationsLayer` island alongside `ReadingMode`
- **Middleware**: auth-gate annotation routes
- **Notifications**: added `annotation_shared` type for when readers share annotations with authors

### Files changed
| File | Change |
|------|--------|
| `drizzle/0006_annotations.sql` | New migration |
| `src/lib/schema/annotations.ts` | New table definition |
| `src/lib/schema/index.ts` | Re-export |
| `src/lib/schema/notifications.ts` | Add `annotation_shared` enum value |
| `src/lib/notifications.ts` | Add `annotation_shared` type |
| `src/middleware.ts` | Auth-gate annotation routes |
| `src/components/AnnotationsLayer.tsx` | New Preact island |
| `src/pages/api/.../annotations/index.ts` | GET + POST |
| `src/pages/api/.../annotations/[annotationId].ts` | PUT + PATCH + DELETE |
| `src/pages/works/[id]/read.astro` | Wire in AnnotationsLayer |
| `src/styles/theme.css` | Annotation CSS |

### Technical notes
- Uses **text offset** (character position within chapter prose) rather than DOM range for storage — stable across re-renders
- `?shared=1` query param lets authors see reader-shared annotations alongside their own
- Guest users see no annotation UI (component returns null)