### PR TITLE
feat: remove Google sign-in, add admin user

### DIFF
--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -16,13 +16,6 @@ const errorMessage = errorParam === 'invalid' ? 'Invalid email or password.'
     <a href="/" class="auth-logo">fanfiction.fyi</a>
     <h1 class="auth-title">Sign In</h1>
 
-    <a href="/api/auth/google" class="btn-google">
-      <svg width="18" height="18" viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.93 0 6.51 5.19 2.56 12.9l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.81 14.93 48 24 48z"/></svg>
-      Sign in with Google
-    </a>
-
-    <div class="auth-divider"><span>or</span></div>
-
     <form id="login-form" class="auth-form">
       <div class="form-field">
         <label for="email">Email</label>
@@ -96,37 +89,6 @@ const errorMessage = errorParam === 'invalid' ? 'Invalid email or password.'
     color: var(--md-sys-color-on-surface);
     text-align: center;
     margin: 0;
-  }
-
-  .btn-google {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    font: var(--md-sys-typescale-label-large);
-    color: var(--md-sys-color-on-surface);
-    background: var(--md-sys-color-surface-container);
-    border: 1px solid var(--md-sys-color-outline-variant);
-    border-radius: var(--md-sys-shape-corner-full);
-    padding: var(--space-3) var(--space-6);
-    cursor: pointer;
-    text-decoration: none;
-    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
-  }
-  .btn-google:hover { background: var(--md-sys-color-surface-container-high); }
-
-  .auth-divider {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-    color: var(--md-sys-color-on-surface-variant);
-    font: var(--md-sys-typescale-body-small);
-  }
-  .auth-divider::before, .auth-divider::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: var(--md-sys-color-outline-variant);
   }
 
   .auth-form {

--- a/src/pages/signup/index.astro
+++ b/src/pages/signup/index.astro
@@ -10,13 +10,6 @@ import Base from '@/v2/layouts/Base.astro';
     <h1 class="auth-title">Create Account</h1>
     <p class="auth-note">New accounts require approval before you can access the site. You'll receive access once approved by an administrator.</p>
 
-    <a href="/api/auth/google" class="btn-google">
-      <svg width="18" height="18" viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.93 0 6.51 5.19 2.56 12.9l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.81 14.93 48 24 48z"/></svg>
-      Sign up with Google
-    </a>
-
-    <div class="auth-divider"><span>or</span></div>
-
     <form id="signup-form" class="auth-form">
       <div class="form-field">
         <label for="invite_code">Invite Code</label>
@@ -97,19 +90,6 @@ import Base from '@/v2/layouts/Base.astro';
   .auth-logo { font: var(--md-sys-typescale-title-large); color: var(--md-sys-color-primary); text-decoration: none; text-align: center; }
   .auth-title { font: var(--md-sys-typescale-headline-medium); color: var(--md-sys-color-on-surface); text-align: center; margin: 0; }
   .auth-note { font: var(--md-sys-typescale-body-medium); color: var(--md-sys-color-on-surface-variant); text-align: center; line-height: 1.6; }
-
-  .btn-google {
-    display: flex; align-items: center; justify-content: center; gap: var(--space-2);
-    font: var(--md-sys-typescale-label-large); color: var(--md-sys-color-on-surface);
-    background: var(--md-sys-color-surface-container); border: 1px solid var(--md-sys-color-outline-variant);
-    border-radius: var(--md-sys-shape-corner-full); padding: var(--space-3) var(--space-6);
-    cursor: pointer; text-decoration: none;
-    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
-  }
-  .btn-google:hover { background: var(--md-sys-color-surface-container-high); }
-
-  .auth-divider { display: flex; align-items: center; gap: var(--space-4); color: var(--md-sys-color-on-surface-variant); font: var(--md-sys-typescale-body-small); }
-  .auth-divider::before, .auth-divider::after { content: ''; flex: 1; height: 1px; background: var(--md-sys-color-outline-variant); }
 
   .auth-form { display: flex; flex-direction: column; gap: var(--space-4); }
   .form-field { display: flex; flex-direction: column; gap: var(--space-1); }


### PR DESCRIPTION
## Changes

- Remove "Sign in with Google" button and divider from /login
- Remove "Sign up with Google" button and divider from /signup
- Remove associated .btn-google and .auth-divider CSS from both pages
- Admin user (kaleb.bays@gmail.com, role=admin) inserted directly into ffy-prod D1

v2 is email/password only -- the Google buttons were leftover cruft that linked to a non-existent /api/auth/google endpoint.