### PR TITLE
fix: resolve login persistence and studio 500

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,21 +46,23 @@ declare module 'astro:middleware' {
 // Reads the route's `config.auth` export if present, otherwise defaults to 'required'.
 
 function getAuthLevel(pathname: string, request: Request): AuthLevel {
-  // ─── Public pages (no auth needed) ──────────────────────────
-  if (pathname === '/' || pathname === '/login' || pathname === '/signup') return 'public';
+  // ─── Public pages (no auth, never needs user context) ───────
+  if (pathname === '/login' || pathname === '/signup') return 'public';
   if (pathname === '/pending-approval') return 'public';
   if (pathname === '/privacy' || pathname === '/terms') return 'public';
   if (pathname === '/feed.xml') return 'public';
 
-  // Public content: browse, read, search, tags, pseuds, works
-  if (pathname === '/works' || pathname.startsWith('/works/')) return 'public';
-  if (pathname === '/pseuds' || pathname.startsWith('/pseuds/')) return 'public';
-  if (pathname === '/tags' || pathname.startsWith('/tags/')) return 'public';
-  if (pathname === '/series' || pathname.startsWith('/series/')) return 'public';
-  if (pathname === '/collections' || pathname.startsWith('/collections/')) return 'public';
-  if (pathname === '/canon' || pathname.startsWith('/canon/')) return 'public';
-  if (pathname === '/characters' || pathname.startsWith('/characters/')) return 'public';
-  if (pathname === '/search') return 'public';
+  // ─── Optional pages (accessible without auth, but resolve user if session exists) ──
+  // Homepage and browse pages need user context for personalized nav (Sign In vs Profile)
+  if (pathname === '/') return 'optional';
+  if (pathname === '/works' || pathname.startsWith('/works/')) return 'optional';
+  if (pathname === '/pseuds' || pathname.startsWith('/pseuds/')) return 'optional';
+  if (pathname === '/tags' || pathname.startsWith('/tags/')) return 'optional';
+  if (pathname === '/series' || pathname.startsWith('/series/')) return 'optional';
+  if (pathname === '/collections' || pathname.startsWith('/collections/')) return 'optional';
+  if (pathname === '/canon' || pathname.startsWith('/canon/')) return 'optional';
+  if (pathname === '/characters' || pathname.startsWith('/characters/')) return 'optional';
+  if (pathname === '/search') return 'optional';
 
   // Static assets
   if (pathname.startsWith('/_astro/') || pathname.startsWith('/favicon')) return 'public';
@@ -237,6 +239,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
     .get();
 
   if (!session) {
+    // Optional routes: invalid/expired session → continue as guest (clear stale cookie)
+    if (authLevel === 'optional') {
+      const response = await next();
+      response.headers.set('Set-Cookie', CLEAR_COOKIE);
+      for (const [header, value] of Object.entries(cspHeaders())) {
+        response.headers.set(header, value);
+      }
+      return response;
+    }
     const headers: Record<string, string> = { 'Set-Cookie': CLEAR_COOKIE };
     if (isApi) {
       return jsonResponse({ error: 'Unauthorized' }, 401, headers);
@@ -259,6 +270,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
     .get();
 
   if (!user) {
+    // Optional routes: user not found → continue as guest
+    if (authLevel === 'optional') {
+      const response = await next();
+      response.headers.set('Set-Cookie', CLEAR_COOKIE);
+      for (const [header, value] of Object.entries(cspHeaders())) {
+        response.headers.set(header, value);
+      }
+      return response;
+    }
     const headers: Record<string, string> = { 'Set-Cookie': CLEAR_COOKIE };
     if (isApi) {
       return jsonResponse({ error: 'Unauthorized' }, 401, headers);
@@ -269,6 +289,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // ─── Banned users: destroy session, redirect ──────────────
   if (user.banned) {
     await db.delete(sessions).where(eq(sessions.token, token));
+    // Optional routes: banned → continue as guest (session already deleted)
+    if (authLevel === 'optional') {
+      const response = await next();
+      response.headers.set('Set-Cookie', CLEAR_COOKIE);
+      for (const [header, value] of Object.entries(cspHeaders())) {
+        response.headers.set(header, value);
+      }
+      return response;
+    }
     if (isApi) {
       return jsonResponse({ error: 'Banned' }, 403);
     }
@@ -279,6 +308,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
   if (user.suspendedUntil) {
     const suspendedTime = new Date(user.suspendedUntil + 'Z').getTime();
     if (Date.now() < suspendedTime) {
+      // Optional routes: suspended → continue as guest
+      if (authLevel === 'optional') {
+        const response = await next();
+        for (const [header, value] of Object.entries(cspHeaders())) {
+          response.headers.set(header, value);
+        }
+        return response;
+      }
       if (isApi) {
         return jsonResponse({ error: 'suspended', suspendedUntil: user.suspendedUntil }, 403);
       }
@@ -289,6 +326,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
   }
 
   // ─── Unapproved users: only access pending-approval page ──
+  // Optional routes: unapproved → treat as guest (no personalized features)
+  if (!user.approved && authLevel === 'optional') {
+    const response = await next();
+    for (const [header, value] of Object.entries(cspHeaders())) {
+      response.headers.set(header, value);
+    }
+    return response;
+  }
   if (!user.approved) {
     if (pathname === '/pending-approval' || pathname === '/api/auth/me' || pathname === '/api/auth/logout') {
       context.locals.user = user;

--- a/src/pages/studio/index.astro
+++ b/src/pages/studio/index.astro
@@ -6,29 +6,79 @@
 export const prerender = false;
 import Base from '@/v2/layouts/Base.astro';
 import WorkCard from '@/v2/components/WorkCard.astro';
+import { getDb } from '@/v2/lib/db';
+import { works, creatorships, pseuds } from '@/v2/lib/schema';
+import { eq, inArray, desc, sql } from 'drizzle-orm';
 
 const user = Astro.locals.user;
+const d1 = Astro.locals.runtime.env.DB as D1Database;
+const db = getDb(d1);
 
-// Fetch the user's pseuds to find their work IDs
 let drafts: any[] = [];
 let published: any[] = [];
 let errorMsg: string | null = null;
 
 try {
-  // Fetch the user's works (including drafts) via internal API
-  const res = await fetch(new URL('/api/works?mine=true&limit=100', Astro.url), {
-    headers: { cookie: Astro.request.headers.get('cookie') || '' },
-  });
-  if (res.ok) {
-    const json = await res.json();
-    const allWorks = json.data ?? [];
-    drafts = allWorks.filter((w: any) => w.draft);
-    published = allWorks.filter((w: any) => !w.draft);
-  } else {
-    errorMsg = 'Failed to load your works.';
+  // Get user's pseud IDs
+  const userPseuds = await db
+    .select({ id: pseuds.id })
+    .from(pseuds)
+    .where(eq(pseuds.userId, user.id))
+    .all();
+
+  const pseudIds = userPseuds.map(p => p.id);
+
+  if (pseudIds.length > 0) {
+    // Get work IDs via creatorships - query per pseud then deduplicate
+    // (inArray with pseudIds would be cleaner but we build it safely)
+    const workIdSet = new Set<number>();
+    for (const pseudId of pseudIds) {
+      const rows = await db
+        .select({ workId: creatorships.workId })
+        .from(creatorships)
+        .where(eq(creatorships.pseudId, pseudId))
+        .all();
+      for (const row of rows) workIdSet.add(row.workId);
+    }
+
+    const workIds = Array.from(workIdSet);
+
+    if (workIds.length > 0) {
+      // Fetch works including the draft field
+      const allWorks = workIds.length === 1
+        ? await db.select({
+            id: works.id,
+            title: works.title,
+            summary: works.summary,
+            language: works.language,
+            wordCount: works.wordCount,
+            complete: works.complete,
+            draft: works.draft,
+            workSkin: works.workSkin,
+            publishedAt: works.publishedAt,
+            createdAt: works.createdAt,
+            updatedAt: works.updatedAt,
+          }).from(works).where(eq(works.id, workIds[0])).orderBy(desc(works.updatedAt)).all()
+        : await db.select({
+            id: works.id,
+            title: works.title,
+            summary: works.summary,
+            language: works.language,
+            wordCount: works.wordCount,
+            complete: works.complete,
+            draft: works.draft,
+            workSkin: works.workSkin,
+            publishedAt: works.publishedAt,
+            createdAt: works.createdAt,
+            updatedAt: works.updatedAt,
+          }).from(works).where(inArray(works.id, workIds)).orderBy(desc(works.updatedAt)).all();
+
+      drafts = allWorks.filter(w => w.draft);
+      published = allWorks.filter(w => !w.draft);
+    }
   }
 } catch {
-  errorMsg = 'Network error loading your works.';
+  errorMsg = 'Error loading your works.';
 }
 ---
 

--- a/src/v2/pages/api/works/index.ts
+++ b/src/v2/pages/api/works/index.ts
@@ -209,6 +209,7 @@ export const GET: APIRoute = async ({ request, url, locals }) => {
     language: w.language,
     wordCount: w.wordCount,
     complete: w.complete,
+    draft: w.draft,
     workSkin: w.workSkin,
     publishedAt: w.publishedAt,
     createdAt: w.createdAt,


### PR DESCRIPTION
## Problems

1. **Login not persisting**: After signing in, user is redirected home but nav shows guest state (Sign In). The session cookie IS set correctly, but the middleware never reads it for `public` routes -- it skips session resolution entirely for pages like `/`, `/works`, `/search`, etc.

2. **Studio 500**: `/studio` makes an internal `fetch()` to `/api/works?mine=true`. On Cloudflare Pages, internal fetches to own routes may not propagate D1/R2 bindings in the subrequest, causing the API handler to crash when accessing `locals.runtime.env.DB`.

3. **Draft field missing**: GET /api/works response doesn't include the `draft` field, so the studio's `allWorks.filter(w => w.draft)` always produces empty drafts.

## Fixes

### Middleware (`src/middleware.ts`)
- Changed browse pages (homepage, works, search, tags, etc.) from `'public'` to `'optional'` so the middleware reads the session cookie when present and populates `Astro.locals.user`
- Login/signup/pending-approval/privacy/terms remain `'public'` (no user context needed)
- Added `optional`-route fallbacks: invalid session, missing user, banned/suspended/unapproved all continue as guest instead of redirecting to `/login`

### Studio page (`src/pages/studio/index.astro`)
- Replaced internal `fetch('/api/works?mine=true')` with direct D1 queries using the page's own `locals.runtime.env.DB`
- Eliminates Cloudflare Pages subrequest binding issue
- Includes `draft` field in the query so drafts/published split actually works

### Works API (`src/v2/pages/api/works/index.ts`)
- Added `draft` field to GET /api/works response