### PR TITLE
feat: Phase 2 — Tokenized Tags, Alias Management, Reading Sidebar, Chapter Versioning

### DIFF
--- a/src/pages/api/pseuds/[id].ts
+++ b/src/pages/api/pseuds/[id].ts
@@ -26,10 +26,10 @@ export const GET: APIRoute = async ({ params, locals }) => {
 
   // Get works by this pseud
   const pseudWorks = await db.select({ id: works.id, title: works.title, summary: works.summary, wordCount: works.wordCount, complete: works.complete, draft: works.draft, publishedAt: works.publishedAt, updatedAt: works.updatedAt })
-    .from(creatorships)
-    .innerJoin(works, eq(creatorships.workId, works.id))
-    .where(and(eq(creatorships.pseudId, pseudId), eq(works.draft, 0)))
-    .orderBy(works.updatedAt);
+  .from(creatorships)
+  .innerJoin(works, eq(creatorships.workId, works.id))
+  .where(and(eq(creatorships.pseudId, pseudId), eq(works.draft, 0)))
+  .orderBy(works.updatedAt);
 
   return new Response(JSON.stringify({
     data: {
@@ -64,6 +64,15 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   if (data.description !== undefined) updates.description = data.description;
   if (data.themeColor !== undefined) updates.themeColor = data.themeColor;
 
+  // Handle isDefault toggle
+  if (data.isDefault !== undefined && data.isDefault === 1) {
+    // Unset all other defaults for this user first
+    await db.update(pseuds)
+      .set({ isDefault: 0 })
+      .where(and(eq(pseuds.userId, auth.user.id), eq(pseuds.isDefault, 1)));
+    updates.isDefault = 1;
+  }
+
   // Check name uniqueness if changing
   if (updates.name && updates.name !== pseud.name) {
     const existing = await db.select().from(pseuds).where(eq(pseuds.name, updates.name)).get();
@@ -74,4 +83,35 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 
   const updated = await db.update(pseuds).set(updates).where(eq(pseuds.id, pseudId)).returning();
   return new Response(JSON.stringify({ data: updated[0] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+
+// DELETE /api/pseuds/:id — Delete pseud (owner only, cannot delete default)
+export const DELETE: APIRoute = async ({ params, request, locals }) => {
+  const pseudId = Number(params.id);
+  if (!pseudId || isNaN(pseudId)) {
+    return new Response(JSON.stringify({ error: 'Invalid pseud ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDb(d1);
+  const auth = await requireAuth(d1, request);
+
+  // Verify ownership
+  const pseud = await db.select().from(pseuds).where(eq(pseuds.id, pseudId)).get();
+  if (!pseud || pseud.userId !== auth.user.id) {
+    return new Response(JSON.stringify({ error: 'Not your pseud' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Cannot delete default pseud
+  if (pseud.isDefault === 1) {
+    return new Response(JSON.stringify({ error: 'Cannot delete your default alias. Set another alias as default first.' }), { status: 422, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Delete creatorships for this pseud first
+  await db.delete(creatorships).where(eq(creatorships.pseudId, pseudId));
+
+  // Delete the pseud
+  await db.delete(pseuds).where(eq(pseuds.id, pseudId));
+
+  return new Response(JSON.stringify({ data: { deleted: pseudId } }), { status: 200, headers: { 'Content-Type': 'application/json' } });
 };

--- a/src/pages/settings/aliases/index.astro
+++ b/src/pages/settings/aliases/index.astro
@@ -1,0 +1,879 @@
+---
+/**
+ * Alias / Pseud Management Page — Auth: required
+ * Sections: Add Alias form, Alias Card List with Edit/Delete/Set-as-Default
+ * POST/PUT/DELETE to /api/pseuds
+ */
+export const prerender = false;
+import Base from '@/v2/layouts/Base.astro';
+
+const user = Astro.locals.user;
+
+// Fetch the user's pseuds
+let pseudsList: any[] = [];
+let pseudsError: string | null = null;
+
+try {
+  const res = await fetch(new URL(`/api/pseuds?limit=100&userId=${user.id}`, Astro.url), {
+    headers: { cookie: Astro.request.headers.get('cookie') || '' },
+  });
+  if (res.ok) {
+    const json = await res.json();
+    pseudsList = json.data ?? [];
+  } else {
+    pseudsError = 'Failed to load aliases.';
+  }
+} catch {
+  pseudsError = 'Network error loading aliases.';
+}
+---
+
+<Base title="My Aliases — fanfiction.fyi" description="Manage your aliases and pseudonyms">
+  <section class="aliases-page">
+    <div class="aliases-header">
+      <a href="/settings" class="back-link">← Settings</a>
+      <h1 class="page-title">My Aliases</h1>
+      <button id="btn-add-alias" class="btn-filled" type="button">Add Alias</button>
+    </div>
+
+    {pseudsError && <div class="error-banner" role="alert">{pseudsError}</div>}
+
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+    <!-- ── Add Alias Form (hidden by default) ────────────────────── -->
+    <div id="add-form-wrapper" class="card add-form-card" style="display:none;">
+      <h2 class="card-heading">New Alias</h2>
+      <form id="add-alias-form" class="settings-form">
+        <div class="form-field">
+          <label for="add-name">Name <span class="required">*</span></label>
+          <input type="text" id="add-name" name="name" required maxlength="100" placeholder="e.g. inkshadow" />
+        </div>
+        <div class="form-field">
+          <label for="add-description">Description</label>
+          <textarea id="add-description" name="description" rows="3" maxlength="2000" class="textarea" placeholder="A short description of this persona..."></textarea>
+        </div>
+        <div class="form-field">
+          <label>Theme Color</label>
+          <div class="color-picker-row">
+            <button type="button" class="color-swatch" data-color="#6750A4" style="background:#6750A4;" title="#6750A4"></button>
+            <button type="button" class="color-swatch" data-color="#E8DEF8" style="background:#E8DEF8;" title="#E8DEF8"></button>
+            <button type="button" class="color-swatch" data-color="#B3261E" style="background:#B3261E;" title="#B3261E"></button>
+            <button type="button" class="color-swatch" data-color="#D0BCFF" style="background:#D0BCFF;" title="#D0BCFF"></button>
+            <button type="button" class="color-swatch" data-color="#0061A4" style="background:#0061A4;" title="#0061A4"></button>
+            <button type="button" class="color-swatch" data-color="#006C4C" style="background:#006C4C;" title="#006C4C"></button>
+            <button type="button" class="color-swatch" data-color="#7C5800" style="background:#7C5800;" title="#7C5800"></button>
+            <button type="button" class="color-swatch" data-color="#616B7A" style="background:#616B7A;" title="#616B7A"></button>
+            <input type="color" id="add-color-custom" class="color-input-custom" value="#6750A4" title="Custom color" />
+          </div>
+          <input type="hidden" id="add-themeColor" name="themeColor" value="" />
+        </div>
+        <div class="form-actions">
+          <button type="button" id="btn-add-cancel" class="btn-outlined">Cancel</button>
+          <button type="submit" class="btn-filled">Create Alias</button>
+        </div>
+      </form>
+    </div>
+
+    <!-- ── Alias Card List ──────────────────────────────────── -->
+    <div id="alias-list">
+      {pseudsList.length === 0 && !pseudsError && (
+        <div class="empty-state">
+          <p>You haven't created any aliases yet.</p>
+          <p class="empty-hint">Aliases let you publish works under different pen names.</p>
+        </div>
+      )}
+      {pseudsList.map((pseud: any) => (
+        <div class="alias-card" data-id={pseud.id} data-is-default={pseud.isDefault}>
+          <div class="alias-card__accent" style={`background: ${pseud.themeColor || 'var(--md-sys-color-outline-variant)'};`}></div>
+          <div class="alias-card__body">
+            <div class="alias-card__left">
+              <div class="alias-avatar" style={`background: ${pseud.themeColor || 'var(--md-sys-color-outline-variant)'}; color: ${pseud.themeColor ? '#fff' : 'var(--md-sys-color-on-surface-variant)'};`}>
+                {pseud.name.charAt(0).toUpperCase()}
+              </div>
+            </div>
+            <div class="alias-card__center">
+              <div class="alias-card__name-row">
+                <span class="alias-card__name">{pseud.name}</span>
+                {pseud.isDefault === 1 && <span class="badge-primary">Primary</span>}
+              </div>
+              {pseud.description && <p class="alias-card__desc">{pseud.description}</p>}
+              <div class="alias-card__stats">
+                <span class="alias-stat" data-pseud-id={pseud.id}>0 Published Works</span>
+              </div>
+            </div>
+            <div class="alias-card__right">
+              <button type="button" class="btn-icon alias-menu-trigger" aria-label="More options" data-menu-for={pseud.id}>⋮</button>
+              <div class="alias-dropdown" id={`dropdown-${pseud.id}`}>
+                {pseud.isDefault !== 1 && (
+                  <button type="button" class="dropdown-item" data-action="set-default" data-id={pseud.id}>Set as Default</button>
+                )}
+                <button type="button" class="dropdown-item" data-action="edit" data-id={pseud.id}>Edit</button>
+                {pseud.isDefault !== 1 && (
+                  <button type="button" class="dropdown-item dropdown-item--danger" data-action="delete" data-id={pseud.id}>Delete</button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <!-- ── Inline Edit Form (hidden by default) ──── -->
+          <div class="alias-edit-form" id={`edit-form-${pseud.id}`} style="display:none;">
+            <form class="settings-form edit-form-inner" data-edit-id={pseud.id}>
+              <div class="form-field">
+                <label>Name <span class="required">*</span></label>
+                <input type="text" class="edit-name" name="name" required maxlength="100" value={pseud.name} />
+              </div>
+              <div class="form-field">
+                <label>Description</label>
+                <textarea class="edit-description textarea" name="description" rows="3" maxlength="2000">{pseud.description || ''}</textarea>
+              </div>
+              <div class="form-field">
+                <label>Theme Color</label>
+                <div class="color-picker-row edit-color-picker" data-edit-id={pseud.id}>
+                  <button type="button" class="color-swatch" data-color="#6750A4" style="background:#6750A4;" title="#6750A4"></button>
+                  <button type="button" class="color-swatch" data-color="#E8DEF8" style="background:#E8DEF8;" title="#E8DEF8"></button>
+                  <button type="button" class="color-swatch" data-color="#B3261E" style="background:#B3261E;" title="#B3261E"></button>
+                  <button type="button" class="color-swatch" data-color="#D0BCFF" style="background:#D0BCFF;" title="#D0BCFF"></button>
+                  <button type="button" class="color-swatch" data-color="#0061A4" style="background:#0061A4;" title="#0061A4"></button>
+                  <button type="button" class="color-swatch" data-color="#006C4C" style="background:#006C4C;" title="#006C4C"></button>
+                  <button type="button" class="color-swatch" data-color="#7C5800" style="background:#7C5800;" title="#7C5800"></button>
+                  <button type="button" class="color-swatch" data-color="#616B7A" style="background:#616B7A;" title="#616B7A"></button>
+                  <input type="color" class="edit-color-custom color-input-custom" value={pseud.themeColor || '#6750A4'} title="Custom color" />
+                </div>
+                <input type="hidden" class="edit-themeColor" name="themeColor" value={pseud.themeColor || ''} />
+              </div>
+              <div class="form-actions">
+                <button type="button" class="btn-outlined btn-edit-cancel" data-edit-cancel={pseud.id}>Cancel</button>
+                <button type="submit" class="btn-filled">Save Changes</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    <!-- ── Delete Confirmation Modal ──────────────────────────── -->
+    <div id="delete-modal" class="modal-overlay" style="display:none;">
+      <div class="modal-dialog">
+        <h3 class="modal-title">Delete Alias</h3>
+        <p id="delete-modal-text" class="modal-body">Are you sure you want to delete this alias? This cannot be undone.</p>
+        <div class="modal-actions">
+          <button type="button" id="btn-delete-cancel" class="btn-outlined">Cancel</button>
+          <button type="button" id="btn-delete-confirm" class="btn-filled btn-filled--danger">Delete</button>
+        </div>
+      </div>
+    </div>
+  </section>
+</Base>
+
+<script>
+  // ─── Toast helper ────────────────────────────────────────────────
+  function showToast(message: string, type: 'success' | 'error' = 'success') {
+    const toast = document.getElementById('toast')!;
+    toast.textContent = message;
+    toast.className = `toast toast--${type} toast--show`;
+    setTimeout(() => { toast.className = 'toast'; }, 3000);
+  }
+
+  // ─── State ───────────────────────────────────────────────────────
+  let deleteTargetId: number | null = null;
+
+  // ─── Fetch pseuds and re-render ────────────────────────────────
+  async function fetchAndReload() {
+    // Server-rendered page — just reload to get fresh data
+    location.reload();
+  }
+
+  // ─── Load work counts per pseud ──────────────────────────────
+  async function loadWorkCounts() {
+    const statEls = document.querySelectorAll<HTMLElement>('.alias-stat[data-pseud-id]');
+    for (const el of statEls) {
+      const pseudId = el.getAttribute('data-pseud-id');
+      if (!pseudId) continue;
+      try {
+        const res = await fetch(`/api/pseuds/${pseudId}`);
+        if (res.ok) {
+          const json = await res.json();
+          const works = json.data?.works ?? [];
+          const published = works.filter((w: any) => !w.draft).length;
+          el.textContent = `${published} Published Work${published !== 1 ? 's' : ''}`;
+        }
+      } catch {
+        // Non-fatal, leave default "0 Published Works"
+      }
+    }
+  }
+  loadWorkCounts();
+
+  // ─── Add Alias Toggle ────────────────────────────────────────
+  const addWrapper = document.getElementById('add-form-wrapper')!;
+  const btnAdd = document.getElementById('btn-add-alias')!;
+  const btnCancelAdd = document.getElementById('btn-add-cancel')!;
+
+  btnAdd.addEventListener('click', () => {
+    const isOpen = addWrapper.style.display !== 'none';
+    addWrapper.style.display = isOpen ? 'none' : 'block';
+    if (!isOpen) {
+      (document.getElementById('add-name') as HTMLInputElement).focus();
+    }
+  });
+
+  btnCancelAdd.addEventListener('click', () => {
+    addWrapper.style.display = 'none';
+    (document.getElementById('add-alias-form') as HTMLFormElement).reset();
+    document.getElementById('add-themeColor')!.setAttribute('value', '');
+    // Clear swatch selection
+    addWrapper.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
+  });
+
+  // ─── Color Picker (Add Form) ────────────────────────────────
+  const addSwatches = addWrapper.querySelectorAll<HTMLButtonElement>('.color-swatch');
+  const addColorCustom = document.getElementById('add-color-custom') as HTMLInputElement;
+  const addThemeColor = document.getElementById('add-themeColor') as HTMLInputElement;
+
+  addSwatches.forEach(swatch => {
+    swatch.addEventListener('click', () => {
+      addSwatches.forEach(s => s.classList.remove('selected'));
+      swatch.classList.add('selected');
+      addThemeColor.value = swatch.dataset.color || '';
+    });
+  });
+
+  addColorCustom.addEventListener('input', () => {
+    addSwatches.forEach(s => s.classList.remove('selected'));
+    addThemeColor.value = addColorCustom.value;
+  });
+
+  // ─── Add Alias Submit ───────────────────────────────────────
+  const addForm = document.getElementById('add-alias-form') as HTMLFormElement;
+  addForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = (document.getElementById('add-name') as HTMLInputElement).value.trim();
+    if (!name) { showToast('Name is required.', 'error'); return; }
+    const description = (document.getElementById('add-description') as HTMLTextAreaElement).value.trim();
+    const themeColor = addThemeColor.value || undefined;
+
+    try {
+      const res = await fetch('/api/pseuds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, description: description || undefined, themeColor }),
+      });
+      if (res.ok) {
+        showToast('Alias created!');
+        location.reload();
+      } else {
+        const data = await res.json();
+        showToast(data.error || 'Failed to create alias.', 'error');
+      }
+    } catch {
+      showToast('Network error.', 'error');
+    }
+  });
+
+  // ─── Three-Dot Menu Toggle ──────────────────────────────────
+  document.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    // Close all dropdowns first
+    document.querySelectorAll('.alias-dropdown').forEach(d => {
+      (d as HTMLElement).classList.remove('open');
+    });
+    // If clicking a trigger, open its dropdown
+    if (target.classList.contains('alias-menu-trigger')) {
+      const pseudId = target.dataset.menuFor;
+      if (pseudId) {
+        const dropdown = document.getElementById(`dropdown-${pseudId}`);
+        if (dropdown) {
+          e.stopPropagation();
+          dropdown.classList.toggle('open');
+        }
+      }
+    }
+  });
+
+  // ─── Dropdown Actions ───────────────────────────────────────
+  document.addEventListener('click', async (e) => {
+    const target = e.target as HTMLElement;
+    if (!target.classList.contains('dropdown-item')) return;
+
+    const action = target.dataset.action;
+    const id = Number(target.dataset.id);
+    if (!action || !id) return;
+
+    // Close dropdown
+    document.querySelectorAll('.alias-dropdown').forEach(d => d.classList.remove('open'));
+
+    if (action === 'set-default') {
+      try {
+        const res = await fetch(`/api/pseuds/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ isDefault: 1 }),
+        });
+        if (res.ok) {
+          showToast('Default alias updated!');
+          location.reload();
+        } else {
+          const data = await res.json();
+          showToast(data.error || 'Failed to set default.', 'error');
+        }
+      } catch {
+        showToast('Network error.', 'error');
+      }
+    }
+
+    if (action === 'edit') {
+      const editForm = document.getElementById(`edit-form-${id}`);
+      if (editForm) {
+        const isVisible = editForm.style.display !== 'none';
+        // Close all edit forms first
+        document.querySelectorAll('.alias-edit-form').forEach(f => f.style.display = 'none');
+        editForm.style.display = isVisible ? 'none' : 'block';
+      }
+    }
+
+    if (action === 'delete') {
+      deleteTargetId = id;
+      // Find the pseud name for the confirmation message
+      const card = document.querySelector(`.alias-card[data-id="${id}"]`);
+      const name = card?.querySelector('.alias-card__name')?.textContent || 'this alias';
+      document.getElementById('delete-modal-text')!.textContent =
+        `Are you sure you want to delete "${name}"? This cannot be undone.`;
+      (document.getElementById('delete-modal') as HTMLElement).style.display = 'flex';
+    }
+  });
+
+  // ─── Edit Color Picker ────────────────────────────────────
+  document.querySelectorAll('.edit-color-picker').forEach(picker => {
+    const editId = picker.getAttribute('data-edit-id');
+    if (!editId) return;
+    const editForm = document.querySelector(`.edit-form-inner[data-edit-id="${editId}"]`) as HTMLElement | null;
+    if (!editForm) return;
+    const themeInput = editForm.querySelector('.edit-themeColor') as HTMLInputElement;
+    const customInput = picker.querySelector('.edit-color-custom') as HTMLInputElement;
+    const swatches = picker.querySelectorAll<HTMLButtonElement>('.color-swatch');
+
+    swatches.forEach(swatch => {
+      swatch.addEventListener('click', () => {
+        swatches.forEach(s => s.classList.remove('selected'));
+        swatch.classList.add('selected');
+        if (themeInput) themeInput.value = swatch.dataset.color || '';
+      });
+    });
+
+    if (customInput) {
+      customInput.addEventListener('input', () => {
+        swatches.forEach(s => s.classList.remove('selected'));
+        if (themeInput) themeInput.value = customInput.value;
+      });
+    }
+  });
+
+  // ─── Edit Cancel ──────────────────────────────────────────
+  document.querySelectorAll('.btn-edit-cancel').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const editId = (btn as HTMLElement).dataset.editCancel;
+      if (editId) {
+        const editForm = document.getElementById(`edit-form-${editId}`);
+        if (editForm) editForm.style.display = 'none';
+      }
+    });
+  });
+
+  // ─── Edit Submit ──────────────────────────────────────────
+  document.querySelectorAll('.edit-form-inner').forEach(form => {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const editId = (form as HTMLElement).dataset.editId;
+      if (!editId) return;
+      const name = (form.querySelector('.edit-name') as HTMLInputElement).value.trim();
+      if (!name) { showToast('Name is required.', 'error'); return; }
+      const description = (form.querySelector('.edit-description') as HTMLTextAreaElement).value.trim();
+      const themeColor = (form.querySelector('.edit-themeColor') as HTMLInputElement).value || undefined;
+
+      try {
+        const res = await fetch(`/api/pseuds/${editId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, description: description || undefined, themeColor }),
+        });
+        if (res.ok) {
+          showToast('Alias updated!');
+          location.reload();
+        } else {
+          const data = await res.json();
+          showToast(data.error || 'Failed to update alias.', 'error');
+        }
+      } catch {
+        showToast('Network error.', 'error');
+      }
+    });
+  });
+
+  // ─── Delete Modal ─────────────────────────────────────────
+  const deleteModal = document.getElementById('delete-modal')!;
+  const btnDeleteCancel = document.getElementById('btn-delete-cancel')!;
+  const btnDeleteConfirm = document.getElementById('btn-delete-confirm')!;
+
+  btnDeleteCancel.addEventListener('click', () => {
+    deleteModal.style.display = 'none';
+    deleteTargetId = null;
+  });
+
+  deleteModal.addEventListener('click', (e) => {
+    if (e.target === deleteModal) {
+      deleteModal.style.display = 'none';
+      deleteTargetId = null;
+    }
+  });
+
+  btnDeleteConfirm.addEventListener('click', async () => {
+    if (!deleteTargetId) return;
+    try {
+      const res = await fetch(`/api/pseuds/${deleteTargetId}`, { method: 'DELETE' });
+      if (res.ok) {
+        showToast('Alias deleted.');
+        location.reload();
+      } else {
+        const data = await res.json();
+        showToast(data.error || 'Failed to delete alias.', 'error');
+      }
+    } catch {
+      showToast('Network error.', 'error');
+    } finally {
+      deleteModal.style.display = 'none';
+      deleteTargetId = null;
+    }
+  });
+</script>
+
+<style is:global>
+  .aliases-page {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .aliases-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    margin-bottom: var(--space-8);
+    flex-wrap: wrap;
+  }
+
+  .back-link {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+  }
+  .back-link:hover { text-decoration: underline; }
+
+  .aliases-header .page-title {
+    font: var(--md-sys-typescale-headline-medium);
+    margin: 0;
+    flex: 1;
+  }
+
+  /* ─── Error Banner ─────────────────────────────────────── */
+  .error-banner {
+    background: var(--md-sys-color-error);
+    color: var(--md-sys-color-on-error);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-6);
+    font: var(--md-sys-typescale-body-medium);
+  }
+
+  /* ─── Toast ────────────────────────────────────────────── */
+  .toast {
+    position: fixed;
+    bottom: var(--space-8);
+    left: 50%;
+    transform: translateX(-50%) translateY(100px);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-3) var(--space-6);
+    font: var(--md-sys-typescale-body-medium);
+    z-index: 1000;
+    opacity: 0;
+    transition: transform 0.3s var(--md-sys-motion-easing-standard), opacity 0.3s var(--md-sys-motion-easing-standard);
+    pointer-events: none;
+  }
+  .toast--show {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+  .toast--success {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+  .toast--error {
+    background: var(--md-sys-color-error);
+    color: var(--md-sys-color-on-error);
+  }
+
+  /* ─── Card ─────────────────────────────────────────────── */
+  .card {
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    padding: var(--space-6);
+    margin-bottom: var(--space-6);
+  }
+
+  .add-form-card {
+    border: 2px dashed var(--md-sys-color-primary);
+    background: var(--md-sys-color-surface-container-low);
+  }
+
+  .card-heading {
+    font: var(--md-sys-typescale-title-large);
+    margin: 0 0 var(--space-4) 0;
+    color: var(--md-sys-color-on-surface);
+  }
+
+  /* ─── Alias Card ─────────────────────────────────────────── */
+  .alias-card {
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    margin-bottom: var(--space-4);
+    overflow: visible;
+    position: relative;
+  }
+
+  .alias-card__accent {
+    height: 3px;
+    border-radius: var(--md-sys-shape-corner-large) var(--md-sys-shape-corner-large) 0 0;
+  }
+
+  .alias-card__body {
+    display: flex;
+    align-items: flex-start;
+    padding: var(--space-4) var(--space-5);
+    gap: var(--space-4);
+  }
+
+  .alias-card__left {
+    flex-shrink: 0;
+  }
+
+  .alias-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font: var(--md-sys-typescale-headline-small);
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .alias-card__center {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .alias-card__name-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .alias-card__name {
+    font: var(--md-sys-typescale-title-medium);
+    color: var(--md-sys-color-on-surface);
+    font-weight: 600;
+  }
+
+  .badge-primary {
+    font: var(--md-sys-typescale-label-small);
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+    padding: 2px var(--space-2);
+    border-radius: var(--md-sys-shape-corner-full);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .alias-card__desc {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: var(--space-1) 0 0 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .alias-card__stats {
+    display: flex;
+    gap: var(--space-4);
+    margin-top: var(--space-2);
+  }
+
+  .alias-stat {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .alias-card__right {
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  /* ─── Three-Dot Menu ────────────────────────────────────── */
+  .btn-icon {
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: transparent;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 1.25rem;
+    color: var(--md-sys-color-on-surface-variant);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s;
+  }
+  .btn-icon:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+
+  .alias-dropdown {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 50;
+    min-width: 160px;
+    background: var(--md-sys-color-surface-container-high);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    padding: var(--space-1) 0;
+  }
+  .alias-dropdown.open {
+    display: block;
+  }
+
+  .dropdown-item {
+    display: block;
+    width: 100%;
+    padding: var(--space-3) var(--space-4);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+    text-align: left;
+    transition: background 0.1s;
+  }
+  .dropdown-item:hover {
+    background: var(--md-sys-color-surface-container-highest);
+  }
+  .dropdown-item--danger {
+    color: var(--md-sys-color-error);
+  }
+  .dropdown-item--danger:hover {
+    background: var(--md-sys-color-error-container);
+    color: var(--md-sys-color-on-error-container);
+  }
+
+  /* ─── Edit Form ──────────────────────────────────────────── */
+  .alias-edit-form {
+    border-top: 1px solid var(--md-sys-color-outline-variant);
+    padding: var(--space-5) var(--space-5) var(--space-4);
+    background: var(--md-sys-color-surface-container-low);
+  }
+
+  .edit-form-inner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  /* ─── Form shared ───────────────────────────────────────── */
+  .settings-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .form-field label {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .required {
+    color: var(--md-sys-color-error);
+  }
+
+  .form-field input,
+  .form-field .select,
+  .form-field .textarea {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface);
+    background: var(--md-sys-color-surface);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-3) var(--space-4);
+    outline: none;
+    transition: border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .form-field input:focus,
+  .form-field .select:focus,
+  .form-field .textarea:focus {
+    border-color: var(--md-sys-color-primary);
+  }
+
+  .textarea {
+    resize: vertical;
+    min-height: 5rem;
+    font-family: inherit;
+  }
+
+  .form-actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: flex-end;
+  }
+
+  /* ─── Color Picker ─────────────────────────────────────── */
+  .color-picker-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+
+  .color-swatch {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.1s;
+    padding: 0;
+  }
+  .color-swatch:hover {
+    transform: scale(1.1);
+  }
+  .color-swatch.selected {
+    border-color: var(--md-sys-color-on-surface);
+    outline: 2px solid var(--md-sys-color-primary);
+    outline-offset: 2px;
+  }
+
+  .color-input-custom {
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: 50%;
+    padding: 2px;
+    cursor: pointer;
+    background: transparent;
+  }
+
+  /* ─── Buttons ────────────────────────────────────────────── */
+  .btn-filled {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-8);
+    cursor: pointer;
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+  .btn-filled:hover { opacity: 0.88; }
+  .btn-filled:disabled { opacity: 0.5; cursor: not-allowed; }
+  .btn-filled--danger {
+    background: var(--md-sys-color-error);
+    color: var(--md-sys-color-on-error);
+  }
+
+  .btn-outlined {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-8);
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .btn-outlined:hover {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+
+  /* ─── Empty State ──────────────────────────────────────── */
+  .empty-state {
+    text-align: center;
+    padding: var(--space-8) var(--space-4);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+  .empty-state p {
+    font: var(--md-sys-typescale-body-large);
+    margin: 0 0 var(--space-2) 0;
+  }
+  .empty-hint {
+    font: var(--md-sys-typescale-body-medium);
+    opacity: 0.7;
+  }
+
+  /* ─── Modal ────────────────────────────────────────────── */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+
+  .modal-dialog {
+    background: var(--md-sys-color-surface-container-high);
+    border-radius: var(--md-sys-shape-corner-extra-large);
+    padding: var(--space-6);
+    max-width: 24rem;
+    width: 90%;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+  }
+
+  .modal-title {
+    font: var(--md-sys-typescale-headline-small);
+    margin: 0 0 var(--space-3) 0;
+    color: var(--md-sys-color-on-surface);
+  }
+
+  .modal-body {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-5) 0;
+  }
+
+  .modal-actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: flex-end;
+  }
+</style>

--- a/src/pages/settings/index.astro
+++ b/src/pages/settings/index.astro
@@ -52,6 +52,15 @@ const skinOptions = [
 
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
 
+    <!-- ── Navigation ────────────────────────────────────────────── -->
+    <nav class="settings-nav">
+      <a href="/settings/aliases" class="settings-nav__item">
+        <span class="settings-nav__icon">👥</span>
+        <span class="settings-nav__label">Manage Aliases</span>
+        <span class="settings-nav__arrow">→</span>
+      </a>
+    </nav>
+
     {profile && (
       <>
         <!-- ── Profile Section ──────────────────────────────── -->
@@ -410,4 +419,40 @@ const skinOptions = [
   }
   .btn-filled:hover { opacity: 0.88; }
   .btn-filled:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  /* ─── Settings Nav ──────────────────────────────────────── */
+  .settings-nav {
+    margin-bottom: var(--space-6);
+  }
+
+  .settings-nav__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-5);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    text-decoration: none;
+    color: var(--md-sys-color-on-surface);
+    transition: background 0.15s;
+  }
+
+  .settings-nav__item:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+
+  .settings-nav__icon {
+    font-size: 1.25rem;
+  }
+
+  .settings-nav__label {
+    font: var(--md-sys-typescale-title-medium);
+    flex: 1;
+  }
+
+  .settings-nav__arrow {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface-variant);
+  }
 </style>

--- a/src/pages/studio/[id]/chapters/[chapterId]/edit.astro
+++ b/src/pages/studio/[id]/chapters/[chapterId]/edit.astro
@@ -89,11 +89,17 @@ if (!chapter && !errorMsg) {
           <span>Keep as Draft</span>
         </label>
 
+        <div class="form-field">
+          <label for="version-note">Version Note <span class="field-hint-inline">(optional — describe what changed)</span></label>
+          <input type="text" id="version-note" name="versionNote" maxlength="500" placeholder="e.g. Fixed typos, Added scene, Revised ending" />
+        </div>
+
         <div class="form-actions">
           <button type="submit" class="btn-filled" id="submit-btn">
             <span class="btn-text">Save Chapter</span>
             <span class="btn-loading" style="display:none;">Saving...</span>
           </button>
+          <a href={`/studio/${workId}/chapters/${chapterId}/history`} class="btn-outlined">History</a>
           <a href={`/studio/${workId}/edit`} class="btn-outlined">Cancel</a>
           <button type="button" id="delete-btn" class="btn-danger-outline">Delete Chapter</button>
         </div>
@@ -145,8 +151,10 @@ if (!chapter && !errorMsg) {
     const contentMd = contentEditor.value || null;
     const mood = (document.getElementById('mood') as HTMLInputElement).value || null;
     const draft = (document.getElementById('draft-toggle') as HTMLInputElement).checked;
+    const versionNote = (document.getElementById('version-note') as HTMLInputElement).value || null;
 
     const body: Record<string, any> = { title, contentMd, mood, draft: draft };
+    if (versionNote) body.versionNote = versionNote;
 
     // Handle position change via reorder API
     const position = parseInt((document.getElementById('position') as HTMLInputElement).value, 10);

--- a/src/pages/studio/[id]/chapters/[chapterId]/history.astro
+++ b/src/pages/studio/[id]/chapters/[chapterId]/history.astro
@@ -1,0 +1,434 @@
+---
+/**
+ * Studio: Chapter Version History — View, compare, and restore previous versions.
+ * Auth: required (enforced by middleware default).
+ */
+export const prerender = false;
+import Base from '@/v2/layouts/Base.astro';
+
+const workId = Number(Astro.params.id);
+const chapterId = Number(Astro.params.chapterId);
+if (!workId || Number.isNaN(workId) || !chapterId || Number.isNaN(chapterId)) {
+  return Astro.redirect('/studio');
+}
+
+// Fetch work, chapter, and version data
+let work: any = null;
+let chapter: any = null;
+let versions: any[] = [];
+let errorMsg: string | null = null;
+
+try {
+  const [workRes, chapterRes, versionsRes] = await Promise.all([
+    fetch(new URL(`/api/works/${workId}`, Astro.url), {
+      headers: { cookie: Astro.request.headers.get('cookie') || '' },
+    }),
+    fetch(new URL(`/api/works/${workId}/chapters/${chapterId}`, Astro.url), {
+      headers: { cookie: Astro.request.headers.get('cookie') || '' },
+    }),
+    fetch(new URL(`/api/works/${workId}/chapters/${chapterId}/versions`, Astro.url), {
+      headers: { cookie: Astro.request.headers.get('cookie') || '' },
+    }),
+  ]);
+
+  if (workRes.ok) {
+    work = (await workRes.json()).data;
+  } else {
+    return Astro.redirect('/studio');
+  }
+
+  if (chapterRes.ok) {
+    chapter = (await chapterRes.json()).data;
+  } else {
+    return Astro.redirect(`/studio/${workId}/edit`);
+  }
+
+  if (versionsRes.ok) {
+    versions = (await versionsRes.json()).data;
+  }
+} catch {
+  errorMsg = 'Failed to load version history.';
+}
+---
+
+<Base title={`History: ${chapter?.title ?? 'Chapter'} — ${work?.title ?? 'Work'} — fanfiction.fyi`} description="Chapter version history">
+  <section class="studio-page">
+    <div class="studio-header">
+      <a href={`/studio/${workId}/chapters/${chapterId}/edit`} class="back-link">← Back to Edit</a>
+      <h1 class="studio-title">Version History</h1>
+      <p class="subtitle">{chapter?.title ?? 'Chapter'}</p>
+    </div>
+
+    {errorMsg && <p class="error-msg">{errorMsg}</p>}
+
+    {versions.length === 0 && !errorMsg && (
+      <p class="empty-msg">No version history yet. Versions are saved automatically when you update a chapter.</p>
+    )}
+
+    {versions.length > 0 && (
+      <ol class="version-timeline" id="version-list">
+        {versions.map((v: any, i: number) => {
+          const prevVersion = versions[i + 1]; // next item is older (list is desc by version number)
+          const wordDiff = prevVersion ? v.wordCount - prevVersion.wordCount : null;
+          const diffClass = wordDiff !== null && wordDiff > 0 ? 'diff-positive' : wordDiff !== null && wordDiff < 0 ? 'diff-negative' : 'diff-neutral';
+          const diffLabel = wordDiff !== null
+            ? wordDiff > 0 ? `+${wordDiff} words` : wordDiff < 0 ? `${wordDiff} words` : 'No change'
+            : '';
+          return (
+            <li class="version-item" data-version-id={v.id} data-version={v.version}>
+              <div class="version-header">
+                <span class="version-number">v{v.version}</span>
+                <span class="version-date">{new Date(v.createdAt).toLocaleString()}</span>
+              </div>
+              <div class="version-meta">
+                <span class="version-word-count">{v.wordCount} words</span>
+                {diffLabel && <span class={`version-diff ${diffClass}`}>{diffLabel}</span>}
+                {v.note && <span class="version-note">"{v.note}"</span>}
+              </div>
+              <div class="version-actions">
+                <button type="button" class="btn-outlined btn-sm view-btn" data-version-id={v.id}>View</button>
+                <button type="button" class="btn-danger-outline btn-sm restore-btn" data-version-id={v.id} data-version={v.version}>Restore</button>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    )}
+
+    <!-- Version preview dialog -->
+    <dialog id="preview-dialog" class="preview-dialog">
+      <div class="preview-header">
+        <h3 id="preview-title">Version Preview</h3>
+        <button type="button" class="close-btn" id="close-preview">&times;</button>
+      </div>
+      <div id="preview-content" class="preview-content"></div>
+      <div class="dialog-actions">
+        <button type="button" class="btn-outlined" id="close-preview-btn">Close</button>
+      </div>
+    </dialog>
+
+    <!-- Restore confirmation dialog -->
+    <dialog id="restore-dialog" class="restore-dialog">
+      <form method="dialog">
+        <h3>Restore this version?</h3>
+        <p>The current content will be saved as a new version before restoring. You won't lose any work.</p>
+        <div class="dialog-actions">
+          <button type="submit" class="btn-outlined" value="cancel">Cancel</button>
+          <button type="submit" class="btn-filled" id="confirm-restore-btn" value="confirm">Restore</button>
+        </div>
+      </form>
+    </dialog>
+  </section>
+</Base>
+
+<script define:vars={{ workId, chapterId }}>
+  // ─── View version preview ──────────────────────────────────────────
+  const versionList = document.getElementById('version-list');
+  const previewDialog = document.getElementById('preview-dialog') as HTMLDialogElement;
+  const previewTitle = document.getElementById('preview-title') as HTMLElement;
+  const previewContent = document.getElementById('preview-content') as HTMLElement;
+  const closePreview = document.getElementById('close-preview') as HTMLButtonElement;
+  const closePreviewBtn = document.getElementById('close-preview-btn') as HTMLButtonElement;
+
+  closePreview.addEventListener('click', () => previewDialog.close());
+  closePreviewBtn.addEventListener('click', () => previewDialog.close());
+
+  versionList?.addEventListener('click', async (e: Event) => {
+    const target = e.target as HTMLElement;
+
+    // View button
+    if (target.classList.contains('view-btn')) {
+      const versionId = target.dataset.versionId;
+      try {
+        const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/versions?id=${versionId}`);
+        if (res.ok) {
+          const { data } = await res.json();
+          previewTitle.textContent = `Version ${data.version}`;
+          previewContent.textContent = data.contentMd || '(empty)';
+          previewDialog.showModal();
+        }
+      } catch {
+        // Ignore fetch errors for preview
+      }
+    }
+
+    // Restore button
+    if (target.classList.contains('restore-btn')) {
+      const versionId = Number(target.dataset.versionId);
+      const versionNum = target.dataset.version;
+      const restoreDialog = document.getElementById('restore-dialog') as HTMLDialogElement;
+      const confirmBtn = document.getElementById('confirm-restore-btn') as HTMLButtonElement;
+
+      restoreDialog.showModal();
+      confirmBtn.onclick = async () => {
+        try {
+          const res = await fetch(`/api/works/${workId}/chapters/${chapterId}/versions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ versionId }),
+          });
+          if (res.ok) {
+            window.location.reload();
+          } else {
+            const data = await res.json();
+            alert(data.error || 'Failed to restore version.');
+          }
+        } catch {
+          alert('Network error. Please try again.');
+        }
+        restoreDialog.close();
+      };
+    }
+  });
+</script>
+
+<style is:global>
+  .studio-page {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .studio-header {
+    margin-bottom: var(--space-8);
+  }
+
+  .back-link {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-primary);
+    text-decoration: none;
+    display: inline-block;
+    margin-bottom: var(--space-2);
+  }
+
+  .studio-title {
+    font: var(--md-sys-typescale-headline-medium);
+    margin: 0 0 var(--space-1) 0;
+  }
+
+  .subtitle {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0;
+  }
+
+  .empty-msg {
+    font: var(--md-sys-typescale-body-large);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .error-msg {
+    color: var(--md-sys-color-error);
+    font: var(--md-sys-typescale-body-large);
+  }
+
+  /* Version timeline */
+  .version-timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .version-item {
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-medium);
+    padding: var(--space-4) var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .version-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .version-number {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    font-weight: 600;
+  }
+
+  .version-date {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .version-meta {
+    display: flex;
+    gap: var(--space-4);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .version-word-count {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .version-diff {
+    font: var(--md-sys-typescale-body-small);
+    font-weight: 500;
+  }
+
+  .diff-positive {
+    color: #2e7d32;
+  }
+
+  .diff-negative {
+    color: #c62828;
+  }
+
+  .diff-neutral {
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  .version-note {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+    font-style: italic;
+  }
+
+  .version-actions {
+    display: flex;
+    gap: var(--space-3);
+    margin-top: var(--space-1);
+  }
+
+  .btn-sm {
+    padding: var(--space-1) var(--space-4);
+    font: var(--md-sys-typescale-label-medium);
+  }
+
+  .btn-outlined {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-8);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .btn-outlined:hover {
+    background: var(--md-sys-color-primary-container);
+  }
+
+  .btn-danger-outline {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-error);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-error);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-8);
+    cursor: pointer;
+    transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .btn-danger-outline:hover {
+    background: #fce4ec;
+  }
+
+  .btn-filled {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-primary);
+    background: var(--md-sys-color-primary);
+    border: none;
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-3) var(--space-8);
+    cursor: pointer;
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+  }
+
+  .btn-filled:hover { opacity: 0.88; }
+
+  /* Preview dialog */
+  .preview-dialog {
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    padding: var(--space-6);
+    background: var(--md-sys-color-surface);
+    max-width: 700px;
+    width: 90vw;
+    max-height: 80vh;
+  }
+
+  .preview-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-4);
+  }
+
+  .preview-header h3 {
+    font: var(--md-sys-typescale-title-large);
+    margin: 0;
+  }
+
+  .close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: var(--md-sys-color-on-surface-variant);
+    padding: 0 var(--space-2);
+  }
+
+  .preview-content {
+    font-family: 'Merriweather', serif;
+    font-size: 1rem;
+    line-height: 1.75;
+    color: var(--md-sys-color-on-surface);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    max-height: 50vh;
+    overflow-y: auto;
+    padding: var(--space-4);
+    background: var(--md-sys-color-surface-container);
+    border-radius: var(--md-sys-shape-corner-small);
+  }
+
+  /* Restore dialog */
+  .restore-dialog {
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-large);
+    padding: var(--space-6);
+    background: var(--md-sys-color-surface);
+    max-width: 400px;
+  }
+
+  .restore-dialog h3 {
+    font: var(--md-sys-typescale-title-large);
+    margin: 0 0 var(--space-4) 0;
+  }
+
+  .restore-dialog p {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface-variant);
+    margin: 0 0 var(--space-6) 0;
+  }
+
+  .dialog-actions {
+    display: flex;
+    gap: var(--space-4);
+    justify-content: flex-end;
+  }
+</style>

--- a/src/pages/studio/new.astro
+++ b/src/pages/studio/new.astro
@@ -57,16 +57,86 @@ try {
         )}
       </div>
 
+      <!-- ─── Rating (single-select radio chips) ─── -->
       <div class="form-field">
-        <label for="tags-input">Tags</label>
-        <div class="tags-input-wrapper">
-          <div id="tags-container" class="tags-container"></div>
-          <input type="text" id="tags-input" placeholder="Start typing to add tags (e.g. fandom, characters)..." />
-          <div id="tags-suggestions" class="suggestions-dropdown" style="display:none;"></div>
+        <label>Rating</label>
+        <div class="chip-group" id="rating-group" role="radiogroup" aria-label="Rating">
+          <button type="button" class="filter-chip" data-value="General Audiences" data-type="rating">General Audiences</button>
+          <button type="button" class="filter-chip" data-value="Teen And Up Audiences" data-type="rating">Teen And Up Audiences</button>
+          <button type="button" class="filter-chip" data-value="Mature" data-type="rating">Mature</button>
+          <button type="button" class="filter-chip" data-value="Explicit" data-type="rating">Explicit</button>
+          <button type="button" class="filter-chip" data-value="Not Rated" data-type="rating">Not Rated</button>
         </div>
-        <input type="hidden" id="tags-json" name="tags" value="[]" />
-        <p class="field-hint">Press Enter or comma to add a tag. Click × to remove.</p>
       </div>
+
+      <!-- ─── Archive Warnings (multi-select checkbox chips) ─── -->
+      <div class="form-field">
+        <label>Archive Warnings</label>
+        <div class="chip-group" id="warnings-group" role="group" aria-label="Archive Warnings">
+          <button type="button" class="filter-chip" data-value="No Archive Warnings Apply" data-type="warning">No Archive Warnings Apply</button>
+          <button type="button" class="filter-chip" data-value="Graphic Depictions Of Violence" data-type="warning">Graphic Depictions Of Violence</button>
+          <button type="button" class="filter-chip" data-value="Major Character Death" data-type="warning">Major Character Death</button>
+          <button type="button" class="filter-chip" data-value="Rape/Non-Con" data-type="warning">Rape/Non-Con</button>
+          <button type="button" class="filter-chip" data-value="Underage Sex" data-type="warning">Underage Sex</button>
+        </div>
+      </div>
+
+      <!-- ─── Categories (multi-select checkbox chips) ─── -->
+      <div class="form-field">
+        <label>Categories</label>
+        <div class="chip-group" id="categories-group" role="group" aria-label="Categories">
+          <button type="button" class="filter-chip" data-value="F/F" data-type="category">F/F</button>
+          <button type="button" class="filter-chip" data-value="F/M" data-type="category">F/M</button>
+          <button type="button" class="filter-chip" data-value="Gen" data-type="category">Gen</button>
+          <button type="button" class="filter-chip" data-value="M/M" data-type="category">M/M</button>
+          <button type="button" class="filter-chip" data-value="Multi" data-type="category">Multi</button>
+          <button type="button" class="filter-chip" data-value="Other" data-type="category">Other</button>
+        </div>
+      </div>
+
+      <!-- ─── Fandoms (tokenized autocomplete) ─── -->
+      <div class="form-field">
+        <label for="fandoms-input">Fandoms</label>
+        <div class="tokenized-input-wrapper" data-tag-type="fandom">
+          <div class="token-chips-container" id="fandoms-chips"></div>
+          <input type="text" id="fandoms-input" placeholder="Type to search fandoms..." autocomplete="off" />
+          <div class="suggestions-dropdown" id="fandoms-suggestions" style="display:none;"></div>
+        </div>
+      </div>
+
+      <!-- ─── Characters (tokenized autocomplete) ─── -->
+      <div class="form-field">
+        <label for="characters-input">Characters</label>
+        <div class="tokenized-input-wrapper" data-tag-type="character">
+          <div class="token-chips-container" id="characters-chips"></div>
+          <input type="text" id="characters-input" placeholder="Type to search characters..." autocomplete="off" />
+          <div class="suggestions-dropdown" id="characters-suggestions" style="display:none;"></div>
+        </div>
+      </div>
+
+      <!-- ─── Relationships (tokenized autocomplete) ─── -->
+      <div class="form-field">
+        <label for="relationships-input">Relationships</label>
+        <div class="tokenized-input-wrapper" data-tag-type="relationship">
+          <div class="token-chips-container" id="relationships-chips"></div>
+          <input type="text" id="relationships-input" placeholder="Type to search relationships..." autocomplete="off" />
+          <div class="suggestions-dropdown" id="relationships-suggestions" style="display:none;"></div>
+        </div>
+      </div>
+
+      <!-- ─── Additional Tags (tokenized autocomplete) ─── -->
+      <div class="form-field">
+        <label for="freeform-input">Additional Tags</label>
+        <div class="tokenized-input-wrapper" data-tag-type="freeform">
+          <div class="token-chips-container" id="freeform-chips"></div>
+          <input type="text" id="freeform-input" placeholder="Type to search or add tags..." autocomplete="off" />
+          <div class="suggestions-dropdown" id="freeform-suggestions" style="display:none;"></div>
+        </div>
+        <p class="field-hint">Press Enter, comma, or Tab to add a tag. Click × to remove.</p>
+      </div>
+
+      <!-- Hidden input carrying ALL tags for form submission -->
+      <input type="hidden" id="tags-json" name="tags" value="[]" />
 
       <details class="form-details">
         <summary class="form-details-summary">First Chapter (optional)</summary>
@@ -96,96 +166,268 @@ try {
 </Base>
 
 <script>
-  // ─── Tag autocomplete ─────────────────────────────────────────────
-  const TAG_TYPES = ['fandom', 'character', 'relationship', 'freeform', 'rating', 'warning', 'category'];
-  const tagsInput = document.getElementById('tags-input') as HTMLInputElement;
-  const tagsContainer = document.getElementById('tags-container') as HTMLDivElement;
+  // ─── Shared state ──────────────────────────────────────────────────
+  // All selected tags across every category, stored as {id?, name, type}
+  const allTags: { id?: number; name: string; type: string }[] = [];
   const tagsJson = document.getElementById('tags-json') as HTMLInputElement;
-  const suggestions = document.getElementById('tags-suggestions') as HTMLDivElement;
-  let selectedTags: { id?: number; name: string; type: string }[] = [];
 
-  function renderTags() {
-    tagsContainer.innerHTML = '';
-    selectedTags.forEach((tag, idx) => {
-      const pill = document.createElement('span');
-      pill.className = 'tag-pill';
-      pill.innerHTML = `<span class="tag-pill-label">${tag.name}</span><span class="tag-pill-type">${tag.type}</span><button type="button" class="tag-pill-remove" data-idx="${idx}">×</button>`;
-      tagsContainer.appendChild(pill);
+  function syncHiddenInput() {
+    tagsJson.value = JSON.stringify(allTags);
+  }
+
+  function addTag(tag: { id?: number; name: string; type: string }): boolean {
+    // Prevent duplicates by name+type
+    if (allTags.some(t => t.name === tag.name && t.type === tag.type)) return false;
+    allTags.push(tag);
+    syncHiddenInput();
+    return true;
+  }
+
+  function removeTag(name: string, type: string) {
+    const idx = allTags.findIndex(t => t.name === name && t.type === type);
+    if (idx !== -1) {
+      allTags.splice(idx, 1);
+      syncHiddenInput();
+    }
+  }
+
+  // ─── Rating (single-select) ──────────────────────────────────────────
+  const ratingGroup = document.getElementById('rating-group')!;
+  const ratingBtns = ratingGroup.querySelectorAll<HTMLButtonElement>('.filter-chip');
+
+  ratingBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const value = btn.dataset.value!;
+      const type = btn.dataset.type!;
+
+      // Check if already selected → deselect
+      const isCurrentlySelected = btn.classList.contains('selected');
+
+      // Deselect all
+      ratingBtns.forEach(b => b.classList.remove('selected'));
+      // Remove any existing rating from allTags
+      const existingIdx = allTags.findIndex(t => t.type === 'rating');
+      if (existingIdx !== -1) allTags.splice(existingIdx, 1);
+
+      if (!isCurrentlySelected) {
+        // Select this one
+        btn.classList.add('selected');
+        addTag({ name: value, type });
+      }
+
+      syncHiddenInput();
     });
-    tagsJson.value = JSON.stringify(selectedTags);
+  });
 
-    // Bind remove handlers
-    tagsContainer.querySelectorAll('.tag-pill-remove').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        const idx = Number((e.currentTarget as HTMLElement).getAttribute('data-idx'));
-        selectedTags.splice(idx, 1);
-        renderTags();
-      });
+  // ─── Warnings (multi-select) ─────────────────────────────────────────
+  const warningsGroup = document.getElementById('warnings-group')!;
+  const warningBtns = warningsGroup.querySelectorAll<HTMLButtonElement>('.filter-chip');
+
+  warningBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const value = btn.dataset.value!;
+      const type = btn.dataset.type!;
+      const isSelected = btn.classList.contains('selected');
+
+      if (isSelected) {
+        btn.classList.remove('selected');
+        removeTag(value, type);
+      } else {
+        btn.classList.add('selected');
+        addTag({ name: value, type });
+      }
+    });
+  });
+
+  // ─── Categories (multi-select) ───────────────────────────────────────
+  const categoriesGroup = document.getElementById('categories-group')!;
+  const categoryBtns = categoriesGroup.querySelectorAll<HTMLButtonElement>('.filter-chip');
+
+  categoryBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const value = btn.dataset.value!;
+      const type = btn.dataset.type!;
+      const isSelected = btn.classList.contains('selected');
+
+      if (isSelected) {
+        btn.classList.remove('selected');
+        removeTag(value, type);
+      } else {
+        btn.classList.add('selected');
+        addTag({ name: value, type });
+      }
+    });
+  });
+
+  // ─── Tokenized Tag Input (reusable) ──────────────────────────────────
+
+  // Chip color map per tag type
+  const CHIP_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+    fandom:       { bg: 'var(--chip-fandom-bg, #e3f2fd)',       text: 'var(--chip-fandom-text, #1565c0)',  border: 'var(--chip-fandom-border, #90caf9)' },
+    character:    { bg: 'var(--chip-character-bg, #e8f5e9)',   text: 'var(--chip-character-text, #2e7d32)', border: 'var(--chip-character-border, #a5d6a7)' },
+    relationship: { bg: 'var(--chip-relationship-bg, #f3e5f5)', text: 'var(--chip-relationship-text, #7b1fa2)', border: 'var(--chip-relationship-border, #ce93d8)' },
+    freeform:     { bg: 'var(--chip-freeform-bg, #fff3e0)',    text: 'var(--chip-freeform-text, #e65100)',  border: 'var(--chip-freeform-border, #ffcc80)' },
+  };
+
+  interface TokenizedInput {
+    wrapper: HTMLDivElement;
+    input: HTMLInputElement;
+    chipsContainer: HTMLDivElement;
+    suggestionsEl: HTMLDivElement;
+    tagType: string;
+    chips: { id?: number; name: string; type: string }[];
+    debounceTimer: ReturnType<typeof setTimeout> | null;
+  }
+
+  const tokenizedInputs: TokenizedInput[] = [];
+
+  function initTokenizedInput(wrapperEl: HTMLDivElement) {
+    const tagType = wrapperEl.dataset.tagType!;
+    const input = wrapperEl.querySelector('input') as HTMLInputElement;
+    const chipsContainer = wrapperEl.querySelector('.token-chips-container') as HTMLDivElement;
+    const suggestionsEl = wrapperEl.querySelector('.suggestions-dropdown') as HTMLDivElement;
+
+    const instance: TokenizedInput = {
+      wrapper: wrapperEl,
+      input,
+      chipsContainer,
+      suggestionsEl,
+      tagType,
+      chips: [],
+      debounceTimer: null,
+    };
+
+    tokenizedInputs.push(instance);
+    renderChips(instance);
+
+    // Autocomplete on input
+    input.addEventListener('input', () => {
+      if (instance.debounceTimer) clearTimeout(instance.debounceTimer);
+      const q = input.value.trim();
+      if (q.length < 2) { suggestionsEl.style.display = 'none'; return; }
+
+      instance.debounceTimer = setTimeout(async () => {
+        try {
+          const res = await fetch(`/api/tags?q=${encodeURIComponent(q)}&type=${tagType}&limit=10`);
+          if (res.ok) {
+            const json = await res.json();
+            const items = json.data ?? [];
+            if (items.length === 0) { suggestionsEl.style.display = 'none'; return; }
+
+            suggestionsEl.innerHTML = items.map((t: any) =>
+              `<div class="suggestion-item" data-id="${t.id}" data-name="${t.name}" data-type="${t.type}">
+                <span class="suggestion-name">${t.name}</span>
+                <span class="suggestion-type">${t.type}</span>
+              </div>`
+            ).join('');
+            suggestionsEl.style.display = 'block';
+
+            suggestionsEl.querySelectorAll('.suggestion-item').forEach(el => {
+              el.addEventListener('mousedown', (e) => {
+                // Use mousedown so it fires before blur
+                e.preventDefault();
+                const item = el as HTMLElement;
+                const id = Number(item.dataset.id);
+                const name = item.dataset.name!;
+                addChipToInstance(instance, { id, name, type: tagType });
+              });
+            });
+          }
+        } catch { /* non-fatal */ }
+      }, 300);
+    });
+
+    // Enter/comma/tab to tokenize
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ',' || e.key === 'Tab') {
+        e.preventDefault();
+        const name = input.value.trim().replace(/,+$/, '');
+        if (name) {
+          addChipToInstance(instance, { name, type: tagType });
+        }
+        return;
+      }
+
+      // Backspace on empty input removes last chip
+      if (e.key === 'Backspace' && input.value === '' && instance.chips.length > 0) {
+        const lastChip = instance.chips[instance.chips.length - 1];
+        removeChipFromInstance(instance, lastChip.name, lastChip.type);
+      }
+    });
+
+    // Close suggestions on blur
+    input.addEventListener('blur', () => {
+      suggestionsEl.style.display = 'none';
+    });
+
+    // Click on wrapper focuses the input
+    wrapperEl.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).closest('.token-chip-remove') === null) {
+        input.focus();
+      }
     });
   }
 
-  let debounceTimer: ReturnType<typeof setTimeout>;
-  tagsInput.addEventListener('input', () => {
-    clearTimeout(debounceTimer);
-    const q = tagsInput.value.trim();
-    if (q.length < 2) { suggestions.style.display = 'none'; return; }
-
-    debounceTimer = setTimeout(async () => {
-      try {
-        // Try autocomplete with each tag type
-        const res = await fetch(`/api/tags?q=${encodeURIComponent(q)}&limit=10`);
-        if (res.ok) {
-          const json = await res.json();
-          const items = json.data ?? [];
-          if (items.length === 0) { suggestions.style.display = 'none'; return; }
-
-          suggestions.innerHTML = items.map((t: any) =>
-            `<div class="suggestion-item" data-id="${t.id}" data-name="${t.name}" data-type="${t.type}">
-              <span class="suggestion-name">${t.name}</span>
-              <span class="suggestion-type">${t.type}</span>
-            </div>`
-          ).join('');
-          suggestions.style.display = 'block';
-
-          suggestions.querySelectorAll('.suggestion-item').forEach(el => {
-            el.addEventListener('click', () => {
-              const item = el as HTMLElement;
-              const id = Number(item.dataset.id);
-              const name = item.dataset.name!;
-              const type = item.dataset.type!;
-              if (!selectedTags.some(t => t.id === id)) {
-                selectedTags.push({ id, name, type });
-                renderTags();
-              }
-              tagsInput.value = '';
-              suggestions.style.display = 'none';
-            });
-          });
-        }
-      } catch { /* non-fatal */ }
-    }, 300);
-  });
-
-  // Enter/comma to add freeform tags
-  tagsInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ',') {
-      e.preventDefault();
-      const name = tagsInput.value.trim().replace(/,+$/, '');
-      if (name && !selectedTags.some(t => t.name === name)) {
-        selectedTags.push({ name, type: 'freeform' });
-        renderTags();
-      }
-      tagsInput.value = '';
-      suggestions.style.display = 'none';
+  function addChipToInstance(instance: TokenizedInput, tag: { id?: number; name: string; type: string }) {
+    // Deduplicate within this instance
+    if (instance.chips.some(c => c.name === tag.name && c.type === tag.type)) {
+      instance.input.value = '';
+      instance.suggestionsEl.style.display = 'none';
+      return;
     }
-  });
 
-  // Close suggestions on blur
-  document.addEventListener('click', (e) => {
-    if (!e.target || !(e.target as HTMLElement).closest('.tags-input-wrapper')) {
-      suggestions.style.display = 'none';
+    instance.chips.push(tag);
+    addTag(tag);
+    renderChips(instance);
+    instance.input.value = '';
+    instance.suggestionsEl.style.display = 'none';
+  }
+
+  function removeChipFromInstance(instance: TokenizedInput, name: string, type: string) {
+    const idx = instance.chips.findIndex(c => c.name === name && c.type === type);
+    if (idx !== -1) {
+      instance.chips.splice(idx, 1);
     }
-  });
+    removeTag(name, type);
+    renderChips(instance);
+  }
+
+  function renderChips(instance: TokenizedInput) {
+    instance.chipsContainer.innerHTML = '';
+    const colors = CHIP_COLORS[instance.tagType] || CHIP_COLORS.freeform;
+
+    instance.chips.forEach(chip => {
+      const pill = document.createElement('span');
+      pill.className = 'token-chip';
+      pill.style.backgroundColor = colors.bg;
+      pill.style.color = colors.text;
+      pill.style.borderColor = colors.border;
+      pill.innerHTML = `${escapeHtml(chip.name)}<button type="button" class="token-chip-remove" aria-label="Remove ${escapeHtml(chip.name)}">×</button>`;
+
+      pill.querySelector('.token-chip-remove')!.addEventListener('click', (e) => {
+        e.stopPropagation();
+        removeChipFromInstance(instance, chip.name, chip.type);
+      });
+
+      instance.chipsContainer.appendChild(pill);
+    });
+
+    // Show overflow indicator if more than 5 chips
+    if (instance.chips.length > 5) {
+      instance.chipsContainer.classList.add('chips-overflow');
+    } else {
+      instance.chipsContainer.classList.remove('chips-overflow');
+    }
+  }
+
+  function escapeHtml(str: string): string {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  // Initialize all tokenized inputs on the page
+  document.querySelectorAll<HTMLDivElement>('.tokenized-input-wrapper').forEach(initTokenizedInput);
 
   // ─── Form submission ──────────────────────────────────────────────
   const form = document.getElementById('new-work-form') as HTMLFormElement;
@@ -322,39 +564,112 @@ try {
   }
   .field-hint a { color: var(--md-sys-color-primary); }
 
-  /* Tags input */
-  .tags-input-wrapper {
-    position: relative;
+  /* ─── M3 Filter Chips (Rating / Warnings / Categories) ─── */
+  .chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
   }
-  .tags-container {
+
+  .filter-chip {
+    display: inline-flex;
+    align-items: center;
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    background: transparent;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: var(--space-1) var(--space-4);
+    cursor: pointer;
+    transition: all var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    user-select: none;
+    white-space: nowrap;
+  }
+  .filter-chip:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+  .filter-chip.selected {
+    color: var(--md-sys-color-on-secondary-container);
+    background: var(--md-sys-color-secondary-container);
+    border-color: transparent;
+  }
+  .filter-chip.selected:hover {
+    background: var(--md-sys-color-secondary-container-high, var(--md-sys-color-secondary-container));
+  }
+
+  /* ─── Tokenized Tag Input ─── */
+  .tokenized-input-wrapper {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-1);
+    background: var(--md-sys-color-surface-container);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    border-radius: var(--md-sys-shape-corner-small);
+    padding: var(--space-2) var(--space-3);
+    cursor: text;
+    transition: border-color var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    min-height: 44px;
+  }
+  .tokenized-input-wrapper:focus-within {
+    border-color: var(--md-sys-color-primary);
+  }
+
+  .token-chips-container {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-1);
-    margin-bottom: var(--space-2);
+    max-height: 7.5em;
+    overflow-y: auto;
+    scrollbar-width: thin;
   }
-  .tag-pill {
+  .token-chips-container.chips-overflow {
+    padding-right: var(--space-1);
+  }
+
+  .tokenized-input-wrapper input {
+    flex: 1;
+    min-width: 120px;
+    border: none;
+    background: transparent;
+    color: var(--md-sys-color-on-surface);
+    font: var(--md-sys-typescale-body-large);
+    padding: 0;
+    outline: none;
+  }
+  .tokenized-input-wrapper input::placeholder {
+    color: var(--md-sys-color-on-surface-variant);
+    opacity: 0.6;
+  }
+
+  .token-chip {
     display: inline-flex;
     align-items: center;
-    gap: var(--space-1);
-    background: var(--md-sys-color-primary-container);
-    color: var(--md-sys-color-on-primary-container);
+    gap: 4px;
+    border: 1px solid;
     border-radius: var(--md-sys-shape-corner-full);
-    padding: 2px 10px;
+    padding: 2px 8px 2px 10px;
     font: var(--md-sys-typescale-body-small);
+    line-height: 1.4;
+    white-space: nowrap;
   }
-  .tag-pill-type {
-    opacity: 0.7;
-    font-size: 0.7rem;
-  }
-  .tag-pill-remove {
+  .token-chip-remove {
     background: none;
     border: none;
-    color: var(--md-sys-color-on-primary-container);
+    color: inherit;
     cursor: pointer;
-    padding: 0;
+    padding: 0 2px;
     font-size: 1rem;
     line-height: 1;
+    opacity: 0.7;
+    transition: opacity var(--md-sys-motion-duration-short4);
   }
+  .token-chip-remove:hover {
+    opacity: 1;
+  }
+
+  /* Suggestions dropdown (reused across all tokenized inputs) */
   .suggestions-dropdown {
     position: absolute;
     top: 100%;
@@ -366,6 +681,7 @@ try {
     max-height: 200px;
     overflow-y: auto;
     z-index: 50;
+    margin-top: 2px;
   }
   .suggestion-item {
     display: flex;

--- a/src/pages/works/[id]/chapters/[chapterId].astro
+++ b/src/pages/works/[id]/chapters/[chapterId].astro
@@ -52,6 +52,23 @@ const nextChapter = currentIndex >= 0 && currentIndex < chapters.length - 1 ? ch
 const authorPseuds = work.authors?.map((a: any) => a.name).join(', ') ?? 'Unknown';
 // Render content: prefer HTML, fall back to markdown-as-plain
 const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map((p: string) => `<p>${p}</p>`).join('\n') ?? '<p><em>No content.</em></p>';
+
+// Derive sidebar data
+const fandoms = work.tags?.filter((t: any) => t.type === 'fandom') ?? [];
+const characters = work.tags?.filter((t: any) => t.type === 'character') ?? [];
+const relationships = work.tags?.filter((t: any) => t.type === 'relationship') ?? [];
+const freeforms = work.tags?.filter((t: any) => t.type === 'freeform') ?? [];
+
+const chapterWordCount = chapter.wordCount?.toLocaleString() ?? '0';
+const chapterPubDate = chapter.publishedAt
+  ? new Date(chapter.publishedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  : null;
+
+// Author notes: prefer chapter-level notes, fall back to work notes
+const chapterNotes = chapter.notes ?? null;
+const endNotes = work.endNotes ?? null;
+
+const user = Astro.locals.user;
 ---
 
 <Base title={`${chapter.title || `Chapter ${chapter.position}`} — ${work.title}`} description={work.summary || ''}>
@@ -60,47 +77,168 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
       <p class="error-msg">{errorMsg}</p>
     ) : (
       <div class="reader-layout">
-        {/* ─── Progress bar ──────────────────────────── */}
+        {/* ─── Progress bar (spans full width above grid) ─── */}
         <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
           <div class="progress-fill" id="progress-fill"></div>
         </div>
 
-        {/* ─── Chapter header ─────────────────────────── */}
-        <header class="reader-header">
-          <nav class="breadcrumb" aria-label="Breadcrumb">
-            <a href="/works">{work.title}</a>
-            <span aria-hidden="true">›</span>
-            <span>{chapter.title || `Chapter ${chapter.position}`}</span>
+        {/* ─── Main column ──────────────────────────────── */}
+        <main class="reader-main">
+          {/* ─── Chapter header ─────────────────────────── */}
+          <header class="reader-header">
+            <nav class="breadcrumb" aria-label="Breadcrumb">
+              <a href="/works">{work.title}</a>
+              <span aria-hidden="true">›</span>
+              <span>{chapter.title || `Chapter ${chapter.position}`}</span>
+            </nav>
+            <h1 class="chapter-title">{chapter.title || `Chapter ${chapter.position}`}</h1>
+            <p class="chapter-meta">by {authorPseuds} · {chapter.wordCount?.toLocaleString() ?? '0'} words</p>
+          </header>
+
+          {/* ─── Chapter content ────────────────────────── */}
+          <article class="reader-content" set:html={chapterContent} />
+
+          {/* ─── End notes ───────────────────────────────── */}
+          {endNotes && (
+            <section class="end-notes">
+              <h2 class="section-heading">End Notes</h2>
+              <div set:html={endNotes} />
+            </section>
+          )}
+
+          {/* ─── Chapter navigation ──────────────────────── */}
+          <nav class="chapter-nav" aria-label="Chapter navigation">
+            {prevChapter ? (
+              <a href={`/works/${workId}/chapters/${prevChapter.id}`} class="btn-outlined" rel="prev">
+                ← Previous
+              </a>
+            ) : <span />}
+            <a href={`/works/${workId}`} class="btn-outlined">↑ Back to Work</a>
+            {nextChapter ? (
+              <a href={`/works/${workId}/chapters/${nextChapter.id}`} class="btn-filled" rel="next">
+                Next →
+              </a>
+            ) : <span />}
           </nav>
-          <h1 class="chapter-title">{chapter.title || `Chapter ${chapter.position}`}</h1>
-          <p class="chapter-meta">by {authorPseuds} · {chapter.wordCount?.toLocaleString() ?? '0'} words</p>
-        </header>
+        </main>
 
-        {/* ─── Chapter content ────────────────────────── */}
-        <article class="reader-content" set:html={chapterContent} />
+        {/* ─── Sidebar ──────────────────────────────────── */}
+        <aside class="reader-sidebar">
+          <div class="sidebar-inner">
+            {/* 1. Chapter Navigation */}
+            {chapters.length > 1 && (
+              <div class="sidebar-section">
+                <h3 class="sidebar-heading">Chapters</h3>
+                <div class="chapter-nav-dropdown">
+                  <select id="chapter-jump" aria-label="Jump to chapter">
+                    {chapters.map((c: any, i: number) => (
+                      <option value={c.id} selected={c.id === chapterId}>
+                        {i + 1}. {c.title || `Chapter ${c.position}`}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <ol class="chapter-list">
+                  {chapters.map((c: any, i: number) => (
+                    <li class={c.id === chapterId ? 'current' : ''}>
+                      <a href={`/works/${workId}/chapters/${c.id}`} aria-current={c.id === chapterId ? 'page' : undefined}>
+                        <span class="chapter-num">{i + 1}.</span> {c.title || `Chapter ${c.position}`}
+                        <span class="chapter-meta-inline">{c.wordCount?.toLocaleString() ?? '0'} words</span>
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
 
-        {/* ─── End notes ───────────────────────────────── */}
-        {work.endNotes && (
-          <section class="end-notes">
-            <h2 class="section-heading">End Notes</h2>
-            <div set:html={work.endNotes} />
-          </section>
-        )}
+            {/* 2. Metadata */}
+            <div class="sidebar-section">
+              <h3 class="sidebar-heading">Chapter Info</h3>
+              <dl class="meta-grid">
+                <dt>Words</dt>
+                <dd>{chapterWordCount}</dd>
+                {chapterPubDate && (
+                  <><dt>Published</dt><dd>{chapterPubDate}</dd></>
+                )}
+              </dl>
+            </div>
 
-        {/* ─── Chapter navigation ──────────────────────── */}
-        <nav class="chapter-nav" aria-label="Chapter navigation">
-          {prevChapter ? (
-            <a href={`/works/${workId}/chapters/${prevChapter.id}`} class="btn-outlined" rel="prev">
-              ← Previous
-            </a>
-          ) : <span />}
-          <a href={`/works/${workId}`} class="btn-outlined">↑ Back to Work</a>
-          {nextChapter ? (
-            <a href={`/works/${workId}/chapters/${nextChapter.id}`} class="btn-filled" rel="next">
-              Next →
-            </a>
-          ) : <span />}
-        </nav>
+            {/* 3. Author's Notes */}
+            {chapterNotes && (
+              <div class="sidebar-section">
+                <h3 class="sidebar-heading">Author's Notes</h3>
+                <div class="sidebar-notes-content" id="sidebar-notes">
+                  <div set:html={chapterNotes} />
+                </div>
+                <button class="notes-toggle" id="notes-toggle" aria-expanded="false" aria-controls="sidebar-notes" style="display:none;">
+                  Show more
+                </button>
+              </div>
+            )}
+
+            {/* 4. Tags */}
+            {(fandoms.length > 0 || characters.length > 0 || relationships.length > 0 || freeforms.length > 0) && (
+              <div class="sidebar-section">
+                <h3 class="sidebar-heading">Tags</h3>
+                {fandoms.length > 0 && (
+                  <div class="tag-group">
+                    <span class="tag-group-label">Fandoms</span>
+                    <div class="tag-cluster">
+                      {fandoms.map((t: any) => (
+                        <a href={`/works?fandom=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-fandom">{t.name}</a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {characters.length > 0 && (
+                  <div class="tag-group">
+                    <span class="tag-group-label">Characters</span>
+                    <div class="tag-cluster">
+                      {characters.map((t: any) => (
+                        <a href={`/works?character=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-character">{t.name}</a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {relationships.length > 0 && (
+                  <div class="tag-group">
+                    <span class="tag-group-label">Relationships</span>
+                    <div class="tag-cluster">
+                      {relationships.map((t: any) => (
+                        <a href={`/works?relationship=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-relationship">{t.name}</a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {freeforms.length > 0 && (
+                  <div class="tag-group">
+                    <span class="tag-group-label">Additional</span>
+                    <div class="tag-cluster">
+                      {freeforms.map((t: any) => (
+                        <a href={`/works?freeform=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-freeform">{t.name}</a>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* 5. React */}
+            <div class="sidebar-section">
+              <h3 class="sidebar-heading">React</h3>
+              <div class="action-row">
+                <button id="kudos-btn" class="btn-outlined action-btn" data-work-id={workId}>
+                  ❤ <span id="kudos-count">{work.kudosCount ?? 0}</span> Kudos
+                </button>
+                {user && (
+                  <button id="bookmark-btn" class="btn-outlined action-btn" data-work-id={workId}>
+                    ★ Mark for Later
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </aside>
       </div>
     )}
   </section>
@@ -119,6 +257,77 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
   }
   window.addEventListener('scroll', updateProgress, { passive: true });
   updateProgress();
+
+  // Chapter jump dropdown
+  const chapterJump = document.getElementById('chapter-jump') as HTMLSelectElement | null;
+  if (chapterJump) {
+    chapterJump.addEventListener('change', () => {
+      // Derive workId from the current URL path
+      const pathMatch = window.location.pathname.match(/\/works\/(\d+)\//);
+      if (pathMatch && chapterJump.value) {
+        window.location.href = `/works/${pathMatch[1]}/chapters/${chapterJump.value}`;
+      }
+    });
+  }
+
+  // Author's notes collapsible (mobile)
+  const notesEl = document.getElementById('sidebar-notes');
+  const notesToggle = document.getElementById('notes-toggle');
+  if (notesEl && notesToggle) {
+    const checkOverflow = () => {
+      if (notesEl.scrollHeight > 120) {
+        notesToggle.style.display = '';
+        notesEl.classList.add('notes-collapsed');
+      } else {
+        notesToggle.style.display = 'none';
+        notesEl.classList.remove('notes-collapsed');
+      }
+    };
+    checkOverflow();
+    notesToggle.addEventListener('click', () => {
+      const expanded = notesToggle.getAttribute('aria-expanded') === 'true';
+      notesToggle.setAttribute('aria-expanded', String(!expanded));
+      notesToggle.textContent = expanded ? 'Show more' : 'Show less';
+      notesEl.classList.toggle('notes-collapsed', !expanded);
+    });
+  }
+
+  // Kudos button
+  const kudosBtn = document.getElementById('kudos-btn');
+  if (kudosBtn) {
+    kudosBtn.addEventListener('click', async () => {
+      const workIdAttr = kudosBtn.getAttribute('data-work-id');
+      try {
+        const res = await fetch(`/api/works/${workIdAttr}/kudos`, { method: 'POST' });
+        if (res.ok) {
+          const countEl = document.getElementById('kudos-count');
+          if (countEl) countEl.textContent = String(Number(countEl.textContent) + 1);
+          kudosBtn.classList.add('kudos-given');
+          kudosBtn.textContent = '❤ Kudos Given';
+          (kudosBtn as HTMLButtonElement).disabled = true;
+        }
+      } catch { /* non-fatal */ }
+    });
+  }
+
+  // Bookmark / Mark for later
+  const bookmarkBtn = document.getElementById('bookmark-btn');
+  if (bookmarkBtn) {
+    bookmarkBtn.addEventListener('click', async () => {
+      const workIdAttr = bookmarkBtn.getAttribute('data-work-id');
+      try {
+        const res = await fetch('/api/readings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ workId: Number(workIdAttr), forLater: true }),
+        });
+        if (res.ok) {
+          bookmarkBtn.textContent = '★ Marked for Later';
+          (bookmarkBtn as HTMLButtonElement).disabled = true;
+        }
+      } catch { /* non-fatal */ }
+    });
+  }
 </script>
 
 <style is:global>
@@ -128,18 +337,40 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
   }
 
   .reader-layout {
-    max-width: 42rem;
+    max-width: 82rem;
     margin: 0 auto;
     padding: 0 var(--space-4) var(--space-12);
   }
 
-  /* ─── Progress bar ────────────────────────────────── */
+  /* ─── Grid layout ─────────────────────────────────────── */
+  .reader-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-6);
+  }
+
+  @media (min-width: 768px) {
+    .reader-layout {
+      grid-template-columns: 1fr 260px;
+      gap: var(--space-8);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .reader-layout {
+      grid-template-columns: 1fr 300px;
+      gap: var(--space-10);
+    }
+  }
+
+  /* ─── Progress bar (spans full width above grid) ──────── */
   .progress-bar {
     position: sticky;
     top: 0;
     height: 3px;
     background: var(--md-sys-color-surface-container);
     z-index: 50;
+    grid-column: 1 / -1;
   }
 
   .progress-fill {
@@ -149,7 +380,19 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
     transition: width 100ms linear;
   }
 
-  /* ─── Chapter header ───────────────────────────────── */
+  /* ─── Main column ─────────────────────────────────────── */
+  .reader-main {
+    max-width: 42rem;
+    min-width: 0;
+  }
+
+  @media (min-width: 768px) {
+    .reader-main {
+      max-width: none; /* let grid control width */
+    }
+  }
+
+  /* ─── Chapter header ─────────────────────────────────── */
   .reader-header {
     margin-top: var(--space-8);
     margin-bottom: var(--space-8);
@@ -183,7 +426,7 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
     margin: 0;
   }
 
-  /* ─── Reader content ───────────────────────────────── */
+  /* ─── Reader content ─────────────────────────────────── */
   .reader-content {
     font-family: 'Merriweather', serif;
     font-size: 1.0625rem;
@@ -217,7 +460,7 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
     max-width: 12rem;
   }
 
-  /* ─── End notes ────────────────────────────────────── */
+  /* ─── End notes ──────────────────────────────────────── */
   .end-notes {
     margin-top: var(--space-12);
     padding-top: var(--space-6);
@@ -233,7 +476,7 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
     margin: 0 0 var(--space-2) 0;
   }
 
-  /* ─── Chapter navigation ───────────────────────────── */
+  /* ─── Chapter navigation ─────────────────────────────── */
   .chapter-nav {
     display: flex;
     justify-content: space-between;
@@ -256,9 +499,11 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
     border-radius: var(--md-sys-shape-corner-full);
     padding: var(--space-2) var(--space-4);
     text-decoration: none;
+    cursor: pointer;
     transition: background var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
   }
   .btn-outlined:hover { background: var(--md-sys-color-primary-container); }
+  .btn-outlined:disabled { opacity: 0.5; cursor: default; }
 
   .btn-filled {
     display: inline-flex;
@@ -273,6 +518,323 @@ const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map
     transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
   }
   .btn-filled:hover { opacity: 0.88; }
+
+  /* ─── Sidebar ──────────────────────────────────────────── */
+  .reader-sidebar {
+    display: flex;
+    flex-direction: column;
+  }
+
+  @media (min-width: 768px) {
+    .reader-sidebar {
+      /* Sidebar itself is not sticky; the inner wrapper is */
+    }
+  }
+
+  .sidebar-inner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+  }
+
+  @media (min-width: 768px) {
+    .sidebar-inner {
+      position: sticky;
+      top: 1rem;
+      max-height: calc(100vh - 2rem);
+      overflow-y: auto;
+      scrollbar-width: thin;
+    }
+  }
+
+  .sidebar-section {
+    margin: 0;
+  }
+
+  .sidebar-heading {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.75rem;
+    margin: 0 0 var(--space-2) 0;
+    padding-bottom: var(--space-1);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  }
+
+  /* ─── Chapter jump dropdown (mobile) / list (desktop) ── */
+  .chapter-nav-dropdown {
+    display: block;
+    margin-bottom: var(--space-3);
+  }
+
+  @media (min-width: 768px) {
+    .chapter-nav-dropdown {
+      display: none;
+    }
+  }
+
+  .chapter-nav-dropdown select {
+    width: 100%;
+    font: var(--md-sys-typescale-body-medium);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: var(--md-sys-shape-corner-small);
+    background: var(--md-sys-color-surface-container);
+    color: var(--md-sys-color-on-surface);
+    cursor: pointer;
+  }
+
+  .chapter-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  /* Hide chapter list on mobile (use dropdown instead) */
+  @media (max-width: 767px) {
+    .chapter-list {
+      display: flex;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      gap: var(--space-2);
+      padding-bottom: var(--space-2);
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin;
+    }
+
+    .chapter-list li {
+      border-bottom: none;
+      flex-shrink: 0;
+    }
+
+    .chapter-list a {
+      display: block;
+      padding: var(--space-1) var(--space-3);
+      border-radius: var(--md-sys-shape-corner-full);
+      font: var(--md-sys-typescale-body-small);
+      white-space: nowrap;
+    }
+
+    .chapter-num { display: none; }
+    .chapter-meta-inline { display: none; }
+  }
+
+  @media (min-width: 768px) {
+    .chapter-list li {
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
+    }
+    .chapter-list li:last-child { border-bottom: none; }
+    .chapter-list li.current {
+      background: var(--md-sys-color-surface-container);
+      border-radius: var(--md-sys-shape-corner-small);
+    }
+
+    .chapter-list a {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      padding: var(--space-2) 0;
+      text-decoration: none;
+      color: var(--md-sys-color-primary);
+      font: var(--md-sys-typescale-body-medium);
+    }
+
+    .chapter-list a[aria-current="page"] {
+      color: var(--md-sys-color-on-surface);
+      font-weight: 600;
+    }
+
+    .chapter-num {
+      color: var(--md-sys-color-on-surface-variant);
+      margin-right: var(--space-1);
+    }
+
+    .chapter-meta-inline {
+      font: var(--md-sys-typescale-body-small);
+      color: var(--md-sys-color-on-surface-variant);
+      margin-left: var(--space-2);
+      white-space: nowrap;
+    }
+  }
+
+  /* ─── Metadata ──────────────────────────────────────── */
+  .meta-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-1) var(--space-4);
+    margin: 0;
+  }
+
+  .meta-grid dt {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: 0.8rem;
+  }
+
+  .meta-grid dd {
+    font: var(--md-sys-typescale-body-medium);
+    color: var(--md-sys-color-on-surface);
+    margin: 0;
+  }
+
+  /* ─── Author's Notes (sidebar) ────────────────────────── */
+  .sidebar-notes-content {
+    font: var(--md-sys-typescale-body-small);
+    color: var(--md-sys-color-on-surface-variant);
+    line-height: 1.6;
+  }
+
+  .sidebar-notes-content.notes-collapsed {
+    max-height: 120px;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .sidebar-notes-content.notes-collapsed::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: linear-gradient(transparent, var(--md-sys-color-surface));
+    pointer-events: none;
+  }
+
+  .notes-toggle {
+    font: var(--md-sys-typescale-label-large);
+    color: var(--md-sys-color-primary);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: var(--space-1) 0;
+    margin-top: var(--space-1);
+  }
+
+  .notes-toggle:hover {
+    text-decoration: underline;
+  }
+
+  /* ─── Tags ─────────────────────────────────────────────── */
+  .tag-group {
+    margin-bottom: var(--space-3);
+  }
+
+  .tag-group:last-child {
+    margin-bottom: 0;
+  }
+
+  .tag-group-label {
+    font: var(--md-sys-typescale-label-small);
+    color: var(--md-sys-color-on-surface-variant);
+    display: block;
+    margin-bottom: var(--space-1);
+  }
+
+  .tag-cluster {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
+
+  .sidebar-tag {
+    font: var(--md-sys-typescale-body-small);
+    border-radius: var(--md-sys-shape-corner-full);
+    padding: 2px 10px;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    display: inline-block;
+  }
+  .sidebar-tag:hover { opacity: 0.88; box-shadow: 0 1px 3px rgba(0,0,0,0.12); }
+
+  /* Color-coded sidebar tags by type */
+  .sidebar-tag-fandom {
+    color: #1565c0;
+    background: #e3f2fd;
+    border-color: #90caf9;
+  }
+  .sidebar-tag-character {
+    color: #2e7d32;
+    background: #e8f5e9;
+    border-color: #a5d6a7;
+  }
+  .sidebar-tag-relationship {
+    color: #7b1fa2;
+    background: #f3e5f5;
+    border-color: #ce93d8;
+  }
+  .sidebar-tag-freeform {
+    color: #e65100;
+    background: #fff3e0;
+    border-color: #ffcc80;
+  }
+
+  /* ─── React section ──────────────────────────────────── */
+  .action-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .action-btn {
+    font: var(--md-sys-typescale-label-large);
+    flex: 1;
+    min-width: fit-content;
+  }
+
+  .kudos-given {
+    color: #c62828;
+    border-color: #c62828;
+  }
+
+  /* ─── Mobile: sidebar sits below main ────────────────── */
+  @media (max-width: 767px) {
+    .reader-main {
+      max-width: 42rem;
+      margin: 0 auto;
+    }
+
+    .reader-sidebar {
+      margin-top: var(--space-6);
+      padding-top: var(--space-6);
+      border-top: 1px solid var(--md-sys-color-outline-variant);
+    }
+
+    /* On mobile, Author's notes are always collapsed initially */
+    .sidebar-notes-content {
+      max-height: 120px;
+      overflow: hidden;
+      position: relative;
+    }
+
+    .sidebar-notes-content::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 40px;
+      background: linear-gradient(transparent, var(--md-sys-color-surface));
+      pointer-events: none;
+    }
+
+    .sidebar-notes-content:not(.notes-collapsed) {
+      max-height: none;
+      overflow: visible;
+    }
+
+    .sidebar-notes-content:not(.notes-collapsed)::after {
+      display: none;
+    }
+
+    /* Always show toggle on mobile if notes exist */
+    .notes-toggle {
+      display: block !important;
+    }
+  }
 
   .error-msg {
     color: var(--md-sys-color-error);

--- a/src/pages/works/[id]/index.astro
+++ b/src/pages/works/[id]/index.astro
@@ -113,7 +113,7 @@ const MATCH_LABELS: Record<string, string> = {
               <div class="tag-row">
                 <span class="tag-label">Category:</span>
                 {categories.map((t: any) => (
-                  <a href={`/works?category=${encodeURIComponent(t.name)}`} class="tag">{t.name}</a>
+                  <a href={`/works?category=${encodeURIComponent(t.name)}`} class="tag tag-category">{t.name}</a>
                 ))}
               </div>
             )}
@@ -185,13 +185,23 @@ const MATCH_LABELS: Record<string, string> = {
             </div>
           </div>
 
-          {/* Characters / Relationships / Freeform tags */}
+          {/* Fandom / Characters / Relationships / Freeform tags */}
+          {fandoms.length > 0 && (
+            <div class="sidebar-section">
+              <h3 class="sidebar-heading">Fandoms</h3>
+              <div class="tag-cluster">
+                {fandoms.map((t: any) => (
+                  <a href={`/works?fandom=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-fandom">{t.name}</a>
+                ))}
+              </div>
+            </div>
+          )}
           {characters.length > 0 && (
             <div class="sidebar-section">
               <h3 class="sidebar-heading">Characters</h3>
               <div class="tag-cluster">
                 {characters.map((t: any) => (
-                  <a href={`/works?character=${encodeURIComponent(t.name)}`} class="sidebar-tag">{t.name}</a>
+                  <a href={`/works?character=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-character">{t.name}</a>
                 ))}
               </div>
             </div>
@@ -201,7 +211,7 @@ const MATCH_LABELS: Record<string, string> = {
               <h3 class="sidebar-heading">Relationships</h3>
               <div class="tag-cluster">
                 {relationships.map((t: any) => (
-                  <a href={`/works?relationship=${encodeURIComponent(t.name)}`} class="sidebar-tag">{t.name}</a>
+                  <a href={`/works?relationship=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-relationship">{t.name}</a>
                 ))}
               </div>
             </div>
@@ -211,7 +221,7 @@ const MATCH_LABELS: Record<string, string> = {
               <h3 class="sidebar-heading">Additional Tags</h3>
               <div class="tag-cluster">
                 {freeforms.map((t: any) => (
-                  <a href={`/works?freeform=${encodeURIComponent(t.name)}`} class="sidebar-tag">{t.name}</a>
+                  <a href={`/works?freeform=${encodeURIComponent(t.name)}`} class="sidebar-tag sidebar-tag-freeform">{t.name}</a>
                 ))}
               </div>
             </div>
@@ -363,6 +373,7 @@ const MATCH_LABELS: Record<string, string> = {
     font: var(--md-sys-typescale-body-small);
     color: var(--md-sys-color-primary);
     background: var(--md-sys-color-surface-container);
+    border: 1px solid transparent;
     border-radius: var(--md-sys-shape-corner-small);
     padding: 2px 8px;
     text-decoration: none;
@@ -370,9 +381,10 @@ const MATCH_LABELS: Record<string, string> = {
   }
   .tag:hover { background: var(--md-sys-color-surface-container-high); }
 
-  .tag-rating { color: #c62828; }
-  .tag-warning { color: #e65100; }
-  .tag-fandom { background: var(--md-sys-color-primary-container); color: var(--md-sys-color-on-primary-container); }
+  .tag-rating { color: #c62828; border-color: #ef9a9a; background: #ffebee; }
+  .tag-warning { color: #e65100; border-color: #ffcc80; background: #fff3e0; }
+  .tag-fandom { background: #e3f2fd; color: #1565c0; border-color: #90caf9; }
+  .tag-category { background: #f3e5f5; color: #7b1fa2; border-color: #ce93d8; }
 
   .work-summary {
     background: var(--md-sys-color-surface-container);
@@ -498,6 +510,8 @@ const MATCH_LABELS: Record<string, string> = {
     letter-spacing: 0.05em;
     font-size: 0.75rem;
     margin: 0 0 var(--space-2) 0;
+    padding-bottom: var(--space-1);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
   }
 
   .tag-cluster {
@@ -508,14 +522,37 @@ const MATCH_LABELS: Record<string, string> = {
 
   .sidebar-tag {
     font: var(--md-sys-typescale-body-small);
-    color: var(--md-sys-color-primary);
-    background: var(--md-sys-color-primary-container);
     border-radius: var(--md-sys-shape-corner-full);
     padding: 2px 10px;
     text-decoration: none;
-    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    border: 1px solid transparent;
+    transition: opacity var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard),
+                box-shadow var(--md-sys-motion-duration-short4) var(--md-sys-motion-easing-standard);
+    display: inline-block;
   }
-  .sidebar-tag:hover { opacity: 0.8; }
+  .sidebar-tag:hover { opacity: 0.88; box-shadow: 0 1px 3px rgba(0,0,0,0.12); }
+
+  /* Color-coded sidebar tags by type */
+  .sidebar-tag-fandom {
+    color: #1565c0;
+    background: #e3f2fd;
+    border-color: #90caf9;
+  }
+  .sidebar-tag-character {
+    color: #2e7d32;
+    background: #e8f5e9;
+    border-color: #a5d6a7;
+  }
+  .sidebar-tag-relationship {
+    color: #7b1fa2;
+    background: #f3e5f5;
+    border-color: #ce93d8;
+  }
+  .sidebar-tag-freeform {
+    color: #e65100;
+    background: #fff3e0;
+    border-color: #ffcc80;
+  }
 
   .chapter-list {
     list-style: none;

--- a/src/v2/lib/validation.ts
+++ b/src/v2/lib/validation.ts
@@ -51,6 +51,7 @@ export const createChapterSchema = z.object({
   contentMd: z.string().optional(),
   contentHtml: z.string().optional(),
   mood: z.string().max(100).optional(),
+  versionNote: z.string().max(500, 'Version note too long').optional(),
 });
 
 export const updateChapterSchema = createChapterSchema.partial();
@@ -83,7 +84,9 @@ export const createPseudSchema = z.object({
   themeColor: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Must be a hex color').optional(),
 });
 
-export const updatePseudSchema = createPseudSchema.partial();
+export const updatePseudSchema = createPseudSchema.partial().extend({
+  isDefault: z.number().int().min(0).max(1).optional(),
+});
 
 // ─── Comments ─────────────────────────────────────────────────────
 

--- a/src/v2/pages/api/works/[id]/chapters/[chapterId]/index.ts
+++ b/src/v2/pages/api/works/[id]/chapters/[chapterId]/index.ts
@@ -4,8 +4,8 @@ import { getDb } from '../../../../../../../lib/db';
 import { requireAuth, checkApproved } from '../../../../../../../lib/auth';
 import { validateBody } from '../../../../../../../lib/validation';
 import { updateChapterSchema } from '../../../../../../../lib/validation';
-import { chapters, creatorships, pseuds } from '../../../../../../../lib/schema/index';
-import { eq, and } from 'drizzle-orm';
+import { chapters, chapterVersions, creatorships, pseuds } from '../../../../../../../lib/schema/index';
+import { eq, and, sql } from 'drizzle-orm';
 
 export const config = { auth: 'public' as const };
 
@@ -57,6 +57,24 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
 
   const [data, error] = await validateBody(request, updateChapterSchema);
   if (error) return error;
+
+  // ─── Save current content as a new version before updating ───
+  const currentChapter = await db.select().from(chapters).where(and(eq(chapters.id, chapterId), eq(chapters.workId, workId))).get();
+  if (currentChapter) {
+    const maxVersionRow = await db.select({ maxVer: sql<number>`COALESCE(MAX(${chapterVersions.version}), 0)` })
+      .from(chapterVersions)
+      .where(eq(chapterVersions.chapterId, chapterId))
+      .get();
+    const nextVersion = (maxVersionRow?.maxVer ?? 0) + 1;
+
+    await db.insert(chapterVersions).values({
+      chapterId,
+      version: nextVersion,
+      contentMd: currentChapter.contentMd,
+      contentHtml: currentChapter.contentHtml,
+      note: data.versionNote ?? null,
+    });
+  }
 
   const updates: Record<string, any> = { updatedAt: new Date().toISOString() };
   if (data.title !== undefined) updates.title = data.title;

--- a/src/v2/pages/api/works/[id]/chapters/[chapterId]/versions.ts
+++ b/src/v2/pages/api/works/[id]/chapters/[chapterId]/versions.ts
@@ -1,0 +1,172 @@
+import type { APIRoute } from 'astro';
+import type { D1Database } from '@cloudflare/workers-types';
+import { getDb } from '../../../../../../../lib/db';
+import { requireAuth, checkApproved } from '../../../../../../../lib/auth';
+import { chapters, chapterVersions, creatorships, pseuds } from '../../../../../../../lib/schema/index';
+import { eq, and, desc, sql } from 'drizzle-orm';
+
+export const config = { auth: 'public' as const };
+
+// GET /api/works/:id/chapters/:chapterId/versions — List versions or get a specific version
+export const GET: APIRoute = async ({ params, url, locals, request }) => {
+  const workId = Number(params.id);
+  const chapterId = Number(params.chapterId);
+  if (!workId || !chapterId || isNaN(workId) || isNaN(chapterId)) {
+    return new Response(JSON.stringify({ error: 'Invalid IDs' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDb(d1);
+
+  // Verify chapter belongs to work
+  const chapter = await db.select().from(chapters).where(and(eq(chapters.id, chapterId), eq(chapters.workId, workId))).get();
+  if (!chapter) {
+    return new Response(JSON.stringify({ error: 'Chapter not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // If ?id=X is specified, return a single version with full content
+  const versionIdParam = url.searchParams.get('id');
+  if (versionIdParam) {
+    const versionId = Number(versionIdParam);
+    if (!versionId || isNaN(versionId)) {
+      return new Response(JSON.stringify({ error: 'Invalid version ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const version = await db.select().from(chapterVersions)
+      .where(and(eq(chapterVersions.id, versionId), eq(chapterVersions.chapterId, chapterId)))
+      .get();
+
+    if (!version) {
+      return new Response(JSON.stringify({ error: 'Version not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const wordCount = version.contentMd ? version.contentMd.split(/\s+/).filter(Boolean).length : 0;
+
+    return new Response(JSON.stringify({
+      data: {
+        id: version.id,
+        version: version.version,
+        contentMd: version.contentMd,
+        contentHtml: version.contentHtml,
+        note: version.note,
+        createdAt: version.createdAt,
+        wordCount,
+      },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // List all versions (lightweight — no full content)
+  const versions = await db.select({
+    id: chapterVersions.id,
+    version: chapterVersions.version,
+    note: chapterVersions.note,
+    contentMd: chapterVersions.contentMd,
+    createdAt: chapterVersions.createdAt,
+  }).from(chapterVersions)
+    .where(eq(chapterVersions.chapterId, chapterId))
+    .orderBy(desc(chapterVersions.version));
+
+  const list = versions.map(v => {
+    const wordCount = v.contentMd ? v.contentMd.split(/\s+/).filter(Boolean).length : 0;
+    return {
+      id: v.id,
+      version: v.version,
+      note: v.note,
+      createdAt: v.createdAt,
+      wordCount,
+    };
+  });
+
+  return new Response(JSON.stringify({ data: list }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+// POST /api/works/:id/chapters/:chapterId/versions — Restore a specific version
+export const POST: APIRoute = async ({ params, request, locals }) => {
+  const workId = Number(params.id);
+  const chapterId = Number(params.chapterId);
+  if (!workId || !chapterId || isNaN(workId) || isNaN(chapterId)) {
+    return new Response(JSON.stringify({ error: 'Invalid IDs' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDb(d1);
+  const auth = await requireAuth(d1, request);
+  checkApproved(auth);
+
+  // Verify authorship
+  const userPseuds = await db.select().from(pseuds).where(eq(pseuds.userId, auth.user.id));
+  const pseudIds = userPseuds.map(p => p.id);
+  const isAuthor = pseudIds.length > 0 && await db.select().from(creatorships)
+    .where(and(eq(creatorships.workId, workId)))
+    .then(rows => rows.some(c => pseudIds.includes(c.pseudId)));
+
+  if (!isAuthor) {
+    return new Response(JSON.stringify({ error: 'Not an author of this work' }), { status: 403, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Parse body
+  let body: { versionId?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  const versionId = body.versionId;
+  if (!versionId || typeof versionId !== 'number') {
+    return new Response(JSON.stringify({ error: 'versionId is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Get the current chapter content
+  const currentChapter = await db.select().from(chapters).where(and(eq(chapters.id, chapterId), eq(chapters.workId, workId))).get();
+  if (!currentChapter) {
+    return new Response(JSON.stringify({ error: 'Chapter not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Get the version to restore
+  const versionToRestore = await db.select().from(chapterVersions)
+    .where(and(eq(chapterVersions.id, versionId), eq(chapterVersions.chapterId, chapterId)))
+    .get();
+  if (!versionToRestore) {
+    return new Response(JSON.stringify({ error: 'Version not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  // Save current content as a new version before restoring
+  const maxVersionRow = await db.select({ maxVer: sql<number>`COALESCE(MAX(${chapterVersions.version}), 0)` })
+    .from(chapterVersions)
+    .where(eq(chapterVersions.chapterId, chapterId))
+    .get();
+  const nextVersion = (maxVersionRow?.maxVer ?? 0) + 1;
+
+  await db.insert(chapterVersions).values({
+    chapterId,
+    version: nextVersion,
+    contentMd: currentChapter.contentMd,
+    contentHtml: currentChapter.contentHtml,
+    note: `Auto-saved before restoring version ${versionToRestore.version}`,
+  });
+
+  // Restore the version's content back to the chapter
+  const wordCount = versionToRestore.contentMd ? versionToRestore.contentMd.split(/\s+/).filter(Boolean).length : 0;
+  const updated = await db.update(chapters).set({
+    contentMd: versionToRestore.contentMd,
+    contentHtml: versionToRestore.contentHtml,
+    wordCount,
+    updatedAt: new Date().toISOString(),
+  }).where(and(eq(chapters.id, chapterId), eq(chapters.workId, workId))).returning();
+
+  if (!updated.length) {
+    return new Response(JSON.stringify({ error: 'Chapter not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  return new Response(JSON.stringify({
+    data: updated[0],
+    restoredFrom: { id: versionToRestore.id, version: versionToRestore.version },
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/v2/pages/api/works/[id]/chapters/index.ts
+++ b/src/v2/pages/api/works/[id]/chapters/index.ts
@@ -5,7 +5,7 @@ import { getDb } from '../../../../../../lib/db';
 import { requireAuth, checkApproved } from '../../../../../../lib/auth';
 import { validateBody } from '../../../../../../lib/validation';
 import { createChapterSchema } from '../../../../../../lib/validation';
-import { chapters, works, creatorships, pseuds } from '../../../../../../lib/schema/index';
+import { chapters, chapterVersions, works, creatorships, pseuds } from '../../../../../../lib/schema/index';
 
 export const config = { auth: 'public' as const };
 
@@ -89,6 +89,17 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
     images: '[]',
     mood: data.mood ?? null,
   }).returning();
+
+  // Create version 1 for the new chapter
+  if (newChapter[0]) {
+    await db.insert(chapterVersions).values({
+      chapterId: newChapter[0].id,
+      version: 1,
+      contentMd: newChapter[0].contentMd,
+      contentHtml: newChapter[0].contentHtml,
+      note: data.versionNote ?? null,
+    });
+  }
 
   return new Response(JSON.stringify({ data: newChapter[0] }), {
     status: 201,


### PR DESCRIPTION
## Phase 2: Polish & UX Overhaul

Completes all 4 Phase 2 items from the roadmap.

### Tokenized Tag System
- Replaced single flat tag input with **7 categorized sections** on `/studio/new`:
  - Rating (single-select radio chips)
  - Archive Warnings (multi-select checkbox chips)
  - Categories (multi-select checkbox chips)
  - Fandoms, Characters, Relationships, Additional Tags (tokenized autocomplete inputs)
- Autocomplete dropdown filtered by tag type via `?type=` param
- Enter/comma/tab tokenizes, backspace removes, × on chips
- Color-coded tag chips per type on work detail sidebar (fandom=blue, character=green, relationship=purple, freeform=orange)
- Added Fandoms section to work detail sidebar (was missing)

### Alias Management
- New `/settings/aliases` page with professional card UI:
  - Avatar placeholder (first letter in theme color), 3px theme accent strip
  - "Primary" badge on default pseud, "Set as Default" toggle
  - Work count stats per alias
  - Three-dot dropdown: Edit / Set as Default / Delete
  - Inline expandable edit form, delete confirmation modal
  - Add Alias card with name, description, 8-color swatch picker
- Fixed `PUT /api/pseuds/:id` — properly toggles `isDefault` (unsets others first)
- Added `DELETE /api/pseuds/:id` — forbids deleting default pseud
- "Manage Aliases" link added to settings page

### Reading Layout
- Responsive CSS Grid on chapter reader: `1fr 300px` desktop, `1fr 260px` tablet, stacked mobile
- Sticky sidebar with 5 sections: chapter nav, metadata, author's notes, tags, kudos/bookmark
- Chapter navigation: dropdown on mobile, ordered list on desktop
- Author's notes: collapsible with gradient fade, always collapsed on mobile
- Color-coded tag chips in reader sidebar
- Merriweather reading experience fully preserved

### Chapter Versioning
- Auto-saves version snapshots before every chapter update (PUT)
- Creates version 1 on new chapter creation (POST)
- `GET /api/works/:id/chapters/:chapterId/versions` — lightweight list
- `GET ?id=X` — full content of specific version
- `POST` — restore a version (auto-saves current first)
- `/studio/:id/chapters/:chapterId/history` — timeline UI with word count diffs, view/restore actions
- "Version Note" field on chapter edit form for annotating changes

### Files Changed
12 files, +2,687 lines, -162 lines