### PR TITLE
feat: wire up Resend email for password resets & notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,13 @@
 # =============================================================================
 # For local dev with Wrangler, secrets are set via:
 #   wrangler pages secret put SECRET_NAME
+# Or add them to .dev.vars (gitignored) for local development.
 # D1 and R2 bindings are configured in wrangler.toml, not here.
 # =============================================================================
+
+# Cloudflare Pages secrets (set via wrangler pages secret put or .dev.vars)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+RESEND_API_KEY=re_xxx
+FOUNDER_EMAIL=
+GITHUB_TOKEN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "drizzle-orm": "^0.45.2",
         "lowlight": "^3.3.0",
         "preact": "^10.0.0",
+        "resend": "^6.12.3",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -4835,6 +4836,12 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
@@ -9148,6 +9155,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
@@ -10476,268 +10489,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/linkify-it": {
@@ -12212,6 +11963,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -12868,6 +12625,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -13408,6 +13186,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -13540,6 +13328,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "drizzle-orm": "^0.45.2",
     "lowlight": "^3.3.0",
     "preact": "^10.0.0",
+    "resend": "^6.12.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -7,6 +7,7 @@ declare namespace Astro {
         DB: D1Database;
         GOOGLE_CLIENT_ID: string;
         GOOGLE_CLIENT_SECRET: string;
+        RESEND_API_KEY: string;
         FOUNDER_EMAIL?: string;
         GITHUB_TOKEN?: string;
       };

--- a/src/pages/api/auth/forgot-password.ts
+++ b/src/pages/api/auth/forgot-password.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import type { D1Database } from '@cloudflare/workers-types';
 import { getDb } from '@/v2/lib/db';
 import { users, passwordResets } from '@/v2/lib/schema/index';
+import { sendPasswordResetEmail } from '@/v2/lib/email';
 import { z } from 'zod';
 import { validateBody } from '@/v2/lib/validation';
 
@@ -14,6 +15,7 @@ export const config = { auth: 'public' as const };
 
 export const POST: APIRoute = async ({ request, locals }) => {
   const d1 = locals.runtime.env.DB as D1Database;
+  const resendApiKey = locals.runtime.env.RESEND_API_KEY;
   const db = getDb(d1);
 
   // Validate request body
@@ -43,10 +45,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
     expiresAt,
   });
 
-  // TODO: Send email with reset link. For now, log the reset URL.
-  // In production, this should use a Cloudflare-compatible email service (e.g. Workers Send Email, Mailgun, Resend).
+  // Send password reset email via Resend
   const resetUrl = `https://fanfiction.fyi/reset-password?token=${token}`;
-  console.log(`[PASSWORD RESET] Reset URL for ${data.email}: ${resetUrl}`);
+  try {
+    await sendPasswordResetEmail(resendApiKey, data.email, resetUrl);
+  } catch (err) {
+    // Log but don't leak email-sending errors to the client
+    console.error('[FORGOT-PASSWORD] Failed to send reset email:', err);
+  }
 
   return new Response(JSON.stringify({ success: true }), {
     status: 200,

--- a/src/v2/lib/email.ts
+++ b/src/v2/lib/email.ts
@@ -1,0 +1,143 @@
+/**
+ * Email sender using Resend API.
+ *
+ * Works in Cloudflare Workers (SSR) via the Resend SDK.
+ * Falls back to console logging if RESEND_API_KEY is not configured,
+ * so local dev and tests don't break without a key.
+ */
+import { Resend } from 'resend';
+
+const DEFAULT_FROM = 'fanfiction.fyi <noreply@kaleb.one>';
+
+interface EmailPayload {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+/**
+ * Get a Resend client instance. Creates a new one per request
+ * (cheap — just wraps an API key).
+ */
+function getClient(apiKey: string): Resend {
+  return new Resend(apiKey);
+}
+
+/**
+ * Send an email via Resend.
+ *
+ * @param apiKey - RESEND_API_KEY from the Cloudflare env
+ * @param payload - Email details (to, subject, html, optional text)
+ * @returns true if sent successfully, false if skipped or failed
+ */
+export async function sendEmail(
+  apiKey: string | undefined,
+  payload: EmailPayload,
+  fromAddress?: string,
+): Promise<boolean> {
+  if (!apiKey) {
+    console.log(`[EMAIL] No RESEND_API_KEY configured — skipping send to ${payload.to}`);
+    console.log(`[EMAIL] Subject: ${payload.subject}`);
+    return false;
+  }
+
+  try {
+    const resend = getClient(apiKey);
+    const { data, error } = await resend.emails.send({
+      from: fromAddress || DEFAULT_FROM,
+      to: payload.to,
+      subject: payload.subject,
+      html: payload.html,
+      text: payload.text,
+    });
+
+    if (error) {
+      console.error(`[EMAIL] Resend error: ${error.name} — ${error.message}`);
+      return false;
+    }
+
+    console.log(`[EMAIL] Sent to ${payload.to} (id: ${data?.id})`);
+    return true;
+  } catch (err) {
+    console.error('[EMAIL] Failed to send:', err);
+    return false;
+  }
+}
+
+// ─── Templated emails ────────────────────────────────────────────────
+
+/**
+ * Send a password reset email.
+ */
+export async function sendPasswordResetEmail(
+  apiKey: string | undefined,
+  to: string,
+  resetUrl: string,
+): Promise<boolean> {
+  return sendEmail(apiKey, {
+    to,
+    subject: 'Reset your password — fanfiction.fyi',
+    html: `
+      <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px 16px;">
+        <h1 style="font-size: 20px; margin-bottom: 16px;">Reset your password</h1>
+        <p style="font-size: 15px; line-height: 1.5; color: #444;">
+          We received a request to reset the password for your fanfiction.fyi account.
+          Click the button below to choose a new password:
+        </p>
+        <a href="${resetUrl}"
+           style="display: inline-block; background: #1a73e8; color: #fff; text-decoration: none;
+                  padding: 12px 24px; border-radius: 8px; font-size: 15px; margin: 16px 0;">
+          Reset password
+        </a>
+        <p style="font-size: 13px; color: #888; line-height: 1.5;">
+          This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.
+        </p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;">
+        <p style="font-size: 12px; color: #aaa;">
+          If the button doesn't work, copy this link into your browser:<br>
+          <a href="${resetUrl}" style="word-break: break-all; color: #1a73e8;">${resetUrl}</a>
+        </p>
+      </div>
+    `,
+    text: `Reset your fanfiction.fyi password by visiting this link (expires in 1 hour):\n\n${resetUrl}\n\nIf you didn't request this, you can safely ignore this email.`,
+  });
+}
+
+/**
+ * Send a notification email (for in-app notifications that warrant email delivery).
+ */
+export async function sendNotificationEmail(
+  apiKey: string | undefined,
+  to: string,
+  opts: { title: string; body: string; link?: string },
+): Promise<boolean> {
+  const linkHtml = opts.link
+    ? `<a href="${opts.link}" style="display: inline-block; background: #1a73e8; color: #fff; text-decoration: none; padding: 10px 20px; border-radius: 8px; font-size: 14px; margin-top: 12px;">View on fanfiction.fyi</a>`
+    : '';
+  const linkText = opts.link ? `\n\nView on fanfiction.fyi: ${opts.link}` : '';
+
+  return sendEmail(apiKey, {
+    to,
+    subject: opts.title,
+    html: `
+      <div style="font-family: system-ui, -apple-system, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px 16px;">
+        <h2 style="font-size: 18px; margin-bottom: 12px;">${escHtml(opts.title)}</h2>
+        <p style="font-size: 15px; line-height: 1.5; color: #444;">${escHtml(opts.body)}</p>
+        ${linkHtml}
+        <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;">
+        <p style="font-size: 12px; color: #aaa;">— fanfiction.fyi</p>
+      </div>
+    `,
+    text: `${opts.title}\n\n${opts.body}${linkText}\n\n— fanfiction.fyi`,
+  });
+}
+
+/** Minimal HTML escaper to prevent injection in email templates. */
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/v2/lib/notify.ts
+++ b/src/v2/lib/notify.ts
@@ -1,5 +1,6 @@
 /**
- * Notification helper — sends in-app notifications to users.
+ * Notification helper — sends in-app notifications to users,
+ * and optionally sends email for high-priority notification types.
  *
  * Checks notificationPreferences for the user+type pair.
  * If no preference row exists, defaults to enabled.
@@ -9,17 +10,23 @@ import type { D1Database } from '@cloudflare/workers-types';
 import { getDb } from './db';
 import { notifications, notificationPreferences } from './schema/index';
 import { eq, and } from 'drizzle-orm';
+import { sendNotificationEmail } from './email';
 
 export interface NotifyOptions {
   type: string;       // e.g. 'comment.new', 'kudos', 'work.update', 'report.resolved', 'user.approved'
   title: string;
   body: string;
   link?: string;
+  /** Email address for sending an email notification. If omitted, only in-app notification is created. */
+  email?: string;
+  /** Resend API key from the runtime env. Required if email is provided. */
+  resendApiKey?: string;
 }
 
 /**
  * Send an in-app notification to a user.
  * Respects their notification preferences — if they've disabled this type, the notification is silently skipped.
+ * If an email address is provided, also sends an email notification (best-effort, won't block the in-app notification).
  */
 export async function notify(
   d1: D1Database,
@@ -50,4 +57,18 @@ export async function notify(
     body: opts.body,
     link: opts.link ?? null,
   });
+
+  // Send email notification if an address was provided (best-effort, don't block)
+  if (opts.email) {
+    try {
+      await sendNotificationEmail(opts.resendApiKey, opts.email, {
+        title: opts.title,
+        body: opts.body,
+        link: opts.link,
+      });
+    } catch (err) {
+      // Don't let email failures break the in-app notification
+      console.error(`[NOTIFY] Failed to send email to ${opts.email}:`, err);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds email sending via Resend, wired into password reset flow and notification system.

### Changes
- **`src/v2/lib/email.ts`** — New module with `sendEmail()`, `sendPasswordResetEmail()`, and `sendNotificationEmail()`. Uses Resend SDK, sends from `noreply@kaleb.one`. Gracefully logs and skips if `RESEND_API_KEY` is not set (dev-safe).
- **`src/pages/api/auth/forgot-password.ts`** — Now sends an actual password reset email via Resend instead of just logging to console.
- **`src/v2/lib/notify.ts`** — Extended with optional `email` and `resendApiKey` params. When provided, sends a notification email in addition to the in-app notification (best-effort, non-blocking).
- **`src/env.d.ts`** — Added `RESEND_API_KEY` to the Cloudflare env type.
- **`.env.example`** — Documented all required env vars.
- **`package.json`** — Added `resend` dependency.

### DNS / Infrastructure
- DKIM, SPF, and DMARC records added to `kaleb.one` in Cloudflare for Resend sending
- `RESEND_API_KEY` secret set on Cloudflare Pages (prod)
- Domain verified and test email sent successfully ✅

### Not in scope (future work)
- Per-notification-type email preference toggle in UI
- Wiring `email` + `resendApiKey` through all existing `notify()` call sites (requires user email lookups)
- Email for admin/signup notifications