### PR TITLE
deploy: merge develop → main for production release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,16 @@ jobs:
 
       - run: npm ci
 
-      - name: Type check
-        run: npx astro check --tsconfig tsconfig.json || true
-
       - name: Build
         run: npm run build
 
+      - name: Type check
+        run: npx astro check --tsconfig tsconfig.json
+        continue-on-error: true
+
       - name: Lint
-        run: npx eslint src/ --max-warnings 0 || true
+        run: npx eslint src/ --max-warnings 0
+        continue-on-error: true
 
   test:
     runs-on: ubuntu-latest
@@ -41,4 +43,5 @@ jobs:
       - run: npm ci
 
       - name: Unit tests
-        run: npx vitest run --reporter=verbose || true
+        run: npx vitest run --reporter=verbose
+        continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,15 +2,17 @@ name: Deploy to Cloudflare Pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 jobs:
   deploy-production:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       deployments: write
+    environment: production
     steps:
       - uses: actions/checkout@v4
 
@@ -34,6 +36,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    environment: staging
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,42 @@
+name: Migrate D1 Database
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Apply migrations (staging)
+        if: github.event.inputs.environment == 'staging'
+        run: wrangler d1 migrations apply fanfiction-fyi-db --remote --env staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Apply migrations (production)
+        if: github.event.inputs.environment == 'production'
+        run: wrangler d1 migrations apply fanfiction-fyi-db --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -6,16 +6,16 @@ on:
       environment:
         description: 'Target environment'
         required: true
-        default: 'staging'
+        default: 'preview'
         type: choice
         options:
-          - staging
+          - preview
           - production
 
 jobs:
   migrate:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'production' && 'production' || 'staging' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,16 +27,16 @@ jobs:
       - name: Install Wrangler
         run: npm install -g wrangler
 
-      - name: Apply migrations (staging)
-        if: github.event.inputs.environment == 'staging'
-        run: wrangler d1 migrations apply fanfiction-fyi-db --remote --env staging
+      - name: Apply migrations (preview/staging)
+        if: github.event.inputs.environment == 'preview'
+        run: wrangler d1 migrations apply ffy-staging --remote --env preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Apply migrations (production)
         if: github.event.inputs.environment == 'production'
-        run: wrangler d1 migrations apply fanfiction-fyi-db --remote
+        run: wrangler d1 migrations apply ffy-prod --remote --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/drizzle/v2/0004_fts5_triggers.sql
+++ b/drizzle/v2/0004_fts5_triggers.sql
@@ -1,0 +1,19 @@
+-- FTS5 Content-Sync Triggers
+-- These triggers keep the `works_fts` FTS5 virtual table in sync with the `works` table.
+-- Without these triggers, search results become stale or missing after inserts/updates/deletes.
+
+-- After INSERT on works: add new row to FTS index
+CREATE TRIGGER IF NOT EXISTS works_ai AFTER INSERT ON works BEGIN
+  INSERT INTO works_fts(rowid, title, summary) VALUES (new.id, new.title, new.summary);
+END;
+
+-- After UPDATE on works: remove old row from FTS index, then insert updated row
+CREATE TRIGGER IF NOT EXISTS works_au AFTER UPDATE ON works BEGIN
+  INSERT INTO works_fts(works_fts, rowid, title, summary) VALUES ('delete', old.id, old.title, old.summary);
+  INSERT INTO works_fts(rowid, title, summary) VALUES (new.id, new.title, new.summary);
+END;
+
+-- After DELETE on works: remove row from FTS index
+CREATE TRIGGER IF NOT EXISTS works_ad AFTER DELETE ON works BEGIN
+  INSERT INTO works_fts(works_fts, rowid, title, summary) VALUES ('delete', old.id, old.title, old.summary);
+END;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,13 +24,16 @@
         "astro": "^5.0.0",
         "drizzle-orm": "^0.45.2",
         "lowlight": "^3.3.0",
+        "marked": "^18.0.4",
         "preact": "^10.0.0",
         "resend": "^6.12.3",
+        "sanitize-html": "^2.17.4",
         "zod": "^3.24.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "@testing-library/preact": "^3.2.0",
+        "@types/sanitize-html": "^2.16.1",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "drizzle-kit": "^0.31.10",
@@ -5446,6 +5449,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -7650,6 +7663,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7743,6 +7762,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -9837,6 +9865,37 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -10151,6 +10210,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -10477,6 +10545,15 @@
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "license": "MIT"
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10630,6 +10707,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11868,6 +11957,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -12840,6 +12935,21 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/sass-formatter": {
       "version": "0.7.9",

--- a/package.json
+++ b/package.json
@@ -47,13 +47,16 @@
     "astro": "^5.0.0",
     "drizzle-orm": "^0.45.2",
     "lowlight": "^3.3.0",
+    "marked": "^18.0.4",
     "preact": "^10.0.0",
     "resend": "^6.12.3",
+    "sanitize-html": "^2.17.4",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@testing-library/preact": "^3.2.0",
+    "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "drizzle-kit": "^0.31.10",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,6 +49,7 @@ function getAuthLevel(pathname: string, request: Request): AuthLevel {
   // ─── Public pages (no auth, never needs user context) ───────
   if (pathname === '/login' || pathname === '/signup') return 'public';
   if (pathname === '/pending-approval') return 'public';
+  if (pathname === '/forgot-password' || pathname === '/reset-password') return 'public';
   if (pathname === '/privacy' || pathname === '/terms') return 'public';
   if (pathname === '/feed.xml') return 'public';
 

--- a/src/pages/api/admin/backfill-content-html.ts
+++ b/src/pages/api/admin/backfill-content-html.ts
@@ -1,0 +1,91 @@
+import type { APIRoute } from 'astro';
+import type { D1Database } from '@cloudflare/workers-types';
+import { getDb } from '@/v2/lib/db';
+import { requireAuth, checkApproved } from '@/v2/lib/auth';
+import { chapters } from '@/v2/lib/schema/index';
+import { isNull, isNotNull, sql } from 'drizzle-orm';
+import { renderMarkdown } from '@/v2/lib/markdown';
+
+export const config = { auth: 'required' as const };
+
+/**
+ * POST /api/admin/backfill-content-html
+ *
+ * Backfill contentHtml from contentMd for all chapters where contentHtml is NULL.
+ * Works in batches to avoid D1 timeout limits.
+ *
+ * Query params:
+ *   ?batchSize=50  — Number of chapters to process per request (default: 50)
+ *   ?dryRun=true    — Return count of chapters to be updated without making changes
+ */
+export const POST: APIRoute = async ({ url, request, locals }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const db = getDb(d1);
+
+  // Verify admin
+  const auth = await requireAuth(d1, request);
+  if (auth.user.role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Admin access required' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const batchSize = Math.min(Math.max(Number(url.searchParams.get('batchSize')) || 50, 1), 200);
+  const dryRun = url.searchParams.get('dryRun') === 'true';
+
+  // Find chapters with contentMd but no contentHtml
+  const chaptersToUpdate = await db
+    .select({
+      id: chapters.id,
+      contentMd: chapters.contentMd,
+    })
+    .from(chapters)
+    .where(sql`${chapters.contentMd} IS NOT NULL AND ${chapters.contentHtml} IS NULL`)
+    .limit(batchSize);
+
+  if (dryRun) {
+    return new Response(JSON.stringify({
+      message: 'Dry run — no changes made',
+      chaptersToUpdate: chaptersToUpdate.length,
+      totalQueued: chaptersToUpdate.length,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let updated = 0;
+  let errors = 0;
+
+  for (const chapter of chaptersToUpdate) {
+    try {
+      const contentHtml = renderMarkdown(chapter.contentMd!);
+      await db
+        .update(chapters)
+        .set({ contentHtml })
+        .where(sql`${chapters.id} = ${chapter.id}`);
+      updated++;
+    } catch (err) {
+      console.error(`Failed to backfill chapter ${chapter.id}:`, err);
+      errors++;
+    }
+  }
+
+  // Count remaining chapters that still need backfill
+  const remaining = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(chapters)
+    .where(sql`${chapters.contentMd} IS NOT NULL AND ${chapters.contentHtml} IS NULL`);
+
+  return new Response(JSON.stringify({
+    message: 'Backfill complete',
+    updated,
+    errors,
+    remaining: remaining[0]?.count ?? 0,
+    batchSize,
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/api/admin/rebuild-fts.ts
+++ b/src/pages/api/admin/rebuild-fts.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro';
+import type { D1Database } from '@cloudflare/workers-types';
+import { requireAuth, checkApproved } from '@/v2/lib/auth';
+
+export const config = { auth: 'required' as const };
+
+/**
+ * POST /api/admin/rebuild-fts — Rebuild the FTS5 search index from scratch.
+ *
+ * This is needed after adding FTS5 triggers for the first time, since any
+ * works that existed before the triggers were created won't be in the index.
+ *
+ * Auth: required, admin+ only
+ */
+export const POST: APIRoute = async ({ request, locals }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  checkApproved(auth);
+
+  if (!['founder', 'admin'].includes(auth.user.role)) {
+    return new Response(
+      JSON.stringify({ error: 'Forbidden: admin access required' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  try {
+    // Clear the FTS index completely using the special delete-all command
+    await d1.exec("INSERT INTO works_fts(works_fts, rowid, title, summary) VALUES ('delete-all', 0, '', '')");
+
+    // Re-insert all existing works into the FTS index
+    await d1.exec('INSERT INTO works_fts(rowid, title, summary) SELECT id, COALESCE(title, \'\'), COALESCE(summary, \'\') FROM works');
+
+    // Count total works in the index
+    const countResult = await d1.prepare('SELECT COUNT(*) as total FROM works').first();
+
+    return new Response(
+      JSON.stringify({
+        message: 'FTS index rebuilt successfully',
+        totalWorks: countResult?.total ?? 0,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    console.error('FTS rebuild error:', err);
+    return new Response(
+      JSON.stringify({ error: 'Failed to rebuild FTS index', details: String(err) }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/src/pages/api/storage/[key].ts
+++ b/src/pages/api/storage/[key].ts
@@ -1,0 +1,75 @@
+import type { APIRoute } from 'astro';
+import type { D1Database } from '@cloudflare/workers-types';
+
+export const config = { auth: 'public' as const };
+
+/**
+ * GET /api/storage/[key] — Serve images from R2 storage.
+ *
+ * The key is a path like "avatars/abc123.jpg" or "works/def456.png".
+ * Returns the image with appropriate Content-Type, caching headers,
+ * and CORS headers for cross-origin image loading.
+ *
+ * This is the public-facing CDN route that makes uploaded images accessible.
+ */
+export const GET: APIRoute = async ({ params, locals }) => {
+  const key = params.key;
+
+  if (!key) {
+    return new Response('Missing key', { status: 400 });
+  }
+
+  // Prevent path traversal — only allow known prefixes
+  const allowedPrefixes = ['avatars/', 'works/', 'pseuds/', 'collections/', 'canon/'];
+  const hasAllowedPrefix = allowedPrefixes.some((prefix) => key.startsWith(prefix));
+  if (!hasAllowedPrefix) {
+    return new Response('Forbidden: invalid key prefix', { status: 403 });
+  }
+
+  // Prevent directory traversal attacks
+  if (key.includes('..') || key.startsWith('/')) {
+    return new Response('Forbidden: invalid key', { status: 403 });
+  }
+
+  const bucket = locals.runtime.env.MEDIA as R2Bucket;
+  if (!bucket) {
+    console.error('R2 MEDIA bucket not bound');
+    return new Response('Storage not configured', { status: 500 });
+  }
+
+  const object = await bucket.get(key);
+
+  if (!object) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  // Determine content type from the key extension as fallback
+  const ext = key.split('.').pop()?.toLowerCase();
+  const contentTypeMap: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    avif: 'image/avif',
+    svg: 'image/svg+xml',
+  };
+
+  const contentType =
+    object.httpMetadata?.contentType
+    || contentTypeMap[ext || '']
+    || 'application/octet-stream';
+
+  // Cache publicly for 30 days (images are immutable — key contains UUID)
+  const headers = new Headers();
+  headers.set('Content-Type', contentType);
+  headers.set('Cache-Control', 'public, max-age=2592000, immutable');
+  headers.set('ETag', object.etag);
+  headers.set('Access-Control-Allow-Origin', '*');
+
+  if (object.httpMetadata?.cacheControl) {
+    headers.set('Cache-Control', object.httpMetadata.cacheControl);
+  }
+
+  return new Response(object.body, { status: 200, headers });
+};

--- a/src/pages/api/upload/index.ts
+++ b/src/pages/api/upload/index.ts
@@ -1,0 +1,126 @@
+import type { APIRoute } from 'astro';
+import type { D1Database } from '@cloudflare/workers-types';
+import { getDb } from '@/v2/lib/db';
+import { requireAuth, checkApproved } from '@/v2/lib/auth';
+import { uploadImage, deleteImage } from '@/v2/lib/storage';
+
+export const config = { auth: 'required' as const };
+
+/**
+ * POST /api/upload — Upload an image to R2 storage.
+ *
+ * Accepts multipart/form-data with a `file` field.
+ * Query params:
+ *   ?prefix=works  — Key prefix (avatars|works|pseuds|collections|canon), default: works
+ *
+ * Returns: { data: { key, url, contentType, size } }
+ */
+export const POST: APIRoute = async ({ request, url, locals }) => {
+  const prefix = url.searchParams.get('prefix') || 'works';
+  const allowedPrefixes = ['avatars', 'works', 'pseuds', 'collections', 'canon'];
+  if (!allowedPrefixes.includes(prefix)) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid prefix', allowed: allowedPrefixes }),
+      { status: 422, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  checkApproved(auth);
+
+  const bucket = locals.runtime.env.MEDIA as R2Bucket;
+  if (!bucket) {
+    return new Response(
+      JSON.stringify({ error: 'Storage not configured' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file');
+
+  if (!file || !(file instanceof File)) {
+    return new Response(
+      JSON.stringify({ error: 'No file provided. Use multipart/form-data with a "file" field.' }),
+      { status: 422, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  try {
+    const result = await uploadImage(bucket, prefix, file);
+    return new Response(
+      JSON.stringify({ data: result }),
+      { status: 201, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    // uploadImage throws Response for validation errors
+    if (err instanceof Response) return err;
+    console.error('Upload error:', err);
+    return new Response(
+      JSON.stringify({ error: 'Upload failed' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};
+
+/**
+ * DELETE /api/upload — Delete an image from R2 storage.
+ *
+ * Body: { key: string } — The R2 key to delete.
+ * Only the owner or an admin can delete an image.
+ */
+export const DELETE: APIRoute = async ({ request, locals }) => {
+  const d1 = locals.runtime.env.DB as D1Database;
+  const auth = await requireAuth(d1, request);
+  checkApproved(auth);
+
+  const bucket = locals.runtime.env.MEDIA as R2Bucket;
+  if (!bucket) {
+    return new Response(
+      JSON.stringify({ error: 'Storage not configured' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  let body: { key?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  if (!body.key) {
+    return new Response(
+      JSON.stringify({ error: 'Missing key' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  // Prevent deleting arbitrary keys — same prefix allowlist
+  const allowedPrefixes = ['avatars/', 'works/', 'pseuds/', 'collections/', 'canon/'];
+  const hasAllowedPrefix = allowedPrefixes.some((p) => body.key!.startsWith(p));
+  if (!hasAllowedPrefix || body.key!.includes('..') || body.key!.startsWith('/')) {
+    return new Response(
+      JSON.stringify({ error: 'Forbidden: invalid key' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  try {
+    await deleteImage(bucket, body.key);
+    return new Response(
+      JSON.stringify({ data: { deleted: true } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    console.error('Delete error:', err);
+    return new Response(
+      JSON.stringify({ error: 'Delete failed' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/src/pages/api/works/[id]/chapters/[chapterId]/index.ts
+++ b/src/pages/api/works/[id]/chapters/[chapterId]/index.ts
@@ -6,6 +6,7 @@ import { validateBody } from '@/v2/lib/validation';
 import { updateChapterSchema } from '@/v2/lib/validation';
 import { chapters, creatorships, pseuds, works } from '@/v2/lib/schema/index';
 import { eq, and, sql } from 'drizzle-orm';
+import { renderMarkdown } from '@/v2/lib/markdown';
 
 export const config = { auth: 'public' as const };
 
@@ -62,9 +63,13 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
   if (data.title !== undefined) updates.title = data.title;
   if (data.contentMd !== undefined) {
     updates.contentMd = data.contentMd;
+    updates.contentHtml = renderMarkdown(data.contentMd);
     updates.wordCount = data.contentMd.split(/\s+/).filter(Boolean).length;
   }
-  if (data.contentHtml !== undefined) updates.contentHtml = data.contentHtml;
+  if (data.contentHtml !== undefined) {
+    // Allow explicit contentHtml override, but normally contentHtml is auto-rendered
+    updates.contentHtml = data.contentHtml;
+  }
   if (data.mood !== undefined) updates.mood = data.mood;
   if (data.draft !== undefined) {
     updates.draft = data.draft ? 1 : 0;

--- a/src/pages/api/works/[id]/chapters/index.ts
+++ b/src/pages/api/works/[id]/chapters/index.ts
@@ -6,6 +6,7 @@ import { requireAuth, checkApproved } from '@/v2/lib/auth';
 import { validateBody } from '@/v2/lib/validation';
 import { createChapterSchema } from '@/v2/lib/validation';
 import { chapters, works, creatorships, pseuds } from '@/v2/lib/schema/index';
+import { renderMarkdown } from '@/v2/lib/markdown';
 
 export const config = { auth: 'public' as const };
 
@@ -75,15 +76,17 @@ export const POST: APIRoute = async ({ params, request, locals }) => {
   const existing = await db.select().from(chapters).where(eq(chapters.workId, workId));
   const nextPosition = existing.length + 1;
 
-  // Calculate word count
-  const wordCount = data.contentMd ? data.contentMd.split(/\s+/).filter(Boolean).length : 0;
+  // Calculate word count and render HTML from Markdown
+  const contentMd = data.contentMd ?? null;
+  const wordCount = contentMd ? contentMd.split(/\s+/).filter(Boolean).length : 0;
+  const contentHtml = contentMd ? renderMarkdown(contentMd) : null;
 
   const newChapter = await db.insert(chapters).values({
     workId,
     position: nextPosition,
     title: data.title,
-    contentMd: data.contentMd ?? null,
-    contentHtml: null,
+    contentMd,
+    contentHtml,
     draft: 1,
     wordCount,
     images: '[]',

--- a/src/pages/canon/lore/[id].astro
+++ b/src/pages/canon/lore/[id].astro
@@ -33,25 +33,16 @@ try {
 const user = Astro.locals.user;
 const isOwner = user && lore && user.id === lore.ownerUserId;
 
-// Render markdown-like content: convert markdown to basic HTML
-// The API may return contentHtml or raw content (markdown)
-const loreContent = lore
-  ? lore.contentHtml ?? lore.content?.split('\n').map((p: string) => {
-      if (!p.trim()) return '';
-      // Simple markdown conversion: headers, bold, italic, links, lists
-      let html = p
-        .replace(/^### (.+)$/, '<h3>$1</h3>')
-        .replace(/^## (.+)$/, '<h2>$1</h2>')
-        .replace(/^# (.+)$/, '<h1>$1</h1>')
-        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-        .replace(/\*(.+?)\*/g, '<em>$1</em>')
-        .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>')
-        .replace(/^- (.+)$/, '<li>$1</li>');
-      if (html.startsWith('<li>')) return '<ul>' + html + '</ul>';
-      if (!html.startsWith('<h')) return '<p>' + html + '</p>';
-      return html;
-    }).join('\n') ?? '<p><em>No content.</em></p>'
-  : '';
+// Render markdown-like content: prefer pre-rendered HTML, fall back to Markdown rendering
+const { renderMarkdown: renderMd } = await import('@/v2/lib/markdown');
+let loreContent: string;
+if (lore?.contentHtml) {
+  loreContent = lore.contentHtml;
+} else if (lore?.content) {
+  loreContent = renderMd(lore.content);
+} else {
+  loreContent = '';
+}
 ---
 
 <Base title={`${lore?.title || 'Lore'} — fanfiction.fyi`} description={lore?.content?.slice(0, 160) || 'View lore entry on fanfiction.fyi'}>

--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -59,7 +59,11 @@ const resetMessage = resetParam === 'success' ? 'Your password has been reset. P
       const data = await res.json();
 
       if (res.ok) {
-        window.location.href = '/';
+        if (data.approved === 1) {
+          window.location.href = '/';
+        } else {
+          window.location.href = '/pending-approval';
+        }
       } else {
         errorEl.textContent = data.error || 'Login failed. Please try again.';
       }

--- a/src/pages/signup/index.astro
+++ b/src/pages/signup/index.astro
@@ -61,7 +61,7 @@ import Base from '@/v2/layouts/Base.astro';
 
       if (res.ok) {
         // Check if user is approved or pending
-        if (data.data?.approved) {
+        if (data.approved === 1) {
           window.location.href = '/';
         } else {
           window.location.href = '/pending-approval';

--- a/src/pages/works/[id]/chapters/[chapterId].astro
+++ b/src/pages/works/[id]/chapters/[chapterId].astro
@@ -50,8 +50,17 @@ const currentIndex = chapters.findIndex((c: any) => c.id === chapterId);
 const prevChapter = currentIndex > 0 ? chapters[currentIndex - 1] : null;
 const nextChapter = currentIndex >= 0 && currentIndex < chapters.length - 1 ? chapters[currentIndex + 1] : null;
 const authorPseuds = work.authors?.map((a: any) => a.name).join(', ') ?? 'Unknown';
-// Render content: prefer HTML, fall back to markdown-as-plain
-const chapterContent = chapter.contentHtml ?? chapter.contentMd?.split('\n').map((p: string) => `<p>${p}</p>`).join('\n') ?? '<p><em>No content.</em></p>';
+// Render content: prefer pre-rendered HTML, fall back to Markdown rendering
+let chapterContent: string;
+if (chapter.contentHtml) {
+  chapterContent = chapter.contentHtml;
+} else if (chapter.contentMd) {
+  // Use server-side markdown rendering as fallback
+  const { renderMarkdown } = await import('@/v2/lib/markdown');
+  chapterContent = renderMarkdown(chapter.contentMd);
+} else {
+  chapterContent = '<p><em>No content.</em></p>';
+}
 
 // Derive sidebar data
 const fandoms = work.tags?.filter((t: any) => t.type === 'fandom') ?? [];

--- a/src/v2/lib/markdown.ts
+++ b/src/v2/lib/markdown.ts
@@ -1,0 +1,112 @@
+/**
+ * Markdown rendering pipeline for fanfiction.fyi
+ * Converts Markdown source to sanitized HTML for chapter display.
+ *
+ * Uses `marked` for parsing and `sanitize-html` for XSS protection.
+ * Both are pure JS and compatible with Cloudflare Workers runtime.
+ */
+import { marked } from 'marked';
+// @ts-expect-error — sanitize-html uses CJS exports, no default in ESM
+import sanitizeHtml from 'sanitize-html';
+
+// Configure marked for fanfiction-friendly output
+marked.setOptions({
+  gfm: true,
+  breaks: true, // single newlines → <br>
+});
+
+/**
+ * Allowed HTML tags and attributes for fanfiction content.
+ * Deliberately permissive for rich storytelling but strict on security.
+ */
+const ALLOWED_TAGS = [
+  // Headings
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  // Block
+  'p', 'br', 'hr', 'blockquote', 'pre', 'code',
+  // Inline
+  'strong', 'em', 'b', 'i', 'u', 's', 'del', 'ins', 'mark', 'sub', 'sup', 'abbr',
+  // Lists
+  'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+  // Links
+  'a',
+  // Images (R2-served)
+  'img',
+  // Tables
+  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption',
+  // Semantic / accessibility
+  'details', 'summary', 'figure', 'figcaption', 'aside', 'cite', 'q',
+  // Container
+  'div', 'span', 'section', 'article',
+];
+
+const ALLOWED_ATTRIBUTES: Record<string, string[]> = {
+  '*': ['class', 'id', 'style'],
+  'a': ['href', 'title', 'rel', 'target'],
+  'img': ['src', 'alt', 'title', 'width', 'height', 'loading'],
+  'abbr': ['title'],
+  'details': ['open'],
+  'td': ['colspan', 'rowspan'],
+  'th': ['colspan', 'rowspan', 'scope'],
+  'code': ['class'], // language- classes for syntax highlighting
+  'pre': ['class'],
+};
+
+const ALLOWED_SCHEMES = ['http', 'https', 'mailto', 'ftp'];
+
+/**
+ * Render Markdown source to sanitized HTML.
+ * This is the main entry point for MD→HTML conversion.
+ *
+ * @param md - Raw Markdown source text
+ * @returns Sanitized HTML string safe for rendering
+ */
+export function renderMarkdown(md: string): string {
+  if (!md || typeof md !== 'string') return '';
+
+  // 1. Parse Markdown → HTML
+  const rawHtml = marked.parse(md) as string;
+
+  // 2. Sanitize HTML — strip dangerous tags/attributes, enforce allowlist
+  const clean = sanitizeHtml(rawHtml, {
+    allowedTags: ALLOWED_TAGS,
+    allowedAttributes: ALLOWED_ATTRIBUTES,
+    allowedSchemes: ALLOWED_SCHEMES,
+    // Allow data: URIs for images (base64-encoded) — optional, disable if strict
+    allowedSchemesAppliedToAttributes: ['href', 'src'],
+    // Enforce rel="noopener noreferrer" on all links
+    transformTags: {
+      'a': sanitizeHtml.simpleTransform('a', { rel: 'noopener noreferrer', target: '_blank' }),
+    },
+    // Don't strip content from disallowed tags, just the tags themselves
+    // e.g. <script>alert(1)</script> → alert(1) (visible text, not executed)
+    disallowedTagsMode: 'recursiveEscape',
+  });
+
+  return clean;
+}
+
+/**
+ * Render Markdown with minimal sanitization — for author-authored contexts
+ * like Author's Notes where more flexibility is acceptable.
+ * Still blocks <script>, <iframe>, <object>, <embed>, <form> etc.
+ */
+export function renderMarkdownLoose(md: string): string {
+  if (!md || typeof md !== 'string') return '';
+
+  const rawHtml = marked.parse(md) as string;
+
+  return sanitizeHtml(rawHtml, {
+    allowedTags: [...ALLOWED_TAGS, 'iframe'],
+    allowedAttributes: {
+      ...ALLOWED_ATTRIBUTES,
+      'iframe': ['src', 'title', 'width', 'height', 'allow', 'allowfullscreen'],
+    },
+    allowedSchemes: [...ALLOWED_SCHEMES, 'data'],
+    allowedSchemesAppliedToAttributes: ['href', 'src'],
+    transformTags: {
+      'a': sanitizeHtml.simpleTransform('a', { rel: 'noopener noreferrer', target: '_blank' }),
+    },
+    disallowedTagsMode: 'recursiveEscape',
+  });
+}

--- a/src/v2/lib/validation.ts
+++ b/src/v2/lib/validation.ts
@@ -94,12 +94,15 @@ export const updatePseudSchema = createPseudSchema.partial().extend({
 
 export const createCommentSchema = z.object({
   content: z.string().min(1, 'Comment cannot be empty').max(10000, 'Comment too long'),
+  workId: z.number().int().positive(),
+  chapterId: z.number().int().positive().optional(),
   parentId: z.number().int().positive().optional(),
 });
 
 // ─── Bookmarks ────────────────────────────────────────────────────
 
 export const createBookmarkSchema = z.object({
+  workId: z.number().int().positive(),
   notes: z.string().max(2000).optional(),
   private: z.boolean().default(false),
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,7 @@ pages_build_output_dir = "./dist"
 binding = "DB"
 database_name = "ffy-dev"
 database_id = "b74e9280-a0a6-40c2-aa7d-840f6260c5ca"
+migrations_dir = "drizzle/v2"
 
 [[r2_buckets]]
 binding = "MEDIA"
@@ -26,6 +27,7 @@ name = "fanfiction-fyi-staging"
 binding = "DB"
 database_name = "ffy-staging"
 database_id = "3ef61c14-917d-4d77-9bb2-76498bf4173e"
+migrations_dir = "drizzle/v2"
 
 [[env.preview.r2_buckets]]
 binding = "MEDIA"
@@ -42,6 +44,7 @@ name = "fanfiction-fyi-prod"
 binding = "DB"
 database_name = "ffy-prod"
 database_id = "9f22ddcb-c003-4c5a-9065-7c30368e7978"
+migrations_dir = "drizzle/v2"
 
 [[env.production.r2_buckets]]
 binding = "MEDIA"


### PR DESCRIPTION
## Summary

Merges all completed work from `develop` into `main` for production deployment.

### Included PRs (already merged to develop)
- **#144** — Markdown rendering pipeline (closes #115)
- **#145** — R2 image serving route (closes #116)
- **#146** — FTS5 sync triggers + admin rebuild endpoint (closes #117)
- **#147** — Dev/Prod environment split (closes #119)

### Additional changes since last merge
- CI: build is now a hard gate (type check & lint advisory)
- Deploy: `develop` → staging, `main` → production (Cloudflare Pages)
- D1 migration workflow (manual dispatch, staging/production selector)
- Branch protection on `main` (1 review + CI) and `develop` (CI only)
- `migrations_dir = "drizzle/v2"` added to wrangler.toml for all environments
- Stale branches cleaned up

### Post-Merge Steps (COMPLETED ✅)
- [x] D1 migrations applied to `ffy-staging`
- [x] D1 migrations applied to `ffy-prod`
- [x] GitHub environments created (`staging`, `production`)
- [x] Branch protection configured on `main` and `develop`
- [ ] Hit `POST /api/admin/backfill-content-html` after deploy
- [ ] Hit `POST /api/admin/rebuild-fts` after deploy