### PR TITLE
fix: login/signup approved check — truthy vs strict === 1

### DIFF
--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -59,7 +59,7 @@ const resetMessage = resetParam === 'success' ? 'Your password has been reset. P
       const data = await res.json();
 
       if (res.ok) {
-        if (data.approved === 1) {
+        if (data.approved) {
           window.location.href = '/';
         } else {
           window.location.href = '/pending-approval';

--- a/src/pages/signup/index.astro
+++ b/src/pages/signup/index.astro
@@ -61,7 +61,7 @@ import Base from '@/v2/layouts/Base.astro';
 
       if (res.ok) {
         // Check if user is approved or pending
-        if (data.approved === 1) {
+        if (data.approved) {
           window.location.href = '/';
         } else {
           window.location.href = '/pending-approval';


### PR DESCRIPTION
## Bug Fix: Login redirects approved users to /pending-approval

The login and signup pages both check `data.approved === 1` after a successful auth response. However, the API returns `approved` as a boolean (`true`/`false`) from Drizzle's boolean mapping, not as the SQLite integer `1`/`0`. 

Since `true === 1` evaluates to `false` in JavaScript, **every approved user was incorrectly redirected to `/pending-approval` after login**.

### Fix
- `src/pages/login/index.astro`: Changed `data.approved === 1` → `data.approved` (truthy check)
- `src/pages/signup/index.astro`: Same change

This is the root cause of the reported login bug where signing in redirects to "Account Pending Approval" even though the user is approved in the database.